### PR TITLE
tests: make ibex creds optional

### DIFF
--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -130,16 +130,16 @@ export const env = createEnv({
     SVIX_ENDPOINT: z.union([z.string().url().nullish(), z.literal("")]), // optional url
 
     IBEX_URL: z.string(),
-    IBEX_EMAIL: z.string(),
-    IBEX_PASSWORD: z.string(),
+    IBEX_EMAIL: z.string().optional(),
+    IBEX_PASSWORD: z.string().optional(),
     IBEX_LISTENER_PORT: z
       .number()
       .min(1)
       .or(z.string())
       .pipe(z.coerce.number())
       .default(4008),
-    IBEX_EXTERNAL_URI: z.string(),
-    IBEX_WEBHOOK_SECRET: z.string(),
+    IBEX_EXTERNAL_URI: z.string().optional(),
+    IBEX_WEBHOOK_SECRET: z.string().optional(),
   },
 
   runtimeEnvStrict: {


### PR DESCRIPTION
unit tests are failing because there are no ibex credentials found in ci. Long-term we want to figure out how to inject secrets into ci. For now, remove the need to have credentials since unit tests don't talk to Ibex