### PR TITLE
fix: remove invalid device tokens

### DIFF
--- a/src/services/notifications/index.ts
+++ b/src/services/notifications/index.ts
@@ -16,7 +16,6 @@ import {
   PushNotificationsService,
 } from "./push-notifications"
 import { createPushNotificationContent } from "./create-push-notification-content"
-import { baseLogger as log } from "@services/logger"
 
 export const NotificationsService = (): INotificationsService => {
   const pubsub = PubSubService()

--- a/src/services/notifications/push-notifications.ts
+++ b/src/services/notifications/push-notifications.ts
@@ -72,6 +72,10 @@ const sendToDevice = async (
         recordExceptionInCurrentSpan({
           error: new InvalidDeviceNotificationsServiceError(item.error.message),
           level: ErrorLevel.Warn,
+          attributes: {
+            code: item?.error?.code,  
+            token: tokens[index],  
+          },
         })
       }
     })


### PR DESCRIPTION
When receiving a lightning transaction, we need to remove invalid tokens, so that a new one can be generated.