### PR TITLE
Fix initiationVia and settlementVia responses

### DIFF
--- a/src/app/wallets/get-transactions-for-wallet.ts
+++ b/src/app/wallets/get-transactions-for-wallet.ts
@@ -65,7 +65,8 @@ export const toWalletTransactions = (ibexResp: GResponse200): IbexTransaction[] 
     }
 
     switch (trx.transactionTypeId) {
-      case 1 || 2:
+      case 1:
+      case 2:
         return {
           ...baseTrx,
           // Ibex does not provide paymentHash, pubkey and preimage in transactions endpoint. To get these fields,
@@ -73,7 +74,8 @@ export const toWalletTransactions = (ibexResp: GResponse200): IbexTransaction[] 
           initiationVia: { type: 'lightning', paymentHash: "", pubkey: "" },
           settlementVia: { type: 'lightning', revealedPreImage: undefined }
         } as WalletLnSettledTransaction
-      case 3 || 4:
+      case 3:
+      case 4:
         return {
           ...baseTrx,
           // Ibex does not provide paymentHash, pubkey and preimage in transactions endpoint. To get these fields,
@@ -82,8 +84,12 @@ export const toWalletTransactions = (ibexResp: GResponse200): IbexTransaction[] 
           settlementVia: { type: 'onchain', transactionHash: '', vout: undefined }
         } as WalletOnChainSettledTransaction // assuming Ibex only gives us settled
       default:
-        baseLogger.warn(`Failed to parse Ibex transaction type. Id: ${baseTrx.walletId}`)
-        return baseTrx
+        baseLogger.error(`Failed to parse Ibex transaction type. { WalletId: ${baseTrx.walletId}, TransactionId: ${trx.id}, transactionTypeId: ${trx.transactionTypeId}`)
+        return { 
+          ...baseTrx,
+          initiationVia: { type: 'unknown' },
+          settlementVia: { type: 'unknown' }
+        } as UnknownTypeTransaction
     }
   })
 }

--- a/src/domain/wallets/index.types.d.ts
+++ b/src/domain/wallets/index.types.d.ts
@@ -130,6 +130,15 @@ type WalletLnSettledTransaction = BaseWalletTransaction & {
   readonly settlementVia: SettlementViaLn
 }
 
+type UnknownTypeTransaction = BaseWalletTransaction & {
+  readonly initiationVia: { 
+    readonly type: 'unknown'
+  } 
+  readonly settlementVia: { 
+    readonly type: 'unknown'
+  } 
+}
+
 type WalletOnChainTransaction =
   | WalletOnChainIntraledgerTransaction
   | WalletOnChainSettledTransaction
@@ -146,7 +155,7 @@ type WalletTransaction =
 type IbexTransaction =
   | WalletOnChainTransaction
   | WalletLnTransaction
