### PR TITLE
Parameterize frappe image tag and add local compose override

### DIFF
--- a/.env
+++ b/.env
@@ -120,3 +120,5 @@ export KRATOS_ADMIN_API="http://localhost:4434"
 export CONFIG_PATH="$HOME/.config/flash"
 
 export ERPNEXT_JWT_SECRET="not-so-secret"
+
+COMPOSE_FILE=docker-compose.yml:docker-compose.override.yml:docker-compose.local.yml

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ junit.xml
 .yarn/
 .yarnrc.yml
 
+docker-compose.local.yml

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,0 +1,7 @@
+# Local overrides — this file is committed but changes are personal.
+# Example: bind mount local frappe-flash-admin for live editing
+#
+# services:
+#   frappe-backend:
+#     volumes:
+#       - ../frappe-flash-admin/admin_panel:/home/frappe/frappe-bench/apps/admin_panel

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -199,7 +199,7 @@ services:
   # Frappe/ERPNext services
   frappe-backend:
     # image: lnflash/frappe-erp-admin:latest
-    image: brh28/frappe-flash:0.0.4
+    image: brh28/frappe-flash:${FRAPPE_TAG:-latest}
     deploy:
       restart_policy:
         condition: on-failure
@@ -213,7 +213,7 @@ services:
       MARIADB_ROOT_PASSWORD: admin
 
   frappe-configurator:
-    image: brh28/frappe-flash:0.0.4
+    image: brh28/frappe-flash:${FRAPPE_TAG:-latest}
     deploy:
       restart_policy:
         condition: none
@@ -245,7 +245,7 @@ services:
       - frappe-logs:/home/frappe/frappe-bench/logs
 
   frappe-create-site:
-    image: brh28/frappe-flash:0.0.4
+    image: brh28/frappe-flash:${FRAPPE_TAG:-latest}
     deploy:
       restart_policy:
         condition: none
@@ -299,7 +299,7 @@ services:
       - mariadb-data:/var/lib/mysql
 
   frappe-frontend:
-    image: brh28/frappe-flash:0.0.4
+    image: brh28/frappe-flash:${FRAPPE_TAG:-latest}
     ports: ["8080:8080"]
     depends_on:
       - frappe-websocket
@@ -322,7 +322,7 @@ services:
       - frappe-logs:/home/frappe/frappe-bench/logs
 
   frappe-websocket:
-    image: brh28/frappe-flash:0.0.4
+    image: brh28/frappe-flash:${FRAPPE_TAG:-latest}
     deploy:
       restart_policy:
         condition: on-failure


### PR DESCRIPTION
By default, erpnext should run with the latest version of `frappe-flash`. However, a developer can bind the docker volume to their host to make developer changes to the `frappe-flash-admin` repo

Replace hardcoded brh28/frappe-flash:0.0.4 with ${FRAPPE_TAG:-latest} so developers can pin versions via env var. Add docker-compose.local.yml for personal overrides (e.g. bind mounting local frappe-flash-admin) and wire it into COMPOSE_FILE in .env.

