### PR TITLE
Update fee response to maintain backward compatibility

### DIFF
--- a/dev/apollo-federation/supergraph.graphql
+++ b/dev/apollo-federation/supergraph.graphql
@@ -312,8 +312,9 @@ scalar CentAmount
 type CentAmountPayload
   @join__type(graph: PUBLIC)
 {
-  amount: CentAmount
+  amount: USDCents
   errors: [Error!]!
+  invoiceAmount: USDCents
 }
 
 type ConsumerAccount implements Account
@@ -1052,7 +1053,7 @@ type Mutation
     associated with the amount).
   """
   lnUsdInvoiceCreateOnBehalfOfRecipient(input: LnUsdInvoiceCreateOnBehalfOfRecipientInput!): LnInvoicePayload!
-  lnUsdInvoiceFeeProbe(input: LnUsdInvoiceFeeProbeInput!): UsdInvoiceEstimate!
+  lnUsdInvoiceFeeProbe(input: LnUsdInvoiceFeeProbeInput!): CentAmountPayload!
   merchantMapSuggest(input: MerchantMapSuggestInput!): MerchantPayload!
   onChainAddressCreate(input: OnChainAddressCreateInput!): OnChainAddressPayload!
   onChainAddressCurrent(input: OnChainAddressCurrentInput!): OnChainAddressPayload!
@@ -1697,14 +1698,6 @@ type UpgradePayload
 """Amount in USD cents"""
 scalar USDCents
   @join__type(graph: PUBLIC)
-
-type UsdInvoiceEstimate
-  @join__type(graph: PUBLIC)
-{
-  errors: [Error!]!
-  fee: USDCents
-  invoiceAmount: USDCents
-}
 
 """
 A wallet belonging to an account which contains a USD balance and a list of transactions.

--- a/src/domain/shared/MoneyAmount.ts
+++ b/src/domain/shared/MoneyAmount.ts
@@ -103,17 +103,6 @@ export class USDAmount extends MoneyAmount {
     return rate.getInstance(converted)
   }
 
-  /**
-   * Create graphql Payload as done in normalizePaymentAmount 
-   * @returns 
-   */
-  gqlPayload(): PaymentAmountPayload<ExchangeCurrencyUnit> {
-    return {
-      amount: Number(this.asCents(0)),
-      currencyUnit: ExchangeCurrencyUnit.Usd, 
-    }
-  }
-  
   toIbex(): number {
     return Number(this.asDollars(8))
   }

--- a/src/graphql/public/root/mutation/ln-noamount-usd-invoice-fee-probe.ts
+++ b/src/graphql/public/root/mutation/ln-noamount-usd-invoice-fee-probe.ts
@@ -77,7 +77,8 @@ const LnNoAmountUsdInvoiceFeeProbeMutation = GT.Field({
 
     return {
       errors: [],
-      ...resp.fee.gqlPayload(),
+      invoiceAmount: resp.invoice,
+      amount: resp.fee,
     }
   },
 })

--- a/src/graphql/public/root/mutation/ln-usd-invoice-fee-probe.ts
+++ b/src/graphql/public/root/mutation/ln-usd-invoice-fee-probe.ts
@@ -32,20 +32,20 @@ const LnUsdInvoiceFeeProbeInput = GT.Input({
   }),
 })
 
-const UsdFeeProbeResponse = GT.Object({
-  name: "UsdInvoiceEstimate",
-  fields: () => ({
-    errors: {
-      type: GT.NonNullList(IError),
-    },
-    invoiceAmount: {
-      type: USDCentsScalar,
-    },
-    fee: {
-      type: USDCentsScalar,
-    },
-  }),
-})
+// const UsdFeeProbeResponse = GT.Object({
+//   name: "UsdInvoiceEstimate",
+//   fields: () => ({
+//     errors: {
+//       type: GT.NonNullList(IError),
+//     },
+//     invoiceAmount: {
+//       type: USDCentsScalar,
+//     },
+//     fee: {
+//       type: USDCentsScalar,
+//     },
+//   }),
+// })
 
 const LnUsdInvoiceFeeProbeMutation = GT.Field<
   null,
@@ -60,7 +60,7 @@ const LnUsdInvoiceFeeProbeMutation = GT.Field<
   extensions: {
     complexity: 120,
   },
-  type: GT.NonNull(UsdFeeProbeResponse),
+  type: GT.NonNull(CentAmountPayload),
   args: {
     input: { type: GT.NonNull(LnUsdInvoiceFeeProbeInput) },
   },
@@ -95,7 +95,7 @@ const LnUsdInvoiceFeeProbeMutation = GT.Field<
     return {
       errors: [],
       invoiceAmount: resp.invoice,
-      fee: resp.fee,
+      amount: resp.fee,
     }
   },
 })

--- a/src/graphql/public/schema.graphql
+++ b/src/graphql/public/schema.graphql
@@ -234,8 +234,9 @@ type CashoutOffer {
 scalar CentAmount
 
 type CentAmountPayload {
-  amount: CentAmount
+  amount: USDCents
   errors: [Error!]!
+  invoiceAmount: USDCents
 }
 
 type ConsumerAccount implements Account {
@@ -829,7 +830,7 @@ type Mutation {
     associated with the amount).
   """
   lnUsdInvoiceCreateOnBehalfOfRecipient(input: LnUsdInvoiceCreateOnBehalfOfRecipientInput!): LnInvoicePayload!
-  lnUsdInvoiceFeeProbe(input: LnUsdInvoiceFeeProbeInput!): UsdInvoiceEstimate!
+  lnUsdInvoiceFeeProbe(input: LnUsdInvoiceFeeProbeInput!): CentAmountPayload!
   merchantMapSuggest(input: MerchantMapSuggestInput!): MerchantPayload!
   onChainAddressCreate(input: OnChainAddressCreateInput!): OnChainAddressPayload!
   onChainAddressCurrent(input: OnChainAddressCurrentInput!): OnChainAddressPayload!
@@ -1326,12 +1327,6 @@ type UpgradePayload {
   authToken: AuthToken
   errors: [Error!]!
   success: Boolean!
-}
-
-type UsdInvoiceEstimate {
-  errors: [Error!]!
-  fee: USDCents
-  invoiceAmount: USDCents
 }
 
 """

--- a/src/graphql/public/types/payload/cent-amount.ts
+++ b/src/graphql/public/types/payload/cent-amount.ts
@@ -2,6 +2,7 @@ import { GT } from "@graphql/index"
 
 import IError from "@graphql/shared/types/abstract/error"
 import CentAmount from "@graphql/public/types/scalar/cent-amount"
+import USDCentsScalar from "@graphql/shared/types/scalar/usd-cents"
 
 const CentAmountPayload = GT.Object({
   name: "CentAmountPayload",
@@ -9,8 +10,12 @@ const CentAmountPayload = GT.Object({
     errors: {
       type: GT.NonNullList(IError),
     },
+    // the fee amount of the invoice 
     amount: {
-      type: CentAmount,
+      type: USDCentsScalar,
+    },
+    invoiceAmount: {
+      type: USDCentsScalar,
     },
   }),
 })


### PR DESCRIPTION
Revert the graphql schema for backward compatibility, while adding the additional field `invoiceAmount` to both fee probe mutations
