### PR TITLE
Trigger Account update events from Ibex transactions

### DIFF
--- a/src/debug/websocket/subscriptions/invoice-status.js
+++ b/src/debug/websocket/subscriptions/invoice-status.js
@@ -1,23 +1,39 @@
 const { gql } = require('@apollo/client');
 
+//const SUBSCRIPTION_QUERY = gql`
+// subscription Subscription($input: LnInvoicePaymentStatusInput!) {
+//   	lnInvoicePaymentStatus(input: $input) {
+//     		errors {
+//       		message
+//     	}
+//     		status
+//   	}
+// }
+// `;
+
 const SUBSCRIPTION_QUERY = gql`
-subscription Subscription($input: LnInvoicePaymentStatusInput!) {
-  	lnInvoicePaymentStatus(input: $input) {
-    		errors {
-      		message
-    	}
-    		status
-  	}
-}
+    subscription myLnUpdates {
+        myUpdates {
+            errors {
+                message
+            }
+            update {
+                ... on LnUpdate {
+                    paymentHash
+                    status
+                }
+            }
+        }
+    }
 `;
 
 module.exports = {
-    invoiceStatusGql: (pr) => ({
+    invoiceStatusGql: () => ({
         query: SUBSCRIPTION_QUERY,
-        variables: {
-            input: {
-                "paymentRequest": pr
-            }
-        }
+        // variables: {
+        //     input: {
+        //         "paymentRequest": pr
+        //     }
+        // }
     })
 }

--- a/src/debug/websocket/ws-listener.js
+++ b/src/debug/websocket/ws-listener.js
@@ -9,13 +9,16 @@ BigInt.prototype.toJSON = function () {
   return this.toString();
 };
 
+const localUrl = "ws://localhost:4000/graphql"
+const stagingUrl = "wss://ws.staging.flashapp.me:8080/graphql"
+const authToken = process.env.AUTH_TOKEN // "ory_st_b7tAbBulgb8MDPcbwrsoPAnUWauozPhI"
+
 const wsLink = new GraphQLWsLink(createClient({
-  url: 'wss://ws.staging.flashapp.me:8080/graphql',
-  // url: 'ws://localhost:4000/graphql',
+  url: localUrl,
+  connectionParams: {
+    Authorization: `Bearer ${authToken}`,
+  },
   webSocketImpl: WebSocket,
-  // connectionParams: {
-  //  authToken: user.authToken,
-  // },
 }));
 
 const client = new ApolloClient({

--- a/src/debug/websocket/ws-listener.js
+++ b/src/debug/websocket/ws-listener.js
@@ -11,7 +11,7 @@ BigInt.prototype.toJSON = function () {
 
 const localUrl = "ws://localhost:4000/graphql"
 const stagingUrl = "wss://ws.staging.flashapp.me:8080/graphql"
-const authToken = process.env.AUTH_TOKEN // "ory_st_b7tAbBulgb8MDPcbwrsoPAnUWauozPhI"
+const authToken = process.env.AUTH_TOKEN 
 
 const wsLink = new GraphQLWsLink(createClient({
   url: localUrl,

--- a/src/domain/notifications/index.types.d.ts
+++ b/src/domain/notifications/index.types.d.ts
@@ -54,7 +54,7 @@ type PriceUpdateArgs<C extends DisplayCurrency> = {
 }
 
 interface INotificationsService {
-  ibexTxReceived: (args: any) => Promise<true | NotificationsServiceError>
+  // ibexTxReceived: (args: any) => Promise<true | NotificationsServiceError>
 
   lightningTxReceived: (
     args: LightningTxReceivedArgs,

--- a/src/servers/ibex-webhook-server.ts
+++ b/src/servers/ibex-webhook-server.ts
@@ -1,5 +1,9 @@
 import WebookServer from "@services/ibex/webhook-server"
+import { baseLogger } from "@services/logger"
+import { setupMongoConnection } from "@services/mongodb"
 
 if (require.main === module) {
-    WebookServer.start()
+    setupMongoConnection()
+        .then(async () => WebookServer.start())
+        .catch((err) => baseLogger.error(err, "ibex webhook server error"))
 }

--- a/src/services/ibex/docs/samples/webhook.http
+++ b/src/services/ibex/docs/samples/webhook.http
@@ -19,7 +19,7 @@ Accept: application/json
   "transaction": {
     "id": "trx_id",
     "createdAt": "string",
-    "accountId": "string",
+    "accountId": "12406785-dbc1-4193-898d-ab03575a8f13",
     "amount": 100,
     "networkFee": 1,
     "exchangeRateCurrencySats": 2000,

--- a/src/services/ibex/docs/samples/webhook.http
+++ b/src/services/ibex/docs/samples/webhook.http
@@ -1,13 +1,13 @@
 // . TODO: use ngrok for integrated testing when running locally
 
-// @baseurl = http://localhost:4008
-@baseurl = https://ibex.staging.flashapp.me:8080
+@baseurlLocal = http://localhost:4008
+@baseurlStaging = https://ibex.staging.flashapp.me:8080
 
 ### Test server endpoint
-GET {{baseurl}}/health HTTP/1.1
+GET {{baseurlLocal}}/health HTTP/1.1
 
 ### Webhook for addInvoiceV2 (receive payment)
-POST {{baseurl}}/invoice/receive HTTP/1.1
+POST {{baseurlLocal}}/invoice/receive HTTP/1.1
 Content-Type: application/json
 Accept: application/json
 
@@ -26,7 +26,7 @@ Accept: application/json
     "currencyID": 1,
     "transactionTypeId": 2,
     "invoice": {
-      "hash": "8e92392b7a05ee59d80046c1cc61ec533d5d9e4c2300116e40296ca800050b0e",
+      "hash": "3c2ea4f665eeb1a85fb45301e7e5a8f7e5e260750cfd7f7f7784a18ec07e37eb",
       "bolt11": "lnbc2350n1pjuz0qdpp5zdl3y72k2p37xtr78mv8z9ans4m6dpvluavrt8ljeln33ewzsdzqdq823jhxaqcqzzsxqzuysp53ykwz05mps467vu99hh3q4tsggll6xcqzm4pmf0yfq0kerkcgsuq9qyyssqhlcruakrjph583797dh7cx9qv5r2ptkt68n976ep0u3yhnc7su5haepp68pcv0s9psjv5nnh7ygtp88lp5ujnvta73jx7s3egtw2tucqhpggqh",
       "preImage": "string",
       "memo": "string",
@@ -46,7 +46,7 @@ Accept: application/json
 }
 
 ### Webhook for payInvoiceV2 (payment sent)
-POST {{baseurl}}/invoice/pay/status HTTP/1.1
+POST {{baseurlLocal}}/invoice/pay/status HTTP/1.1
 Content-Type: application/json
 Accept: application/json
 {

--- a/src/services/ibex/webhook-server/routes/on-receive.ts
+++ b/src/services/ibex/webhook-server/routes/on-receive.ts
@@ -47,12 +47,7 @@ router.post(
             recipientAccountId: recipientAccountId,
             recipientWalletId,
             paymentAmount: req.body.transaction.amount,
-            displayPaymentAmount: undefined,
-            // { // DisplayAmount<DisplayCurrency>
-            //     amountInMinor: bigint
-            //     displayCurrency,
-            //     displayInMajor: DisplayCurrencyMajorAmount
-            // } as DisplayAmount<UsdCents>,
+            displayPaymentAmount: undefined, // DisplayAmount<DisplayCurrency>
             paymentHash: req.body.transaction.invoice.hash,
             recipientDeviceTokens: recipientUser.deviceTokens,
             recipientNotificationSettings: recipientAccount.notificationSettings,

--- a/src/services/ibex/webhook-server/routes/on-receive.ts
+++ b/src/services/ibex/webhook-server/routes/on-receive.ts
@@ -2,6 +2,15 @@ import express, { Request, Response } from "express"
 import { baseLogger as logger } from "@services/logger"
 import { NotificationsService } from "@services/notifications"
 import { authenticate, logRequest } from "../middleware"
+import { AccountsRepository, UsersRepository, WalletsRepository } from "@services/mongoose"
+import { RepositoryError } from "@domain/errors"
+// import {
+//   displayAmountFromWalletAmount,
+//   priceAmountFromDisplayPriceRatio,
+// } from ""
+import { from } from "form-data"
+import { getCurrentPriceAsDisplayPriceRatio } from "@app/prices"
+import { DisplayAmountsConverter } from "@domain/fiat"
 
 const path = "/invoice/receive"
 
@@ -12,7 +21,43 @@ router.post(
     logRequest, 
     async (req: Request, resp: Response) => {
         const { transaction } = req.body
-        const nsResp = await NotificationsService().ibexTxReceived({paymentHash: transaction.invoice.hash})
+        const paymentAmount = transaction.amount
+        const recipientWalletId = transaction.accountId
+        
+        const receiverWallet = await WalletsRepository().findById(recipientWalletId)
+        if (receiverWallet instanceof RepositoryError) {
+            logger.error(receiverWallet, `Failed to fetch wallet with id ${recipientWalletId}`)
+            return resp.sendStatus(500)
+        }
+
+        const recipientAccountId = receiverWallet.accountId
+        const recipientAccount = await AccountsRepository().findById(recipientAccountId)
+        if (recipientAccount instanceof Error) {
+            logger.error(recipientAccount, `Failed to fetch account with id ${recipientAccountId}`)
+            return resp.sendStatus(500)
+        }
+
+        const recipientUser = await UsersRepository().findById(recipientAccount.kratosUserId)
+        if (recipientUser instanceof Error) {
+            logger.error(recipientUser, `Failed to fetch user with kratos id ${recipientAccount.kratosUserId}`)
+            return resp.sendStatus(500)
+        }
+
+        const nsResp = await NotificationsService().lightningTxReceived({
+            recipientAccountId: recipientAccountId,
+            recipientWalletId,
+            paymentAmount: req.body.transaction.amount,
+            displayPaymentAmount: undefined,
+            // { // DisplayAmount<DisplayCurrency>
+            //     amountInMinor: bigint
+            //     displayCurrency,
+            //     displayInMajor: DisplayCurrencyMajorAmount
+            // } as DisplayAmount<UsdCents>,
+            paymentHash: req.body.transaction.invoice.hash,
+            recipientDeviceTokens: recipientUser.deviceTokens,
+            recipientNotificationSettings: recipientAccount.notificationSettings,
+            recipientLanguage: recipientUser.language,
+        })       
         if (nsResp instanceof NotificationsService) {
             logger.error(nsResp)
         }

--- a/src/services/mongoose/wallets.ts
+++ b/src/services/mongoose/wallets.ts
@@ -70,12 +70,14 @@ export const WalletsRepository = (): IWalletsRepository => {
 
   const findById = async (walletId: WalletId): Promise<Wallet | RepositoryError> => {
     try {
+      baseLogger.info(walletId, "walletId")
       const result: WalletRecord | null = await Wallet.findOne({ id: walletId })
       if (!result) {
         return new CouldNotFindWalletFromIdError()
       }
       return resultToWallet(result)
     } catch (err) {
+      baseLogger.error(err, "MongooseErr")
       return parseRepositoryError(err)
     }
   }

--- a/src/services/notifications/index.ts
+++ b/src/services/notifications/index.ts
@@ -22,29 +22,6 @@ export const NotificationsService = (): INotificationsService => {
   const pubsub = PubSubService()
   const pushNotification = PushNotificationsService()
 
-  const ibexTxReceived = async ({
-    paymentHash,
-  }: any): Promise<true | NotificationsServiceError> => {
-    try {
-      const lnPaymentStatusTrigger = customPubSubTrigger({
-        event: PubSubDefaultTriggers.LnPaymentStatus,
-        suffix: paymentHash,
-      })
-      const psResp = await pubsub.publish({
-        trigger: lnPaymentStatusTrigger,
-        payload: { status: "PAID" },
-      })
-      if (psResp instanceof PubSubServiceError) {
-        log.error("Failed to publish")
-        return new NotificationsServiceError(psResp) 
-      }
-      // ACCOUNT AND DEVICE NOTIFCATIONS LEFT OUT
-      return true
-    } catch (err) {
-      return handleCommonNotificationErrors(err)
-    }
-  }
-
   const lightningTxReceived = async ({
     recipientAccountId,
     recipientWalletId,
@@ -456,7 +433,6 @@ export const NotificationsService = (): INotificationsService => {
     ...wrapAsyncFunctionsToRunInSpan({
       namespace: "services.notifications",
       fns: {
-        ibexTxReceived,
         lightningTxReceived,
         intraLedgerTxReceived,
         onChainTxReceived,


### PR DESCRIPTION
Replaces the `ibexTxReceived` with `lightningTxReceived` previously used by galoy. This function requires extra params which we're fetching from Mongo similar to how it's done elsewhere in the code. 