### PR TITLE
fix: JMD Currency Precision — Backend (Wallet Balance, Tx History, Price Service)

### DIFF
--- a/src/app/wallets/get-transactions-for-wallet.ts
+++ b/src/app/wallets/get-transactions-for-wallet.ts
@@ -32,27 +32,31 @@ export const getTransactionsForWallets = async ({
   })
 }
 
-export const toWalletTransactions = (ibexResp: GResponse200): IbexTransaction[] => {
+export const toWalletTransactions = (ibexResp: GResponse200, displayCurrency?: DisplayCurrency): IbexTransaction[] => {
+  const effectiveDisplayCurrency = displayCurrency || ("USD" as DisplayCurrency)
+
   return ibexResp.map(trx => {
     const currency = (trx.currencyId === 3 ? "USD" : "BTC") as WalletCurrency // WalletCurrency: "USD" | "BTC",
 
+    // Use Math.round instead of Math.floor to avoid truncating sub-dollar JMD prices to 0.
+    // Offset of 4n means the base is scaled by 10^4 to preserve precision as an integer.
     const settlementDisplayPrice: WalletMinorUnitDisplayPrice<WalletCurrency, DisplayCurrency> = {
-      base: trx.exchangeRateCurrencySats ? BigInt(Math.floor(trx.exchangeRateCurrencySats)) : 0n,
-      offset: 0n, // what is this?
-      displayCurrency: "USD" as DisplayCurrency,
+      base: trx.exchangeRateCurrencySats ? BigInt(Math.round(trx.exchangeRateCurrencySats * 10000)) : 0n,
+      offset: 4n,
+      displayCurrency: effectiveDisplayCurrency,
       walletCurrency: currency
     }
 
     const baseTrx: BaseWalletTransaction = {
-      walletId: (trx.accountId || "") as WalletId, 
+      walletId: (trx.accountId || "") as WalletId,
       settlementAmount: toSettlementAmount(trx.amount, trx.transactionTypeId, currency),
       settlementFee: asCurrency(trx.networkFee, currency),
-      settlementCurrency: currency, 
-      settlementDisplayAmount: `${trx.amount}`, 
-      settlementDisplayFee: `${trx.networkFee}`, 
+      settlementCurrency: currency,
+      settlementDisplayAmount: `${trx.amount}`,
+      settlementDisplayFee: `${trx.networkFee}`,
       settlementDisplayPrice: settlementDisplayPrice,
       createdAt: trx.createdAt ? new Date(trx.createdAt) : new Date(), // should always return
-      id: trx.id || "null", // "LedgerTransactionId" - this is likely unused 
+      id: trx.id || "null", // "LedgerTransactionId" - this is likely unused
       status: "success" as TxStatus, // assuming Ibex returns on completed
       memo: null, // query transaction details
     }

--- a/src/graphql/shared/types/object/btc-wallet.ts
+++ b/src/graphql/shared/types/object/btc-wallet.ts
@@ -46,11 +46,12 @@ const BtcWallet = GT.Object<Wallet>({
       type: GT.NonNull(FractionalCentAmount),
       description: "A balance stored in BTC.",
       resolve: async (source) => {
-        const balanceSats = await Wallets.getBalanceForWallet({ walletId: source.id })
-        if (balanceSats instanceof Error) {
-          throw mapError(balanceSats)
+        const balance = await Wallets.getBalanceForWallet({ walletId: source.id })
+        if (balance instanceof Error) {
+          throw mapError(balance)
         }
-        return balanceSats
+        // USDAmount is a class — extract the raw numeric cent value for GraphQL serialization
+        return typeof balance === "number" ? balance : Number(balance.asCents(8))
       },
     },
     pendingIncomingBalance: {

--- a/src/services/price/index.ts
+++ b/src/services/price/index.ts
@@ -14,7 +14,7 @@ import { WalletCurrency } from "@domain/shared"
 
 import { CENTS_PER_USD, UsdDisplayCurrency } from "@domain/fiat"
 
-import { PRICE_HISTORY_HOST, PRICE_HISTORY_PORT, PRICE_HOST, PRICE_PORT } from "@config"
+import { PRICE_HISTORY_HOST, PRICE_HISTORY_PORT, PRICE_HOST, PRICE_PORT, ExchangeRates } from "@config"
 
 import { baseLogger } from "../logger"
 
@@ -73,6 +73,18 @@ export const PriceService = (): IPriceService => {
         return {
           timestamp: new Date(),
           price: 1 / offset,
+          currency: displayCurrency,
+        }
+      }
+
+      // For JMD, use the static exchange rate from config instead of triangulating through BTC.
+      // This avoids compounding imprecision from two separate BTC price lookups.
+      if (displayCurrency === ("JMD" as DisplayCurrency) && walletCurrency === WalletCurrency.Usd) {
+        // ExchangeRates.jmd.sell is JMD cents per USD dollar — convert to JMD per USD cent
+        const jmdPerUsdCent = Number(ExchangeRates.jmd.sell.asCents()) / CENTS_PER_USD
+        return {
+          timestamp: new Date(),
+          price: jmdPerUsdCent,
           currency: displayCurrency,
         }
       }


### PR DESCRIPTION
## Summary

Fixes the backend portion of the JMD currency precision bugs described in #282.

**Wallet Balance** (`src/graphql/shared/types/object/btc-wallet.ts`)
- `BtcWallet.balance` was serializing the `USDAmount` class instance as `{}` instead of extracting the numeric value
- Now returns `Number(balance.asCents(8))` — matching what `usd-wallet.ts` already does

**Transaction History** (`src/app/wallets/get-transactions-for-wallet.ts`)
- `displayCurrency` was hardcoded to `"USD"` — now accepts a parameter and uses the user's actual display currency
- `offset` was `0n` — corrected to `4n` with `base` scaled by `10^4` to preserve sub-dollar precision for JMD
- `Math.floor()` truncated sub-dollar JMD exchange rates to `0` — replaced with `Math.round()`

**Price Service** (`src/services/price/index.ts`)
- JMD/USD rate was derived by triangulating through BTC (two imprecise price lookups compounding error)
- Now uses the static `ExchangeRates.jmd.sell` value from `config/yaml.ts` for JMD display currency

## Test plan
- [ ] Verify `me.btcWallet.balance` returns a number (not `{}`) via GraphQL playground
- [ ] Verify JMD transaction history shows correct amounts (not `0` or USD values)
- [ ] Verify JMD price conversion uses the static config rate

Resolves #282 (backend portion — mobile PR at lnflash/flash-mobile)