### PR TITLE
dev: clean docker frappe containers and volumes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,9 @@ start-deps:
 start-frappe:
 	docker compose up frappe -d
 
+clean-frappe:
+	./dev/clean-frappe
+
 start-deps-integration:
 	docker compose up integration-deps -d
 

--- a/dev/clean-frappe
+++ b/dev/clean-frappe
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -e
+
+echo "Cleaning Frappe environment..."
+
+# Stop and remove Frappe containers
+echo "Stopping and removing Frappe containers..."
+docker compose stop frappe-backend frappe-frontend frappe-websocket 2>/dev/null || true
+docker compose rm -f frappe-backend frappe-frontend frappe-websocket frappe-create-site frappe-configurator 2>/dev/null || true
+
+# Stop and remove MariaDB and Redis
+echo "Stopping and removing MariaDB and Redis containers..."
+docker compose stop mariadb redis 2>/dev/null || true
+docker compose rm -f mariadb redis 2>/dev/null || true
+
+# Remove Frappe volumes
+echo "Removing Frappe volumes..."
+docker volume rm flash_frappe-sites flash_frappe-logs 2>/dev/null || true
+
+# Remove MariaDB volume
+echo "Removing MariaDB volume..."
+docker volume rm flash_mariadb-data 2>/dev/null || true
+
+echo "✓ Frappe environment cleaned successfully!"
+echo ""
+echo "To start fresh, run: make start-frappe"


### PR DESCRIPTION
Run `make clean-frappe` to clean out all docker containers and volumes. Run `make start-frappe` to start again