### PR TITLE
add broadcast mutation for emergency broadcasts via FCM 

### DIFF
--- a/src/app/admin/index.ts
+++ b/src/app/admin/index.ts
@@ -1,5 +1,6 @@
 export * from "./update-user-phone"
 export * from "./send-admin-push-notification"
+export * from "./send-broadcast-notification"
 
 import { checkedToAccountUuid, checkedToUsername } from "@domain/accounts"
 import { IdentityRepository } from "@services/kratos"

--- a/src/app/admin/send-broadcast-notification.ts
+++ b/src/app/admin/send-broadcast-notification.ts
@@ -1,0 +1,43 @@
+import { checkedToBroadcastTag } from "@domain/notifications"
+
+import { NotificationsService } from "@services/notifications"
+import { User } from "@services/mongoose/schema"
+
+export const sendBroadcastNotification = async ({
+  title,
+  body,
+  tag,
+}: {
+  title: string
+  body: string
+  tag: string
+}): Promise<true | ApplicationError> => {
+  // Validate broadcast tag
+  const broadcastTag = checkedToBroadcastTag(tag)
+  if (broadcastTag instanceof Error) return broadcastTag
+
+  // Fetch all users with device tokens
+  const users = await User.find(
+    { deviceTokens: { $exists: true, $not: { $size: 0 } } },
+    { deviceTokens: 1 },
+  ).lean()
+
+  if (!users || users.length === 0) return true
+
+  // Collect all device tokens from all users
+  const allDeviceTokens: DeviceToken[] = users.flatMap(
+    (user) => user.deviceTokens as DeviceToken[],
+  )
+
+  if (allDeviceTokens.length === 0) return true
+
+  // Send broadcast notification with tag in data
+  const result = await NotificationsService().sendBroadcast({
+    deviceTokens: allDeviceTokens,
+    title,
+    body,
+    data: { tag: broadcastTag },
+  })
+
+  return result
+}

--- a/src/domain/notifications/index.ts
+++ b/src/domain/notifications/index.ts
@@ -21,6 +21,13 @@ export const GaloyNotificationCategories = {
   AdminPushNotification: "AdminPushNotification" as NotificationCategory,
 } as const
 
