### PR TITLE
Define test suite ECMAscript version explicitly

### DIFF
--- a/test/swc-config.json
+++ b/test/swc-config.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json.schemastore.org/swcrc",
   "jsc": {
+    "target": "es2022",
     "experimental": {
       "plugins": [["jest_workaround", {}]]
     }


### PR DESCRIPTION
Test suite failing due to implicitly using es2023. Explicitly setting es2022 fixes the issue