### PR TITLE
dev: Refactor Graphql SuccessResponse to stay DRY

### DIFF
--- a/src/graphql/admin/root/mutation/admin-broadcast-send.ts
+++ b/src/graphql/admin/root/mutation/admin-broadcast-send.ts
@@ -4,6 +4,7 @@ import AdminBroadcastSendPayload from "@graphql/admin/types/payload/admin-broadc
 import BroadcastTag from "@graphql/admin/types/scalar/broadcast-tag"
 import { Admin } from "@app"
 import { mapAndParseErrorForGqlResponse } from "@graphql/error-map"
+import { SUCCESS_RESPONSE } from "@graphql/shared/types/payload/success-payload"
 
 const AdminBroadcastSendInput = GT.Input({
   name: "AdminBroadcastSendInput",
@@ -50,7 +51,7 @@ const AdminBroadcastSendMutation = GT.Field<
     if (success instanceof Error) {
       return { errors: [mapAndParseErrorForGqlResponse(success)] }
     }
-    return { errors: [], success: true }
+    return SUCCESS_RESPONSE
   },
 })
 

--- a/src/graphql/admin/root/mutation/admin-push-notification-send.ts
+++ b/src/graphql/admin/root/mutation/admin-push-notification-send.ts
@@ -3,6 +3,7 @@ import { GT } from "@graphql/index"
 import AdminPushNotificationSendPayload from "@graphql/admin/types/payload/admin-push-notification-send"
 import { Admin } from "@app"
 import { mapAndParseErrorForGqlResponse } from "@graphql/error-map"
+import { SUCCESS_RESPONSE } from "@graphql/shared/types/payload/success-payload"
 import NotificationCategory from "@graphql/shared/types/scalar/notification-category"
 
 const AdminPushNotificationSendInput = GT.Input({
@@ -60,7 +61,7 @@ const AdminPushNotificationSendMutation = GT.Field<
     if (success instanceof Error) {
       return { errors: [mapAndParseErrorForGqlResponse(success)] }
     }
-    return { errors: [], success: true }
+    return SUCCESS_RESPONSE
   },
 })
 

--- a/src/graphql/public/root/mutation/device-notification-token-create.ts
+++ b/src/graphql/public/root/mutation/device-notification-token-create.ts
@@ -1,6 +1,6 @@
 import { GT } from "@graphql/index"
 
-import SuccessPayload from "@graphql/shared/types/payload/success-payload"
+import SuccessPayload, { SUCCESS_RESPONSE } from "@graphql/shared/types/payload/success-payload"
 
 import { Users } from "@app"
 import { parseErrorMessageFromUnknown } from "@domain/shared"
@@ -34,7 +34,7 @@ const DeviceNotificationTokenCreateMutation = GT.Field<
       return { errors: [{ message: parseErrorMessageFromUnknown(err) }] }
     }
 
-    return { errors: [], success: true }
+    return SUCCESS_RESPONSE
   },
 })
 

--- a/src/graphql/public/root/mutation/user-logout.ts
+++ b/src/graphql/public/root/mutation/user-logout.ts
@@ -2,7 +2,7 @@ import { GT } from "@graphql/index"
 
 import { logoutToken } from "@app/authentication"
 import { mapAndParseErrorForGqlResponse } from "@graphql/error-map"
-import SuccessPayload from "@graphql/shared/types/payload/success-payload"
+import SuccessPayload, { SUCCESS_RESPONSE } from "@graphql/shared/types/payload/success-payload"
 
 const UserLogoutInput = GT.Input({
   name: "UserLogoutInput",
@@ -33,7 +33,7 @@ const UserLogoutMutation = GT.Field<
     const logoutResp = await logoutToken({ sessionId, deviceToken, userId: user.id })
     if (logoutResp instanceof Error)
       return { errors: [mapAndParseErrorForGqlResponse(logoutResp)], success: false }
-    return { errors: [], success: true }
+    return SUCCESS_RESPONSE
   },
 })
 

--- a/src/graphql/shared/types/payload/success-payload.ts
+++ b/src/graphql/shared/types/payload/success-payload.ts
@@ -15,4 +15,6 @@ const SuccessPayload = GT.Object({
   }),
 })
 
+export const SUCCESS_RESPONSE = { errors: [], success: true } as const
+
 export default SuccessPayload


### PR DESCRIPTION
Defines standard SUCCESS_RESPONSE for graphql that maps to the SuccessPayload