### PR TITLE
fix: JMD currency precision — balance serialization and transaction history

### DIFF
--- a/src/app/wallets/get-transactions-for-wallet.ts
+++ b/src/app/wallets/get-transactions-for-wallet.ts
@@ -4,13 +4,18 @@ import { IbexError } from "@services/ibex/errors"
 import { baseLogger } from "@services/logger"
 import { GResponse200 } from "ibex-client"
 import { ConnectionArguments, ConnectionCursor } from "graphql-relay"
+import { ExchangeRates } from "@config"
+import { SATS_PER_BTC } from "@domain/bitcoin"
+import { CENTS_PER_USD } from "@domain/fiat"
 
 export const getTransactionsForWallets = async ({
   wallets,
   paginationArgs,
+  displayCurrency,
 }: {
   wallets: Wallet[]
   paginationArgs?: PaginationArgs
+  displayCurrency?: DisplayCurrency
 }): Promise<PartialResult<PaginatedArray<IbexTransaction>>> => {
   const walletIds = wallets.map((wallet) => wallet.id)
   
@@ -21,9 +26,11 @@ export const getTransactionsForWallets = async ({
     }))
   )
 
+  const resolvedDisplayCurrency = displayCurrency || ("USD" as DisplayCurrency)
+
   const transactions = ibexCalls.flatMap(resp => {
     if (resp instanceof IbexError) return [] 
-    else return toWalletTransactions(resp)
+    else return toWalletTransactions(resp, resolvedDisplayCurrency)
   })
 
   return PartialResult.ok({
@@ -32,14 +39,24 @@ export const getTransactionsForWallets = async ({
   })
 }
 
-export const toWalletTransactions = (ibexResp: GResponse200): IbexTransaction[] => {
+export const toWalletTransactions = (ibexResp: GResponse200, displayCurrency: DisplayCurrency = "USD" as DisplayCurrency): IbexTransaction[] => {
   return ibexResp.map(trx => {
     const currency = (trx.currencyId === 3 ? "USD" : "BTC") as WalletCurrency // WalletCurrency: "USD" | "BTC",
 
+    // Use ExchangeRates.jmd.sell for JMD display currency instead of BTC triangulation
+    let exchangeRateBase = trx.exchangeRateCurrencySats ? BigInt(Math.round(trx.exchangeRateCurrencySats)) : 0n
+    if (displayCurrency === ("JMD" as DisplayCurrency) && ExchangeRates?.jmd?.sell) {
+      const jmdRate = Number(ExchangeRates.jmd.sell)
+      if (jmdRate > 0) {
+        // Convert using static JMD/USD rate instead of BTC triangulation
+        exchangeRateBase = BigInt(Math.round(jmdRate * CENTS_PER_USD))
+      }
+    }
+
     const settlementDisplayPrice: WalletMinorUnitDisplayPrice<WalletCurrency, DisplayCurrency> = {
-      base: trx.exchangeRateCurrencySats ? BigInt(Math.floor(trx.exchangeRateCurrencySats)) : 0n,
-      offset: 0n, // what is this?
-      displayCurrency: "USD" as DisplayCurrency,
+      base: exchangeRateBase,
+      offset: BigInt(SATS_PER_BTC), // proper offset: satoshi precision (8 decimal places)
+      displayCurrency: displayCurrency,
       walletCurrency: currency
     }
 

--- a/src/graphql/shared/types/object/btc-wallet.ts
+++ b/src/graphql/shared/types/object/btc-wallet.ts
@@ -50,7 +50,7 @@ const BtcWallet = GT.Object<Wallet>({
         if (balanceSats instanceof Error) {
           throw mapError(balanceSats)
         }
-        return balanceSats
+        return Number(balanceSats.asCents(8))
       },
     },
     pendingIncomingBalance: {


### PR DESCRIPTION
## Summary

Fixes #282 — JMD Currency Precision Full-Stack Fix (backend layer)

This PR addresses the backend-side bugs causing incorrect JMD display amounts across wallet balance and transaction history.

### Changes

**1. BTC Wallet Balance Serialization** (`src/graphql/shared/types/object/btc-wallet.ts`)
- **Bug:** `getBalanceForWallet()` returns a `USDAmount` class instance, but the BTC wallet resolver returned it directly — serializing as `{}` instead of a number.
- **Fix:** Apply `Number(balanceSats.asCents(8))` to match the USD wallet pattern (see `usd-wallet.ts:55`).

**2. Transaction History Adaptor** (`src/app/wallets/get-transactions-for-wallet.ts`)

Four compounding bugs fixed:

- **Hardcoded display currency:** Was always `"USD"`, now accepts a `displayCurrency` parameter (backward-compatible, defaults to USD).
- **Wrong exponent offset:** Was `0n`, now `BigInt(SATS_PER_BTC)` (1e8) for proper decimal precision.
- **Precision loss:** `BigInt(Math.floor(...))` replaced with `BigInt(Math.round(...))` to avoid truncating sub-unit values.
- **JMD rate derivation:** Was using BTC triangulation (imprecise), now uses static `ExchangeRates.jmd.sell` from config for JMD display currency.

### What's NOT in this PR (mobile layer)

Per the bounty scope, the mobile fixes in `lnflash/flash-mobile` (TxItem component, useBreezPayments hook, use-price-conversion.ts) are separate and should be addressed in a companion PR against that repo.

### Testing Notes

The changes are structurally minimal — the `displayCurrency` parameter is optional with a backward-compatible default, so all existing call sites continue to work. The `ExchangeRates` import is already exported from `@config`.
