### PR TITLE
Check null/undefined fee explicitly

### DIFF
--- a/src/graphql/public/root/mutation/ln-usd-invoice-fee-probe.ts
+++ b/src/graphql/public/root/mutation/ln-usd-invoice-fee-probe.ts
@@ -72,7 +72,7 @@ const LnUsdInvoiceFeeProbeMutation = GT.Field<
       currencyId: "3", 
     })
     if (resp instanceof IbexClientError) return { errors: [mapAndParseErrorForGqlResponse(resp)] }     
-    if (!resp.amount) return { errors: [mapAndParseErrorForGqlResponse(new UnexpectedResponseError("Amount field not found."))] }
+    if (resp.amount === null || resp.amount === undefined) return { errors: [mapAndParseErrorForGqlResponse(new UnexpectedResponseError("Amount field not found."))] }
 
     return {
       errors: [],


### PR DESCRIPTION
Bug fix: case where estimated fee is 0 would return an error