### PR TITLE
feat: Add the invoice amount to fee probe response

### DIFF
--- a/dev/apollo-federation/supergraph.graphql
+++ b/dev/apollo-federation/supergraph.graphql
@@ -1049,7 +1049,7 @@ type Mutation
     associated with the amount).
   """
   lnUsdInvoiceCreateOnBehalfOfRecipient(input: LnUsdInvoiceCreateOnBehalfOfRecipientInput!): LnInvoicePayload!
-  lnUsdInvoiceFeeProbe(input: LnUsdInvoiceFeeProbeInput!): CentAmountPayload!
+  lnUsdInvoiceFeeProbe(input: LnUsdInvoiceFeeProbeInput!): UsdInvoiceEstimate!
   merchantMapSuggest(input: MerchantMapSuggestInput!): MerchantPayload!
   onChainAddressCreate(input: OnChainAddressCreateInput!): OnChainAddressPayload!
   onChainAddressCurrent(input: OnChainAddressCurrentInput!): OnChainAddressPayload!
@@ -1694,6 +1694,14 @@ type UpgradePayload
 """Amount in USD cents"""
 scalar USDCents
   @join__type(graph: PUBLIC)
+
+type UsdInvoiceEstimate
+  @join__type(graph: PUBLIC)
+{
+  errors: [Error!]!
+  fee: USDCents
+  invoiceAmount: USDCents
+}
 
 """
 A wallet belonging to an account which contains a USD balance and a list of transactions.

--- a/src/domain/shared/MoneyAmount.ts
+++ b/src/domain/shared/MoneyAmount.ts
@@ -72,7 +72,7 @@ export class USDAmount extends MoneyAmount {
   // convert dollars to cents
   static dollars(d: number | string): USDAmount | BigIntConversionError {
     try {
-      const dollarAmt = new Money(d, "USDollars", Round.HALF_TO_EVEN)
+      const dollarAmt = new Money(d.toString(), "USDollars", Round.HALF_TO_EVEN)
       const cents = USDAmount.cents(100n)
       if (cents instanceof BigIntConversionError) return cents // should never happen
       return new USDAmount(cents.money.multiply(dollarAmt).toFixed(2))

--- a/src/graphql/public/root/mutation/ln-usd-invoice-fee-probe.ts
+++ b/src/graphql/public/root/mutation/ln-usd-invoice-fee-probe.ts
@@ -18,6 +18,9 @@ import Ibex from "@services/ibex/client"
 import { IbexError, UnexpectedIbexResponse } from "@services/ibex/errors"
 import { ValidationError, WalletCurrency } from "@domain/shared"
 import { baseLogger } from "@services/logger"
+import IError from "@graphql/shared/types/abstract/error"
+import USDCentsScalar from "@graphql/shared/types/scalar/usd-cents"
+import CentAmount from "@graphql/public/types/scalar/cent-amount"
 // import { IbexRoutes } from "../../../../services/ibex/Routes"
 // import { requestIBexPlugin } from "../../../../services/ibex/IbexHelper"
 
@@ -26,6 +29,21 @@ const LnUsdInvoiceFeeProbeInput = GT.Input({
   fields: () => ({
     walletId: { type: GT.NonNull(WalletId) },
     paymentRequest: { type: GT.NonNull(LnPaymentRequest) },
+  }),
+})
+
+const UsdFeeProbeResponse = GT.Object({
+  name: "UsdInvoiceEstimate",
+  fields: () => ({
+    errors: {
+      type: GT.NonNullList(IError),
+    },
+    invoiceAmount: {
+      type: USDCentsScalar,
+    },
+    fee: {
+      type: USDCentsScalar,
+    },
   }),
 })
 
@@ -42,7 +60,7 @@ const LnUsdInvoiceFeeProbeMutation = GT.Field<
   extensions: {
     complexity: 120,
   },
-  type: GT.NonNull(CentAmountPayload),
+  type: GT.NonNull(UsdFeeProbeResponse),
   args: {
     input: { type: GT.NonNull(LnUsdInvoiceFeeProbeInput) },
   },
@@ -76,7 +94,8 @@ const LnUsdInvoiceFeeProbeMutation = GT.Field<
     
     return {
       errors: [],
-      ...resp.fee.gqlPayload(),
+      invoiceAmount: resp.invoice,
+      fee: resp.fee,
     }
   },
 })

