### PR TITLE
fix/onchain-fee-calculation-to-support-fractional-cents

### DIFF
--- a/quickstart/graphql/public/schema.graphql
+++ b/quickstart/graphql/public/schema.graphql
@@ -856,7 +856,7 @@ input OnChainUsdPaymentSendInput {
 }
 
 type OnChainUsdTxFee {
-  amount: CentAmount!
+  amount: FractionalCentAmount!
 }
 
 type OneDayAccountLimit implements AccountLimit {
@@ -1009,7 +1009,7 @@ type Query {
   me: User
   mobileVersions: [MobileVersions]
   onChainTxFee(address: OnChainAddress!, amount: SatAmount!, speed: PayoutSpeed = FAST, walletId: WalletId!): OnChainTxFee!
-  onChainUsdTxFee(address: OnChainAddress!, amount: CentAmount!, speed: PayoutSpeed = FAST, walletId: WalletId!): OnChainUsdTxFee!
+  onChainUsdTxFee(address: OnChainAddress!, amount: FractionalCentAmount!, speed: PayoutSpeed = FAST, walletId: WalletId!): OnChainUsdTxFee!
   onChainUsdTxFeeAsBtcDenominated(address: OnChainAddress!, amount: SatAmount!, speed: PayoutSpeed = FAST, walletId: WalletId!): OnChainUsdTxFee!
   quizQuestions: [QuizQuestion] @deprecated(reason: "TODO: remove. we don't need a non authenticated version of this query. the users can only do the query while authenticated")
 

--- a/src/graphql/public/schema.graphql
+++ b/src/graphql/public/schema.graphql
@@ -979,7 +979,7 @@ input OnChainUsdPaymentSendInput {
 }
 
 type OnChainUsdTxFee {
-  amount: CentAmount!
+  amount: FractionalCentAmount!
 }
 
 type OneDayAccountLimit implements AccountLimit {
@@ -1134,7 +1134,7 @@ type Query {
   mobileVersions: [MobileVersions]
   npubByUsername(username: Username!): npubByUsername
   onChainTxFee(address: OnChainAddress!, amount: SatAmount!, speed: PayoutSpeed = FAST, walletId: WalletId!): OnChainTxFee!
-  onChainUsdTxFee(address: OnChainAddress!, amount: CentAmount!, speed: PayoutSpeed = FAST, walletId: WalletId!): OnChainUsdTxFee!
+  onChainUsdTxFee(address: OnChainAddress!, amount: FractionalCentAmount!, speed: PayoutSpeed = FAST, walletId: WalletId!): OnChainUsdTxFee!
   onChainUsdTxFeeAsBtcDenominated(address: OnChainAddress!, amount: SatAmount!, speed: PayoutSpeed = FAST, walletId: WalletId!): OnChainUsdTxFee!
   quizQuestions: [QuizQuestion] @deprecated(reason: "TODO: remove. we don't need a non authenticated version of this query. the users can only do the query while authenticated")
 

--- a/src/graphql/public/types/object/onchain-usd-tx-fee.ts
+++ b/src/graphql/public/types/object/onchain-usd-tx-fee.ts
@@ -1,11 +1,11 @@
 import { GT } from "@graphql/index"
 
-import CentAmount from "../scalar/cent-amount"
+import FractionalCentAmount from "../scalar/cent-amount-fraction"
 
 const OnChainUsdTxFee = GT.Object({
   name: "OnChainUsdTxFee",
   fields: () => ({
-    amount: { type: GT.NonNull(CentAmount) },
+    amount: { type: GT.NonNull(FractionalCentAmount) },
   }),
 })
 


### PR DESCRIPTION
fix #117 
- Changed onChainUsdTxFee to use FractionalCentAmount instead of CentAmount
- Removed Math.round() that was losing decimal precision from Ibex API
- Updated both main and quickstart GraphQL schemas
- Aligns with existing pattern used in LnNoAmountUsdInvoiceFeeProbe

