### PR TITLE
Moved create on-chain addr Ibex logic into Wallets module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,8 @@ junit.xml
 
 .direnv
 .env.local
+
+.editorconfig
+.gitattributes
+.yarn/
+.yarnrc.yml

--- a/DEV.md
+++ b/DEV.md
@@ -26,9 +26,9 @@
 This setup was last tested with the following tools:
 ```
 $ node --version
-v18.12.0
+v20.10.0
 $ yarn --version
-1.22.17
+1.22.21
 $ direnv --version
 2.28.0
 $ jq --version
@@ -38,6 +38,8 @@ Docker version 20.10.8, build f0df350
 $ docker compose version
 Docker Compose version 2.0.0
 ```
+
+To use the correct node version, you can install nvm and run `nvm use 20`. Then enable and inititialize yarn using the [yarn docs](https://yarnpkg.com/getting-started/install)
 
 We use [direnv](https://direnv.net) to load environment variables needed for running the integration tests.
 Don't forget to add the [direnv hook](https://direnv.net/docs/hook.html) to your `shell.rc` file.

--- a/src/app/errors.ts
+++ b/src/app/errors.ts
@@ -25,6 +25,8 @@ import * as KratosErrors from "@services/kratos/errors"
 import * as BriaEventErrors from "@services/bria/errors"
 import * as SvixErrors from "@services/svix/errors"
 
+import * as IbexEventErrors from "@services/IbexHelper/errors"
+
 export const ApplicationErrors = {
   ...SharedErrors,
   ...DomainErrors,
@@ -52,4 +54,7 @@ export const ApplicationErrors = {
   ...LedgerFacadeErrors,
   ...BriaEventErrors,
   ...SvixErrors,
+
+  // Flash Errors
+  ...IbexEventErrors,
 } as const

--- a/src/app/wallets/create-on-chain-address.ts
+++ b/src/app/wallets/create-on-chain-address.ts
@@ -1,87 +1,132 @@
-import { AccountValidator } from "@domain/accounts"
-import { OnChainAddressNotFoundError } from "@domain/bitcoin/onchain"
-import { RateLimitConfig } from "@domain/rate-limit"
-import { RateLimiterExceededError } from "@domain/rate-limit/errors"
+// import { AccountValidator } from "@domain/accounts"
+// import { OnChainAddressNotFoundError } from "@domain/bitcoin/onchain"
+// import { RateLimitConfig } from "@domain/rate-limit"
+// import { RateLimiterExceededError } from "@domain/rate-limit/errors"
 
-import { OnChainService } from "@services/bria"
-import {
-  AccountsRepository,
-  WalletOnChainAddressesRepository,
-  WalletsRepository,
-} from "@services/mongoose"
-import { consumeLimiter } from "@services/rate-limit"
+// import { OnChainService } from "@services/bria"
+// import {
+//   AccountsRepository,
+//   WalletOnChainAddressesRepository,
+//   WalletsRepository,
+// } from "@services/mongoose"
+// import { consumeLimiter } from "@services/rate-limit"
+
+// export const createOnChainAddress = async ({
+//   walletId,
+//   requestId,
+// }: {
+//   walletId: WalletId
+//   requestId?: OnChainAddressRequestId
+// }) => {
+//   const wallet = await WalletsRepository().findById(walletId)
+//   if (wallet instanceof Error) return wallet
+//   const account = await AccountsRepository().findById(wallet.accountId)
+//   if (account instanceof Error) return account
+
+//   const accountValidator = AccountValidator(account)
+//   if (accountValidator instanceof Error) return accountValidator
+
+//   const onChain = OnChainService()
+
+//   let onChainAddress: OnChainAddressIdentifier | undefined = undefined
+//   if (requestId) {
+//     const foundAddress = await onChain.findAddressByRequestId(requestId)
+//     if (
+//       foundAddress instanceof Error &&
+//       !(foundAddress instanceof OnChainAddressNotFoundError)
+//     ) {
+//       return foundAddress
+//     }
+
+//     if (!(foundAddress instanceof OnChainAddressNotFoundError)) {
+//       onChainAddress = foundAddress
+//     }
+//   }
+
+//   if (onChainAddress === undefined) {
+//     const limitOk = await checkOnChainAddressAccountIdLimits(wallet.accountId)
+//     if (limitOk instanceof Error) return limitOk
+
+//     const newOnChainAddress = await onChain.getAddressForWallet({
+//       walletDescriptor: {
+//         id: wallet.id,
+//         currency: wallet.currency,
+//         accountId: wallet.accountId,
+//       },
+//       requestId,
+//     })
+//     if (newOnChainAddress instanceof Error) return newOnChainAddress
+//     onChainAddress = newOnChainAddress
+//   }
+
+//   const onChainAddressesRepo = WalletOnChainAddressesRepository()
+
+//   const addressRecorded = await onChainAddressesRepo.isRecorded({
+//     walletId,
+//     onChainAddress,
+//   })
+//   if (addressRecorded instanceof Error) return addressRecorded
+
+//   if (!addressRecorded) {
+//     const savedOnChainAddress = await onChainAddressesRepo.persistNew({
+//       walletId,
+//       onChainAddress,
+//     })
+//     if (savedOnChainAddress instanceof Error) return savedOnChainAddress
+//   }
+
+//   return onChainAddress.address
+// }
+
+// const checkOnChainAddressAccountIdLimits = async (
+//   accountId: AccountId,
+// ): Promise<true | RateLimiterExceededError> =>
+//   consumeLimiter({
+//     rateLimitConfig: RateLimitConfig.onChainAddressCreate,
+//     keyToConsume: accountId,
+//   })
+
+// FLASH FORK
+import { IbexRoutes } from "@services/IbexHelper/Routes"
+import { requestIBexPlugin } from "@services/IbexHelper/IbexHelper"
+import { IbexEventError } from "@services/IbexHelper/errors"
 
 export const createOnChainAddress = async ({
-  walletId,
-  requestId,
-}: {
-  walletId: WalletId
-  requestId?: OnChainAddressRequestId
-}) => {
-  const wallet = await WalletsRepository().findById(walletId)
-  if (wallet instanceof Error) return wallet
-  const account = await AccountsRepository().findById(wallet.accountId)
-  if (account instanceof Error) return account
-
-  const accountValidator = AccountValidator(account)
-  if (accountValidator instanceof Error) return accountValidator
-
-  const onChain = OnChainService()
-
-  let onChainAddress: OnChainAddressIdentifier | undefined = undefined
-  if (requestId) {
-    const foundAddress = await onChain.findAddressByRequestId(requestId)
-    if (
-      foundAddress instanceof Error &&
-      !(foundAddress instanceof OnChainAddressNotFoundError)
-    ) {
-      return foundAddress
-    }
-
-    if (!(foundAddress instanceof OnChainAddressNotFoundError)) {
-      onChainAddress = foundAddress
-    }
-  }
-
-  if (onChainAddress === undefined) {
-    const limitOk = await checkOnChainAddressAccountIdLimits(wallet.accountId)
-    if (limitOk instanceof Error) return limitOk
-
-    const newOnChainAddress = await onChain.getAddressForWallet({
-      walletDescriptor: {
-        id: wallet.id,
-        currency: wallet.currency,
-        accountId: wallet.accountId,
-      },
-      requestId,
-    })
-    if (newOnChainAddress instanceof Error) return newOnChainAddress
-    onChainAddress = newOnChainAddress
-  }
-
-  const onChainAddressesRepo = WalletOnChainAddressesRepository()
-
-  const addressRecorded = await onChainAddressesRepo.isRecorded({
     walletId,
-    onChainAddress,
-  })
-  if (addressRecorded instanceof Error) return addressRecorded
+    requestId,
+  }: {
+    walletId: WalletId
+    requestId?: OnChainAddressRequestId
+  }) => {
+    // TODO: reintroduce + test validation occuring here
+    //   const wallet = await WalletsRepository().findById(walletId)
+    //   if (wallet instanceof Error) return wallet
+    //   const account = await AccountsRepository().findById(wallet.accountId)
+    //   if (account instanceof Error) return account
 
-  if (!addressRecorded) {
-    const savedOnChainAddress = await onChainAddressesRepo.persistNew({
-      walletId,
-      onChainAddress,
-    })
-    if (savedOnChainAddress instanceof Error) return savedOnChainAddress
+    //   const accountValidator = AccountValidator(account)
+    //   if (accountValidator instanceof Error) return accountValidator
+    
+    /* 
+    TODO- Define return types 
+        e.g Promise<{
+            status: number;
+            data: null;
+            error: string;
+        } | IbexEventError>
+    */
+    const CreateOnChain: any = await requestIBexPlugin(
+        "POST",
+        IbexRoutes.OnChain,
+        {},
+        {
+          accountId: walletId,
+        },
+    )
+
+    if (!CreateOnChain || !CreateOnChain.data || !CreateOnChain.data["data"]) {
+        return new IbexEventError("unable to get CreateOnChain")
+    } else {
+        return CreateOnChain.data["data"] // type: address
+    }
   }
-
-  return onChainAddress.address
-}
-
-const checkOnChainAddressAccountIdLimits = async (
-  accountId: AccountId,
-): Promise<true | RateLimiterExceededError> =>
-  consumeLimiter({
-    rateLimitConfig: RateLimitConfig.onChainAddressCreate,
-    keyToConsume: accountId,
-  })

--- a/src/graphql/error-map.ts
+++ b/src/graphql/error-map.ts
@@ -642,6 +642,8 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
     case "InvalidCarrierForPhoneMetadataError":
     case "InvalidCarrierTypeForPhoneMetadataError":
     case "InvalidCountryCodeForPhoneMetadataError":
+    // FLASH ERRORS
+    case "IbexEventError":
       message = `Unexpected error occurred, please try again or contact support if it persists (code: ${
         error.name
       }${error.message ? ": " + error.message : ""})`

--- a/src/graphql/public/root/mutation/on-chain-address-create.ts
+++ b/src/graphql/public/root/mutation/on-chain-address-create.ts
@@ -1,13 +1,12 @@
 import { GT } from "@graphql/index"
-// import { Wallets } from "@app"
+import { Wallets } from "@app"
 import OnChainAddressPayload from "@graphql/public/types/payload/on-chain-address"
 import WalletId from "@graphql/shared/types/scalar/wallet-id"
 import { mapAndParseErrorForGqlResponse } from "@graphql/error-map"
 
 // FLASH FORK: import ibex dependencies
-import { IbexRoutes } from "../../../../services/IbexHelper/Routes"
-
-import { requestIBexPlugin } from "../../../../services/IbexHelper/IbexHelper"
+// import { IbexRoutes } from "../../../../services/IbexHelper/Routes"
+// import { requestIBexPlugin } from "../../../../services/IbexHelper/IbexHelper"
 
 const OnChainAddressCreateInput = GT.Input({
   name: "OnChainAddressCreateInput",
@@ -31,28 +30,13 @@ const OnChainAddressCreateMutation = GT.Field({
     }
 
     // FLASH FORK: use IBEX to create on-chain address
-    // const address = await Wallets.createOnChainAddress({ walletId })
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const CreateOnChain: any = await requestIBexPlugin(
-      "POST",
-      IbexRoutes.OnChain,
-      {},
-      {
-        accountId: walletId,
-      },
-    )
-    if (!CreateOnChain || !CreateOnChain.data || !CreateOnChain.data["data"]) {
-      console.error({ error: "unable to get CreateOnChain" })
-    } else {
-      const address = CreateOnChain.data["data"]
-
-      if (address instanceof Error) {
-        return { errors: [mapAndParseErrorForGqlResponse(address)] }
-      }
-      return {
-        errors: [],
-        address,
-      }
+    const address = await Wallets.createOnChainAddress({ walletId })
+    if (address instanceof Error) {
+      return { errors: [mapAndParseErrorForGqlResponse(address)] }
+    }
+    return {
+      errors: [],
+      address,
     }
   },
 })

--- a/src/services/IbexHelper/errors.ts
+++ b/src/services/IbexHelper/errors.ts
@@ -1,0 +1,3 @@
+import { DomainError, ErrorLevel } from "@domain/shared"
+
+export class IbexEventError extends DomainError {}


### PR DESCRIPTION
Motivations for refactoring:

1) Stay consistent with patterns used by Galoy base, including error handling
2) Reuse create-onchain-address logic. e.g I see Wallets.getLastOnChainAddress also references this code 