### PR TITLE
Update Intraledger payments to use Ibex

### DIFF
--- a/src/app/accounts/index.ts
+++ b/src/app/accounts/index.ts
@@ -64,3 +64,11 @@ export const getUsernameFromWalletId = async (
   if (account instanceof Error) return account
   return account.username
 }
+
+export const getLnurlpFromWalletId = async (
+  walletId: WalletId,
+): Promise<Lnurl | ApplicationError> => {
+  const wallet = await WalletsRepository().findById(walletId)
+  if (wallet instanceof Error) return wallet
+  return wallet.lnurlp
+}

--- a/src/graphql/public/root/mutation/intraledger-usd-payment-send.ts
+++ b/src/graphql/public/root/mutation/intraledger-usd-payment-send.ts
@@ -1,4 +1,5 @@
 import { Accounts, Payments } from "@app"
+import { PaymentSendStatus } from "@domain/bitcoin/lightning"
 import { checkedToWalletId } from "@domain/wallets"
 import { mapAndParseErrorForGqlResponse } from "@graphql/error-map"
 import { GT } from "@graphql/index"
@@ -6,7 +7,10 @@ import PaymentSendPayload from "@graphql/public/types/payload/payment-send"
 import CentAmount from "@graphql/public/types/scalar/cent-amount"
 import Memo from "@graphql/shared/types/scalar/memo"
 import WalletId from "@graphql/shared/types/scalar/wallet-id"
+import { client as Ibex } from "@services/ibex"
+import { IbexApiError, UnexpectedResponseError } from "@services/ibex/client/errors"
 import dedent from "dedent"
+// import { RequestInit, Response } from 'node-fetch'
 
 const IntraLedgerUsdPaymentSendInput = GT.Input({
   name: "IntraLedgerUsdPaymentSendInput",
@@ -23,9 +27,11 @@ const IntraLedgerUsdPaymentSendMutation = GT.Field<null, GraphQLPublicContextAut
     complexity: 120,
   },
   type: GT.NonNull(PaymentSendPayload),
-  description: dedent`Actions a payment which is internal to the ledger e.g. it does
+  description: dedent`Galoy: Actions a payment which is internal to the ledger e.g. it does
   not use onchain/lightning. Returns payment status (success,
-  failed, pending, already_paid).`,
+  failed, pending, already_paid).
+  
+  Flash: We do not currently have an internal ledger. Consequently, this endpoint has been updated to call Ibex instead.`,
   args: {
     input: { type: GT.NonNull(IntraLedgerUsdPaymentSendInput) },
   },
@@ -48,23 +54,69 @@ const IntraLedgerUsdPaymentSendMutation = GT.Field<null, GraphQLPublicContextAut
     }
 
     // TODO: confirm whether we need to check for username here