-  | BaseWalletTransaction
+  | UnknownTypeTransaction
 
 type MemoSharingConfig = {
   memoSharingCentsThreshold: UsdCents

--- a/src/domain/wallets/index.types.d.ts
+++ b/src/domain/wallets/index.types.d.ts
@@ -143,6 +143,11 @@ type WalletTransaction =
   | WalletOnChainTransaction
   | WalletLnTransaction
 
+type IbexTransaction =
+  | WalletOnChainTransaction
+  | WalletLnTransaction
+  | BaseWalletTransaction
+
 type MemoSharingConfig = {
   memoSharingCentsThreshold: UsdCents
   memoSharingSatsThreshold: Satoshis

--- a/src/graphql/shared/types/object/transaction.ts
+++ b/src/graphql/shared/types/object/transaction.ts
@@ -44,7 +44,7 @@ const Transaction = GT.Object<WalletTransaction>({
       description: "To which protocol the payment has settled on.",
       resolve: async (source, _, { loaders }) => {
         const { settlementVia } = source
-
+        console.log(`settlementVia = ${JSON.stringify(settlementVia)}`)
         // Filter out source.id as OnChainTxHash
         if (
           settlementVia.type === "onchain" &&
@@ -61,6 +61,7 @@ const Transaction = GT.Object<WalletTransaction>({
         try {
           result = await loaders.txnMetadata.load(source.id)
         } catch (err) {
+          console.log(`result = ${JSON.stringify(result)}`)
           result = parseErrorFromUnknown(err)
         }
         if (result instanceof Error || result === undefined) return settlementVia

--- a/src/graphql/shared/types/object/transaction.ts
+++ b/src/graphql/shared/types/object/transaction.ts
@@ -42,41 +42,42 @@ const Transaction = GT.Object<WalletTransaction>({
     settlementVia: {
       type: GT.NonNull(SettlementVia),
       description: "To which protocol the payment has settled on.",
-      resolve: async (source, _, { loaders }) => {
-        const { settlementVia } = source
-        console.log(`settlementVia = ${JSON.stringify(settlementVia)}`)
-        // Filter out source.id as OnChainTxHash
-        if (
-          settlementVia.type === "onchain" &&
-          source.id ===
-            getUuidByString(`${settlementVia.transactionHash}:${settlementVia.vout}`) &&
-          // If not pending, we would like this to error in the next step with invalid source.id
-          source.status === DomainTxStatus.Pending
-        ) {
-          return settlementVia
-        }
 
-        let result: LedgerTransactionMetadata | undefined | RepositoryError
-        // Need try-catch because 'load' function throws any errors returned to it from loader function
-        try {
-          result = await loaders.txnMetadata.load(source.id)
-        } catch (err) {
-          console.log(`result = ${JSON.stringify(result)}`)
-          result = parseErrorFromUnknown(err)
-        }
-        if (result instanceof Error || result === undefined) return settlementVia
+      // resolve: async (source, _, { loaders }) => {
+      //   const { settlementVia } = source
+      //   console.log(`settlementVia = ${JSON.stringify(settlementVia)}`)
+      //   // Filter out source.id as OnChainTxHash
+      //   if (
+      //     settlementVia.type === "onchain" &&
+      //     source.id ===
+      //       getUuidByString(`${settlementVia.transactionHash}:${settlementVia.vout}`) &&
+      //     // If not pending, we would like this to error in the next step with invalid source.id
+      //     source.status === DomainTxStatus.Pending
+      //   ) {
+      //     return settlementVia
+      //   }
 
-        const updatedSettlementVia = { ...settlementVia }
-        for (const key of Object.keys(settlementVia)) {
-          /* eslint @typescript-eslint/ban-ts-comment: "off" */
-          // @ts-ignore-next-line no-implicit-any
-          updatedSettlementVia[key] =
-            // @ts-ignore-next-line no-implicit-any
-            result[key] !== undefined ? result[key] : settlementVia[key]
-        }
+      //   let result: LedgerTransactionMetadata | undefined | RepositoryError
+      //   // Need try-catch because 'load' function throws any errors returned to it from loader function
+      //   try {
+      //     result = await loaders.txnMetadata.load(source.id)
+      //   } catch (err) {
+      //     console.log(`result = ${JSON.stringify(result)}`)
+      //     result = parseErrorFromUnknown(err)
+      //   }
+      //   if (result instanceof Error || result === undefined) return settlementVia
 
-        return updatedSettlementVia
-      },
+      //   const updatedSettlementVia = { ...settlementVia }
+      //   for (const key of Object.keys(settlementVia)) {
+      //     /* eslint @typescript-eslint/ban-ts-comment: "off" */
+      //     // @ts-ignore-next-line no-implicit-any
+      //     updatedSettlementVia[key] =
+      //       // @ts-ignore-next-line no-implicit-any
+      //       result[key] !== undefined ? result[key] : settlementVia[key]
+      //   }
+
+      //   return updatedSettlementVia
+      // },
     },
     settlementAmount: {
       type: GT.NonNull(SignedAmount),

--- a/src/graphql/shared/types/object/usd-wallet.ts
+++ b/src/graphql/shared/types/object/usd-wallet.ts
@@ -74,6 +74,7 @@ const UsdWallet = GT.Object<Wallet>({
           throw paginationArgs
         }
 
+        console.log('resolving transactions...')
         const { result, error } = await Wallets.getTransactionsForWallets({
           wallets: [source],
           paginationArgs,

--- a/src/graphql/shared/types/object/usd-wallet.ts
+++ b/src/graphql/shared/types/object/usd-wallet.ts
@@ -74,7 +74,6 @@ const UsdWallet = GT.Object<Wallet>({
           throw paginationArgs
         }
 
-        console.log('resolving transactions...')
         const { result, error } = await Wallets.getTransactionsForWallets({
           wallets: [source],
           paginationArgs,
@@ -86,7 +85,7 @@ const UsdWallet = GT.Object<Wallet>({
         // Non-null signal to type checker; consider fixing in PartialResult type
         if (!result?.slice) throw error
 
-        return connectionFromPaginatedArray<WalletTransaction>(
+        return connectionFromPaginatedArray<IbexTransaction>(
           result.slice,
           result.total,
           paginationArgs,

--- a/src/services/ledger/csv-wallet-export.ts
+++ b/src/services/ledger/csv-wallet-export.ts
@@ -66,7 +66,7 @@ export class CsvWalletsExport {
     }
   }
 
-  async formatTxs(txs?: WalletTransaction[]) {
+  async formatTxs(txs?: IbexTransaction[]) {
     const result = txs?.map((el) => {
       return {
         id: el.id,


### PR DESCRIPTION
- Maps the ibex `transactionTypeId` to the proper Galoy type.
- Removes the data loader resolver on the `settlementVia` which was causing errors
- DOES NOT lookup transaction data such as hash, preimage, onchain address, etc. That requires a separate API call which should be done when a user queries for transaction details.