--- a/src/graphql/public/schema.graphql
+++ b/src/graphql/public/schema.graphql
@@ -826,7 +826,7 @@ type Mutation {
     associated with the amount).
   """
   lnUsdInvoiceCreateOnBehalfOfRecipient(input: LnUsdInvoiceCreateOnBehalfOfRecipientInput!): LnInvoicePayload!
-  lnUsdInvoiceFeeProbe(input: LnUsdInvoiceFeeProbeInput!): CentAmountPayload!
+  lnUsdInvoiceFeeProbe(input: LnUsdInvoiceFeeProbeInput!): UsdInvoiceEstimate!
   merchantMapSuggest(input: MerchantMapSuggestInput!): MerchantPayload!
   onChainAddressCreate(input: OnChainAddressCreateInput!): OnChainAddressPayload!
   onChainAddressCurrent(input: OnChainAddressCurrentInput!): OnChainAddressPayload!
@@ -1323,6 +1323,12 @@ type UpgradePayload {
   authToken: AuthToken
   errors: [Error!]!
   success: Boolean!
+}
+
+type UsdInvoiceEstimate {
+  errors: [Error!]!
+  fee: USDCents
+  invoiceAmount: USDCents
 }
 
 """

--- a/src/services/ibex/client.ts
+++ b/src/services/ibex/client.ts
@@ -1,5 +1,5 @@
 import IbexClient, { GetFeeEstimateResponse200, IbexClientError } from "ibex-client"
-import { errorHandler, IbexError, UnexpectedIbexResponse } from "./errors"
+import { errorHandler, IbexError, ParseError, UnexpectedIbexResponse } from "./errors"
 import { IbexConfig } from "@config";
 import { AddInvoiceBodyParam, AddInvoiceResponse201, CreateAccountResponse201, CreateLnurlPayBodyParam, CreateLnurlPayResponse201, DecodeLnurlMetadataParam, DecodeLnurlResponse200, EstimateFeeCopyMetadataParam, EstimateFeeCopyResponse200, GenerateBitcoinAddressBodyParam, GenerateBitcoinAddressResponse201, GetAccountDetailsMetadataParam, GetAccountDetailsResponse200, GetFeeEstimationMetadataParam, GetFeeEstimationResponse200, GetTransactionDetails1MetadataParam, GetTransactionDetails1Response200, GMetadataParam, GResponse200, InvoiceFromHashMetadataParam, InvoiceFromHashResponse200, PayInvoiceV2BodyParam, PayInvoiceV2Response200, PayToALnurlPayBodyParam, PayToALnurlPayResponse201, SendToAddressCopyBodyParam, SendToAddressCopyResponse200 } from "ibex-client";
 import { addAttributesToCurrentSpan, wrapAsyncFunctionsToRunInSpan } from "@services/tracing";
@@ -7,6 +7,7 @@ import WebhookServer from "./webhook-server";
 import { Redis }  from "./cache"
 import { GetFeeEstimateArgs, IbexAccountDetails, IbexFeeEstimation, IbexInvoiceArgs, PayInvoiceArgs } from "./types";
 import { USDAmount } from "@domain/shared";
+import { baseLogger } from "@services/logger";
 
 const Ibex = new IbexClient(
   IbexConfig.url, 
@@ -83,9 +84,9 @@ const getLnFeeEstimation = async (args: GetFeeEstimateArgs): Promise<IbexFeeEsti
   else if (resp.invoiceAmount === null || resp.invoiceAmount === undefined) return new UnexpectedIbexResponse("invoiceAmount not found.")
   else {
     let fee = USDAmount.dollars(resp.amount)
-    if (fee instanceof Error) return new UnexpectedIbexResponse("Could not parse fee.")
+    if (fee instanceof Error) return new ParseError(fee)
     let invoiceAmount = USDAmount.dollars(resp.invoiceAmount)
-    if (invoiceAmount instanceof Error) return new UnexpectedIbexResponse("Could not parse invoice amount.")
+    if (invoiceAmount instanceof Error) return new ParseError(invoiceAmount)
     return { 
       fee, 
       invoice: invoiceAmount,

--- a/src/services/ibex/errors.ts
+++ b/src/services/ibex/errors.ts
@@ -22,6 +22,8 @@ export class UnexpectedIbexResponse extends IbexError {
   }
 }
 
+export class ParseError extends IbexError {}
+
 export class InsufficientIbexBalance extends IbexError {}
 export class CompletedInvoice extends IbexError {}
 

--- a/test/flash/unit/domain/shared/Money.spec.ts
+++ b/test/flash/unit/domain/shared/Money.spec.ts
@@ -70,6 +70,12 @@ describe("Money Amount", () => {
       expect(cents.asCents()).toBe('123')
     })
 
+    it("should get the cent amount from dollars", () => {
+      const cents = USDAmount.dollars(0.013717477287)
+      if (cents instanceof Error) throw cents
+      expect(cents.asCents(2)).toBe('1.37')
+    })
+
     it("should calculate the correct percentage using mulBasisPoints", () => {
       const amount = USDAmount.cents('10000') // $100.00
       if (amount instanceof Error) throw amount


### PR DESCRIPTION
- The `invoiceAmount` represents the amount the receiver should see credited in their account, which includes the "stable account fee" charged by Ibex.
- Also resolves a parsing error discovered while testing