### PR TITLE
Fix NotificationServiceErrors handler

### DIFF
--- a/src/services/ibex/webhook-server/routes/on-receive.ts
+++ b/src/services/ibex/webhook-server/routes/on-receive.ts
@@ -6,6 +6,7 @@ import { AccountsRepository, UsersRepository, WalletsRepository } from "@service
 import { RepositoryError } from "@domain/errors"
 import { displayAmountFromWalletAmount } from "@domain/fiat"
 import { WalletCurrency } from "@domain/shared"
+import { NotificationsServiceError } from "@domain/notifications"
 
 const sendLightningNotification = async (req: Request, resp: Response) => {
     const { transaction } = req.body
@@ -44,7 +45,7 @@ const sendLightningNotification = async (req: Request, resp: Response) => {
         recipientNotificationSettings: recipientAccount.notificationSettings,
         recipientLanguage: recipientUser.language,
     })       
-    if (nsResp instanceof NotificationsService) {
+    if (nsResp instanceof NotificationsServiceError) {
         logger.error(nsResp)
     }
     return resp.status(200).end()

--- a/src/services/notifications/push-notifications.ts
+++ b/src/services/notifications/push-notifications.ts
@@ -44,7 +44,7 @@ const sendToDevice = async (
   logger.info({ tokens, ...message })
   try {
     if (!messaging) {
-      baseLogger.info("Firebase messaging module not loaded")
+      baseLogger.error("Firebase messaging module not loaded")
       // FIXME: should return an error?
       return true
     }
@@ -59,7 +59,6 @@ const sendToDevice = async (
     // apns?: ApnsConfig;
     // fcmOptions?: FcmOptions;
     const response = await messaging.sendEachForMulticast({ tokens, ...message }, false)
-    logger.info({ response })
 
     const invalidTokens: DeviceToken[] = []
     response.responses.forEach((item, index: number) => {
@@ -72,7 +71,7 @@ const sendToDevice = async (
       if (item?.error?.message) {
         recordExceptionInCurrentSpan({
           error: new InvalidDeviceNotificationsServiceError(item.error.message),
-          level: ErrorLevel.Info,
+          level: ErrorLevel.Warn,
         })
       }
     })


### PR DESCRIPTION
There have been multiple errors regarding notifications. The primary culprit appears to be a typo when an error bubbles up to `on-receive` handler, which causes the process to crash. Because of this, it appears notifications are being re-triggered (multiple notifications) while others are never being triggered. 