### PR TITLE
Add 404s to 'hack'

### DIFF
--- a/src/services/ledger/index.ts
+++ b/src/services/ledger/index.ts
@@ -307,7 +307,7 @@ export const LedgerService = (): ILedgerService => {
       const resp = await Ibex().getAccountDetails({ accountId: walletId })
       if (resp instanceof IbexApiError ) {
         console.error(`Ibex Call failed with ${resp.code}: ${resp.message}`)
-        if (resp.code === 403) return toSats(0) // this is a hack for requests to Ibex with accountIds it doesn't recognize
+        if (resp.code === 403 || resp.code === 404) return toSats(0) // this is a hack for requests to Ibex with accountIds it doesn't recognize
         return resp
       }
       if (resp instanceof IbexAuthenticationError) {


### PR DESCRIPTION
This is a short-term fix to a change in the Ibex API. Previously, Ibex was returning a 403 when we called requested for an account they did not recognize. They changed that to a 404, which changed our response handling. 

Long-term: we should be removing accounts that are unused. At the very least we should stop calling Ibex for our BTC accounts we know don't exist. 