+export const BroadcastTag = {
+  EMERGENCY: "EMERGENCY",
+  ATTENTION: "ATTENTION",
+  INFO: "INFO",
+  MARKETING: "MARKETING",
+} as const
+
 export const checkedToNotificationCategory = (
   notificationCategory: string,
 ): NotificationCategory | ValidationError => {
@@ -30,6 +37,18 @@ export const checkedToNotificationCategory = (
   }
 
   return notificationCategory as NotificationCategory
+}
+
+export const checkedToBroadcastTag = (
+  tag: string,
+): BroadcastTag | ValidationError => {
+  const validTags = Object.values(BroadcastTag)
+  if (!validTags.includes(tag as BroadcastTag)) {
+    return new InvalidNotificationSettingsError(
+      `Invalid broadcast tag. Must be one of: ${validTags.join(", ")}`,
+    )
+  }
+  return tag as BroadcastTag
 }
 
 export const enableNotificationChannel = ({

--- a/src/domain/notifications/index.types.d.ts
+++ b/src/domain/notifications/index.types.d.ts
@@ -53,6 +53,13 @@ type PriceUpdateArgs<C extends DisplayCurrency> = {
   pricePerUsdCent: RealTimePrice<C>
 }
 
+type SendBroadcastArgs = {
+  deviceTokens: DeviceToken[]
+  title: string
+  body: string
+  data?: { [key: string]: string }
+}
+
 interface INotificationsService {
   // ibexTxReceived: (args: any) => Promise<true | NotificationsServiceError>
 
@@ -80,10 +87,14 @@ interface INotificationsService {
   adminPushNotificationFilteredSend(
     args: SendFilteredPushNotificationArgs,
   ): Promise<true | NotificationsServiceError>
+  sendBroadcast(args: SendBroadcastArgs): Promise<true | NotificationsServiceError>
 }
 
 type NotificationChannel =
   (typeof import("./index").NotificationChannel)[keyof typeof import("./index").NotificationChannel]
+
+type BroadcastTag =
+  (typeof import("./index").BroadcastTag)[keyof typeof import("./index").BroadcastTag]
 
 type NotificationSettings = Record<NotificationChannel, NotificationChannelSettings>
 

--- a/src/graphql/admin/mutations.ts
+++ b/src/graphql/admin/mutations.ts
@@ -7,6 +7,7 @@ import BusinessUpdateMapInfoMutation from "@graphql/admin/root/mutation/business
 import UserUpdatePhoneMutation from "./root/mutation/user-update-phone"
 import BusinessDeleteMapInfoMutation from "./root/mutation/delete-business-map"
 import AdminPushNotificationSendMutation from "./root/mutation/admin-push-notification-send"
+import AdminBroadcastSendMutation from "./root/mutation/admin-broadcast-send"
 
 import MerchantMapDeleteMutation from "./root/mutation/merchant-map-delete"
 import MerchantMapValidateMutation from "./root/mutation/merchant-map-validate"
@@ -23,6 +24,7 @@ export const mutationFields = {
     businessUpdateMapInfo: BusinessUpdateMapInfoMutation,
     businessDeleteMapInfo: BusinessDeleteMapInfoMutation,
     adminPushNotificationSend: AdminPushNotificationSendMutation,
+    adminBroadcastSend: AdminBroadcastSendMutation,
   },
 }
 

--- a/src/graphql/admin/root/mutation/admin-broadcast-send.ts
+++ b/src/graphql/admin/root/mutation/admin-broadcast-send.ts
@@ -1,0 +1,57 @@
+import { GT } from "@graphql/index"
+
+import AdminBroadcastSendPayload from "@graphql/admin/types/payload/admin-broadcast-send"
+import BroadcastTag from "@graphql/admin/types/scalar/broadcast-tag"
+import { Admin } from "@app"
+import { mapAndParseErrorForGqlResponse } from "@graphql/error-map"
+
+const AdminBroadcastSendInput = GT.Input({
+  name: "AdminBroadcastSendInput",
+  fields: () => ({
+    title: {
+      type: GT.NonNull(GT.String),
+    },
+    body: {
+      type: GT.NonNull(GT.String),
+    },
+    tag: {
+      type: GT.NonNull(BroadcastTag),
+    },
+  }),
+})
+
+const AdminBroadcastSendMutation = GT.Field<
+  null,
+  GraphQLAdminContext,
+  {
+    input: {
+      title: string
+      body: string
+      tag: string
+    }
+  }
+>({
+  extensions: {
+    complexity: 120,
+  },
+  type: GT.NonNull(AdminBroadcastSendPayload),
+  args: {
+    input: { type: GT.NonNull(AdminBroadcastSendInput) },
+  },
+  resolve: async (_, args) => {
+    const { title, body, tag } = args.input
+
+    const success = await Admin.sendBroadcastNotification({
+      title,
+      body,
+      tag,
+    })
+
+    if (success instanceof Error) {
+      return { errors: [mapAndParseErrorForGqlResponse(success)] }
+    }
+    return { errors: [], success: true }
+  },
+})
+
+export default AdminBroadcastSendMutation

--- a/src/graphql/admin/schema.graphql
+++ b/src/graphql/admin/schema.graphql
@@ -29,6 +29,17 @@ input AccountUpdateStatusInput {
   uid: ID!
 }
 
+input AdminBroadcastSendInput {
+  body: String!
+  tag: BroadcastTag!
+  title: String!
+}
+
+type AdminBroadcastSendPayload {
+  errors: [Error!]!
+  success: Boolean
+}
+
 input AdminPushNotificationSendInput {
   accountId: String!
   body: String!
@@ -119,6 +130,8 @@ type BTCWallet implements Wallet {
   ): TransactionConnection
   walletCurrency: WalletCurrency!
 }
+
+scalar BroadcastTag
 
 input BusinessDeleteMapInfoInput {
   username: Username!
@@ -253,6 +266,7 @@ type MerchantPayload {
 type Mutation {
   accountUpdateLevel(input: AccountUpdateLevelInput!): AccountDetailPayload!
   accountUpdateStatus(input: AccountUpdateStatusInput!): AccountDetailPayload!
+  adminBroadcastSend(input: AdminBroadcastSendInput!): AdminBroadcastSendPayload!
   adminPushNotificationSend(input: AdminPushNotificationSendInput!): AdminPushNotificationSendPayload!
   businessDeleteMapInfo(input: BusinessDeleteMapInfoInput!): AccountDetailPayload!
   businessUpdateMapInfo(input: BusinessUpdateMapInfoInput!): AccountDetailPayload!

--- a/src/graphql/admin/types/payload/admin-broadcast-send.ts
+++ b/src/graphql/admin/types/payload/admin-broadcast-send.ts
@@ -1,0 +1,16 @@
+import { GT } from "@graphql/index"
+import IError from "@graphql/shared/types/abstract/error"
+
+const AdminBroadcastSendPayload = GT.Object({
+  name: "AdminBroadcastSendPayload",
+  fields: () => ({
+    errors: {
+      type: GT.NonNullList(IError),
+    },
+    success: {
+      type: GT.Boolean,
+    },
+  }),
+})
+
+export default AdminBroadcastSendPayload

--- a/src/graphql/admin/types/scalar/broadcast-tag.ts
+++ b/src/graphql/admin/types/scalar/broadcast-tag.ts
@@ -1,0 +1,31 @@
+import { InputValidationError } from "@graphql/error"
+import { GT } from "@graphql/index"
+import { checkedToBroadcastTag } from "@domain/notifications"
+
+const BroadcastTag = GT.Scalar({
+  name: "BroadcastTag",
+  parseValue(value) {
+    if (typeof value !== "string") {
+      return new InputValidationError({
+        message: "Invalid type for BroadcastTag",
+      })
+    }
+    return validBroadcastTag(value)
+  },
+  parseLiteral(ast) {
+    if (ast.kind === GT.Kind.STRING) {
+      return validBroadcastTag(ast.value)
+    }
+    return new InputValidationError({ message: "Invalid type for BroadcastTag" })
+  },
+})
+
+function validBroadcastTag(value: string): BroadcastTag | InputValidationError {
+  const checkedTag = checkedToBroadcastTag(value)
+  if (checkedTag instanceof Error) {
+    return new InputValidationError({ message: checkedTag.message })
+  }
+  return checkedTag
+}
+
+export default BroadcastTag

--- a/src/services/notifications/index.ts
+++ b/src/services/notifications/index.ts
@@ -425,6 +425,27 @@ export const NotificationsService = (): INotificationsService => {
     }
   }
 
+  const sendBroadcast = async ({
+    title,
+    body,
+    data,
+    deviceTokens,
+  }: SendBroadcastArgs): Promise<true | NotificationsServiceError> => {
+    const hasDeviceTokens = deviceTokens && deviceTokens.length > 0
+    if (!hasDeviceTokens) return true
+
+    try {
+      return pushNotification.sendNotification({
+        deviceTokens,
+        title,
+        body,
+        data,
+      })
+    } catch (err) {
+      return handleCommonNotificationErrors(err)
+    }
+  }
+
   // trace everything except price update because it runs every 30 seconds
   return {
     priceUpdate,
@@ -439,6 +460,7 @@ export const NotificationsService = (): INotificationsService => {
         sendBalance,
         adminPushNotificationSend,
         adminPushNotificationFilteredSend,
+        sendBroadcast,
       },
     }),
   }


### PR DESCRIPTION

Admin-only mutation protected by "Accounts Manager" role
Broadcast tags: EMERGENCY, ATTENTION, INFO, MARKETING (predefined enum)
Sends to all users with FCM tokens registered in the system


Example:

mutation {
    adminBroadcastSend(input: {
      title: "System Maintenance"
      body: "We'll be performing maintenance tonight"
      tag: EMERGENCY
    }) {
      success
      errors {
        message
      }
    }
  }