### PR TITLE
fix: check no amount invoice in the amount mutation

### DIFF
--- a/src/app/wallets/add-invoice-for-wallet.ts
+++ b/src/app/wallets/add-invoice-for-wallet.ts
@@ -45,7 +45,7 @@ const addInvoiceForSelf = async ({
   const limitOk = await checkSelfWalletIdRateLimits(wallet.accountId)
   if (limitOk instanceof Error) return limitOk
 
-  const checkedAmount = USDollars.fromFractionalCents(amount)
+  const checkedAmount = amount ? USDollars.fromFractionalCents(amount) : undefined 
   if (checkedAmount instanceof Error) return checkedAmount
   const resp = await Ibex.addInvoice({
     amount: checkedAmount, 


### PR DESCRIPTION
This PR allows for invoices to be created without an amount from the `lnUsdInvoiceCreate`, rather than requiring client to use `lnUsdNoAmountInvoiceCreate`