### PR TITLE
[chore] Update balance field type to be FractionalCentAmount

### DIFF
--- a/dev/apollo-federation/supergraph.graphql
+++ b/dev/apollo-federation/supergraph.graphql
@@ -177,7 +177,7 @@ type BTCWallet implements Wallet
   accountId: ID!
 
   """A balance stored in BTC."""
-  balance: SignedAmount!
+  balance: FractionalCentAmount!
   id: ID!
   lnurlp: Lnurl
 
@@ -469,7 +469,9 @@ type FeesInformation
   deposit: DepositFeesInformation!
 }
 
-"""(Positive) Cent amount (1/100 of a dollar) as a float"""
+"""
+Cent amount (1/100 of a dollar) as a float, can be positive or negative
+"""
 scalar FractionalCentAmount
   @join__type(graph: PUBLIC)
 
@@ -1714,7 +1716,7 @@ type UsdWallet implements Wallet
   @join__type(graph: PUBLIC)
 {
   accountId: ID!
-  balance: SignedAmount!
+  balance: FractionalCentAmount!
   id: ID!
   lnurlp: Lnurl
 
@@ -2043,7 +2045,7 @@ interface Wallet
   @join__type(graph: PUBLIC)
 {
   accountId: ID!
-  balance: SignedAmount!
+  balance: FractionalCentAmount!
   id: ID!
   lnurlp: Lnurl
   pendingIncomingBalance: SignedAmount!

--- a/src/graphql/admin/schema.graphql
+++ b/src/graphql/admin/schema.graphql
@@ -80,7 +80,7 @@ type BTCWallet implements Wallet {
   accountId: ID!
 
   """A balance stored in BTC."""
-  balance: SignedAmount!
+  balance: FractionalCentAmount!
   id: ID!
   lnurlp: Lnurl
 
@@ -152,6 +152,11 @@ interface Error {
   message: String!
   path: [String]
 }
+
+"""
+Cent amount (1/100 of a dollar) as a float, can be positive or negative
+"""
+scalar FractionalCentAmount
 
 type GraphQLApplicationError implements Error {
   code: String
@@ -430,7 +435,7 @@ A wallet belonging to an account which contains a USD balance and a list of tran
 """
 type UsdWallet implements Wallet {
   accountId: ID!
-  balance: SignedAmount!
+  balance: FractionalCentAmount!
   id: ID!
   lnurlp: Lnurl
 
@@ -481,7 +486,7 @@ A generic wallet which stores value in one of our supported currencies.
 """
 interface Wallet {
   accountId: ID!
-  balance: SignedAmount!
+  balance: FractionalCentAmount!
   id: ID!
   lnurlp: Lnurl
   pendingIncomingBalance: SignedAmount!

--- a/src/graphql/public/schema.graphql
+++ b/src/graphql/public/schema.graphql
@@ -120,7 +120,7 @@ type BTCWallet implements Wallet {
   accountId: ID!
 
   """A balance stored in BTC."""
-  balance: SignedAmount!
+  balance: FractionalCentAmount!
   id: ID!
   lnurlp: Lnurl
 
@@ -360,7 +360,9 @@ type FeesInformation {
   deposit: DepositFeesInformation!
 }
 
-"""(Positive) Cent amount (1/100 of a dollar) as a float"""
+"""
+Cent amount (1/100 of a dollar) as a float, can be positive or negative
+"""
 scalar FractionalCentAmount
 
 """
@@ -1339,7 +1341,7 @@ A wallet belonging to an account which contains a USD balance and a list of tran
 """
 type UsdWallet implements Wallet {
   accountId: ID!
-  balance: SignedAmount!
+  balance: FractionalCentAmount!
   id: ID!
   lnurlp: Lnurl
 
@@ -1596,7 +1598,7 @@ A generic wallet which stores value in one of our supported currencies.
 """
 interface Wallet {
   accountId: ID!
-  balance: SignedAmount!
+  balance: FractionalCentAmount!
   id: ID!
   lnurlp: Lnurl
   pendingIncomingBalance: SignedAmount!

--- a/src/graphql/public/types/scalar/cent-amount-fraction.ts
+++ b/src/graphql/public/types/scalar/cent-amount-fraction.ts
@@ -4,7 +4,7 @@ import { GT } from "@graphql/index"
 
 const FractionalCentAmount = GT.Scalar({
   name: "FractionalCentAmount",
-  description: "(Positive) Cent amount (1/100 of a dollar) as a float",
+  description: "Cent amount (1/100 of a dollar) as a float, can be positive or negative",
   parseValue(value) {
     if (typeof value !== "string" && typeof value !== "number") {
       return new InputValidationError({ message: "Invalid type for FractionalCentAmount" })
@@ -12,7 +12,7 @@ const FractionalCentAmount = GT.Scalar({
     return validFractionalCentAmount(value)
   },
   parseLiteral(ast) {
-    if (ast.kind === GT.Kind.INT) {
+    if (ast.kind === GT.Kind.INT || ast.kind === GT.Kind.FLOAT) {
       return validFractionalCentAmount(ast.value)
     }
     return new InputValidationError({ message: "Invalid type for FractionalCentAmount" })
@@ -20,22 +20,23 @@ const FractionalCentAmount = GT.Scalar({
 })
 
 function validFractionalCentAmount(value: string | number) {
-  let intValue: number
+  let floatValue: number
   if (typeof value === "number") {
-    intValue = value
+    floatValue = value
   } else {
-    intValue = Number.parseFloat(value) 
+    floatValue = Number.parseFloat(value)
   }
 
-  if (!(intValue >= 0)) {
+  if (!Number.isFinite(floatValue)) {
     return new InputValidationError({ message: "Invalid value for FractionalCentAmount" })
   }
 
-  if (intValue > MAX_CENTS.amount) {
-    return new InputValidationError({ message: "Value too big for FractionalCentAmount" })
+  const maxCents = Number(MAX_CENTS.amount)
+  if (floatValue > maxCents || floatValue < -maxCents) {
+    return new InputValidationError({ message: "Value out of range for FractionalCentAmount" })
   }
 
-  return intValue
+  return floatValue
 }
 
 export default FractionalCentAmount

--- a/src/graphql/shared/types/abstract/wallet.ts
+++ b/src/graphql/shared/types/abstract/wallet.ts
@@ -8,6 +8,7 @@ import WalletCurrency from "../scalar/wallet-currency"
 import SignedAmount from "../scalar/signed-amount"
 import OnChainAddress from "../scalar/on-chain-address"
 import Lnurl from "../scalar/lnurl"
+import FractionalCentAmount from "@graphql/public/types/scalar/cent-amount-fraction"
 
 const IWallet = GT.Interface({
   name: "Wallet",
@@ -26,7 +27,7 @@ const IWallet = GT.Interface({
       type: Lnurl,
     },
     balance: {
-      type: GT.NonNull(SignedAmount),
+      type: GT.NonNull(FractionalCentAmount),
     },
     pendingIncomingBalance: {
       type: GT.NonNull(SignedAmount),

--- a/src/graphql/shared/types/object/btc-wallet.ts
+++ b/src/graphql/shared/types/object/btc-wallet.ts
@@ -16,6 +16,7 @@ import IWallet from "../abstract/wallet"
 import SignedAmount from "../scalar/signed-amount"
 import WalletCurrency from "../scalar/wallet-currency"
 import OnChainAddress from "../scalar/on-chain-address"
+import FractionalCentAmount from "@graphql/public/types/scalar/cent-amount-fraction"
 
 import { TransactionConnection } from "./transaction"
 import Lnurl from "../scalar/lnurl"
@@ -42,7 +43,7 @@ const BtcWallet = GT.Object<Wallet>({
       resolve: (source) => source.lnurlp,
     },
     balance: {
-      type: GT.NonNull(SignedAmount),
+      type: GT.NonNull(FractionalCentAmount),
       description: "A balance stored in BTC.",
       resolve: async (source) => {
         const balanceSats = await Wallets.getBalanceForWallet({ walletId: source.id })

--- a/src/graphql/shared/types/object/usd-wallet.ts
+++ b/src/graphql/shared/types/object/usd-wallet.ts
@@ -16,6 +16,7 @@ import IWallet from "../abstract/wallet"
 import WalletCurrency from "../scalar/wallet-currency"
 import SignedAmount from "../scalar/signed-amount"
 import OnChainAddress from "../scalar/on-chain-address"
+import FractionalCentAmount from "@graphql/public/types/scalar/cent-amount-fraction"
 
 import { TransactionConnection } from "./transaction"
 import { baseLogger } from "@services/logger"
@@ -45,13 +46,13 @@ const UsdWallet = GT.Object<Wallet>({
     },
     
     balance: {
-      type: GT.NonNull(SignedAmount),
+      type: GT.NonNull(FractionalCentAmount),
       resolve: async (source) => {
         const balance = await Wallets.getBalanceForWallet({ walletId: source.id })
         if (balance instanceof Error) {
           throw mapError(balance)
         }
-        return Number(balance.asCents())
+        return Number(balance.asCents(8))
       },
     },
     pendingIncomingBalance: {


### PR DESCRIPTION
updated the me query's balance field to use Fractional Cents with full precision from IBEX.

interface Wallet {
    balance: FractionalCentAmount!  # Was: SignedAmount!
    ...
  }