-    const recipientUsername = await Accounts.getUsernameFromWalletId(
+    // const recipientUsername = await Accounts.getUsernameFromWalletId(
+    //   recipientWalletIdChecked,
+    // )
+    // if (recipientUsername instanceof Error) {
+    //   return { errors: [mapAndParseErrorForGqlResponse(recipientUsername)] }
+    // }
+   
+   
+    // bob: 3ba88684-3b13-4282-83cf-79de50445368
+    const recipientLnurlp = await Accounts.getLnurlpFromWalletId(
       recipientWalletIdChecked,
     )
-    if (recipientUsername instanceof Error) {
-      return { errors: [mapAndParseErrorForGqlResponse(recipientUsername)] }
+    if (recipientLnurlp instanceof Error) {
+      return { errors: [mapAndParseErrorForGqlResponse(recipientLnurlp)] }
+    }
+    console.log("LNURLP = " + recipientLnurlp)
+   
+    // decode Lnurl can probably be done locally to extract k1
+    const decodeResp = await Ibex().decodeLnurl({ lnurl: recipientLnurlp })
+    if (decodeResp instanceof Error) return { errors: [mapAndParseErrorForGqlResponse(decodeResp)] }
+    if (!decodeResp.decodedLnurl) return { errors: [mapAndParseErrorForGqlResponse(new UnexpectedResponseError("Decoded Lnurl not found."))]}
+    console.log("decoded = " + JSON.stringify(decodeResp))
+
+    const paramsResp = await fetch(decodeResp.decodedLnurl as unknown as URL)
+    const payResp = await Ibex().payToLnurl({
+      params: await paramsResp.json(),
+      amount: amount / 100, // convert cents to dollars for Ibex api
+      accountId: walletId, 
+    })
+    if (payResp instanceof Error) return { errors: [mapAndParseErrorForGqlResponse(payResp)] }
+    console.log(payResp)
+
+    // https://docs.ibexmercado.com/reference/flow-1#payment-status
+    let status: PaymentSendStatus 
+    switch(payResp.transaction?.payment?.statusId) {
+      case 1:
+        status = PaymentSendStatus.Pending 
+        break;
+      case 2:
+        status = PaymentSendStatus.Success 
+        break;
+      case 3:
+        status = PaymentSendStatus.Failure
+        break;
+      case 0: 
+        return { errors: [mapAndParseErrorForGqlResponse(new UnexpectedResponseError("Lnurl-pay already paid"))]}
+      default:
+        return { errors: [mapAndParseErrorForGqlResponse(new UnexpectedResponseError("StatusId not in documenation"))]}
     }
 
-    const status = await Payments.intraledgerPaymentSendWalletIdForUsdWallet({
-      recipientWalletId,
-      memo,
-      amount,
-      senderWalletId: walletId,
-      senderAccount: domainAccount,
-    })
-    if (status instanceof Error) {
-      return { status: "failed", errors: [mapAndParseErrorForGqlResponse(status)] }
-    }
+    // TODO: MOVE ABOVE LOGIC IN HERE
+
+    // const status = await Payments.intraledgerPaymentSendWalletIdForUsdWallet({
+    //   recipientWalletId,
+    //   memo,
+    //   amount,
+    //   senderWalletId: walletId,
+    //   senderAccount: domainAccount,
+    // })
+    // if (status instanceof Error) {
+    //   return { status: "failed", errors: [mapAndParseErrorForGqlResponse(status)] }
+    // }
+    // END TODO
 
     return {
       errors: [],

--- a/src/services/ibex/client/index.ts
+++ b/src/services/ibex/client/index.ts
@@ -92,6 +92,16 @@ export default () => {
             .catch(e => new IbexApiError(e.status, e.data))
     }
 
+    const decodeLnurl = async (lnurl: types.DecodeLnurlMetadataParam): Promise<types.DecodeLnurlResponse200 | IbexAuthenticationError | IbexApiError> => {
+        return withAuth(() => IbexSDK.decodeLnurl(lnurl))
+            .catch(e => new IbexApiError(e.status, e.data))
+    }
+    
+    const payToLnurl = async (body: types.PayToALnurlPayBodyParam): Promise<types.PayToALnurlPayResponse201 | IbexAuthenticationError | IbexApiError> => {
+        return withAuth(() => IbexSDK.payToALnurlPay(body))
+            .catch(e => new IbexApiError(e.status, e.data))
+    }
+
     return wrapAsyncFunctionsToRunInSpan({
         namespace: "services.ibex.client",
         fns: { 
@@ -106,7 +116,9 @@ export default () => {
             payInvoiceV2, 
             sendToAddressV2, 
             estimateFeeV2, 
-            createLnurlPay 
+            createLnurlPay,
+            decodeLnurl,
+            payToLnurl
         },
     })
 }


### PR DESCRIPTION
This PR updates the Payments `send-intraledger` module to use Ibex. By applying this change here rather than the `intraLedgerUsdPaymentSend` graphQL resolver, we keep Galoy's validation and contacts features, while ensuring other uses of this code are changed as well.

Ibex does not support intraledger payments, so we are fetching an invoice on behalf of the receiver and then settling it for the sender.

