### PR TITLE
Fix: handle Ibex fee estimation

### DIFF
--- a/src/graphql/public/root/mutation/ln-noamount-usd-invoice-fee-probe.ts
+++ b/src/graphql/public/root/mutation/ln-noamount-usd-invoice-fee-probe.ts
@@ -61,8 +61,9 @@ const LnNoAmountUsdInvoiceFeeProbeMutation = GT.Field({
         errors: [mapAndParseErrorForGqlResponse(resp)],
       } 
     }
+
     const feeSatAmount: PaymentAmount<WalletCurrency> = {
-      amount: BigInt(Math.round(resp.data["data"]["amount"] * 1000)),
+      amount: BigInt(Math.ceil(resp.amount * 100)),
       currency: "USD",
     }
 

--- a/src/graphql/public/root/mutation/ln-usd-invoice-fee-probe.ts
+++ b/src/graphql/public/root/mutation/ln-usd-invoice-fee-probe.ts
@@ -77,7 +77,7 @@ const LnUsdInvoiceFeeProbeMutation = GT.Field<
     return {
       errors: [],
       ...normalizePaymentAmount({
-        amount: BigInt(Math.round(resp.amount * 100)),
+        amount: BigInt(Math.ceil(resp.amount * 100)),
         currency: WalletCurrency.Usd, 
       }),
     }

--- a/src/services/ibex/client/index.ts
+++ b/src/services/ibex/client/index.ts
@@ -140,7 +140,8 @@ export default () => {
     }
 
     // LN fee estimation
-    // GetFeeEstimationResponse200 not defined
+    // GetFeeEstimationResponse200 not defined in sdk
+    // Returns { amount: integer, invoiceAmount: integer }
     const getFeeEstimation = async (metadata: types.GetFeeEstimationMetadataParam): Promise<types.GetFeeEstimationResponse200 | IbexAuthenticationError | IbexApiError> => {
         addAttributesToCurrentSpan({ "request.params": JSON.stringify(metadata) })
         return withAuth(() => Ibex.getFeeEstimation(metadata))


### PR DESCRIPTION
Bug caused by improper handling of Ibex response. 

This PR also replaces `round` function with `ceil` which rounds the fee up to the nearest penny, which will help avoid confusion if a user is trying to drain their wallet