### PR TITLE
chore: Revert "chore: use direnv to load node version (#129)"

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,6 +1,5 @@
 dotenv
 
-use nvm 20
 use flake
 
 if [ -f .env.local ]; then
@@ -9,4 +8,3 @@ if [ -f .env.local ]; then
 else
   echo ".env.local not found"
 fi
-

--- a/DEV.md
+++ b/DEV.md
@@ -40,6 +40,8 @@ $ docker compose version
 Docker Compose version 2.0.0
 ```
 
+To use the correct node version, you can install nvm and run `nvm use 20`. Then enable and inititialize yarn using the [yarn docs](https://yarnpkg.com/getting-started/install)
+
 ### Clone the repo:
 
 ```


### PR DESCRIPTION
Didn't work as planned. This reverts commit fe6e57b925c33158dbd0cad9039700944db9dfc4.