### PR TITLE
fix: JMD currency precision and BTC wallet balance serialization (#282)

### DIFF
--- a/src/app/wallets/get-transactions-for-wallet.ts
+++ b/src/app/wallets/get-transactions-for-wallet.ts
@@ -4,6 +4,7 @@ import { IbexError } from "@services/ibex/errors"
 import { baseLogger } from "@services/logger"
 import { GResponse200 } from "ibex-client"
 import { ConnectionArguments, ConnectionCursor } from "graphql-relay"
+import { SAT_PRICE_PRECISION_OFFSET } from "@domain/fiat"
 
 export const getTransactionsForWallets = async ({
   wallets,
@@ -36,9 +37,10 @@ export const toWalletTransactions = (ibexResp: GResponse200): IbexTransaction[] 
   return ibexResp.map(trx => {
     const currency = (trx.currencyId === 3 ? "USD" : "BTC") as WalletCurrency // WalletCurrency: "USD" | "BTC",
 
+    const exchangeRate = trx.exchangeRateCurrencySats ?? 0
     const settlementDisplayPrice: WalletMinorUnitDisplayPrice<WalletCurrency, DisplayCurrency> = {
-      base: trx.exchangeRateCurrencySats ? BigInt(Math.floor(trx.exchangeRateCurrencySats)) : 0n,
-      offset: 0n, // what is this?
+      base: BigInt(Math.round(exchangeRate * 10 ** SAT_PRICE_PRECISION_OFFSET)),
+      offset: BigInt(SAT_PRICE_PRECISION_OFFSET),
       displayCurrency: "USD" as DisplayCurrency,
       walletCurrency: currency
     }

--- a/src/graphql/shared/types/object/btc-wallet.ts
+++ b/src/graphql/shared/types/object/btc-wallet.ts
@@ -50,7 +50,7 @@ const BtcWallet = GT.Object<Wallet>({
         if (balanceSats instanceof Error) {
           throw mapError(balanceSats)
         }
-        return balanceSats
+        return Number(balanceSats.asCents(8))
       },
     },
     pendingIncomingBalance: {

--- a/src/services/price/index.ts
+++ b/src/services/price/index.ts
@@ -14,7 +14,7 @@ import { WalletCurrency } from "@domain/shared"
 
 import { CENTS_PER_USD, UsdDisplayCurrency } from "@domain/fiat"
 
-import { PRICE_HISTORY_HOST, PRICE_HISTORY_PORT, PRICE_HOST, PRICE_PORT } from "@config"
+import { PRICE_HISTORY_HOST, PRICE_HISTORY_PORT, PRICE_HOST, PRICE_PORT, ExchangeRates } from "@config"
 
 import { baseLogger } from "../logger"
 
@@ -80,6 +80,19 @@ export const PriceService = (): IPriceService => {
       // FIXME: price server should return CentsPerSat directly and timestamp
       const { price } = await getPrice({ currency: displayCurrency })
       if (!price) return new PriceNotAvailableError()
+
+      // For JMD, use the static exchange rate from config instead of BTC triangulation
+      // to avoid compounding rounding errors from two gRPC price calls
+      if (displayCurrency === "JMD" as DisplayCurrency && walletCurrency === WalletCurrency.Usd) {
+        const jmdPerUsd = Number(ExchangeRates.jmd.sell.asCents(2))
+        const displayCurrencyPrice = jmdPerUsd / CENTS_PER_USD
+
+        return {
+          timestamp: new Date(),
+          price: displayCurrencyPrice,
+          currency: displayCurrency,
+        }
+      }
 
       let displayCurrencyPrice = price / SATS_PER_BTC
       if (walletCurrency === WalletCurrency.Usd) {


### PR DESCRIPTION
## Summary

Partial fix for [#282](https://github.com/lnflash/flash/issues/282) — addresses three backend bugs contributing to incorrect JMD display amounts.

### Changes

#### 1. BTC Wallet Balance Serialization ()
- **Bug:** `getBalanceForWallet` returns a `USDAmount` class instance, which has private fields. When serialized by GraphQL, it produces `{}` instead of the numeric balance.
- **Fix:** Return `Number(balanceSats.asCents(8))`, matching the pattern already used in `UsdWallet.balance`.

#### 2. Transaction History Price Precision (`get-transactions-for-wallet.ts`)
- **Bug:** `settlementDisplayPrice` used `BigInt(Math.floor(exchangeRate))` with `offset: 0n`, which truncates sub-dollar JMD exchange rates to 0 (e.g., 0.15726 → 0).
- **Fix:** Use `SAT_PRICE_PRECISION_OFFSET` (12) as the offset, and preserve decimal precision via `BigInt(Math.round(rate * 10^12))`.

#### 3. Price Service JMD Rate (`price/index.ts`)
- **Bug:** JMD/USD rate was derived by triangulating through BTC (two gRPC calls), compounding floating point rounding errors.
- **Fix:** Use `ExchangeRates.jmd.sell` from config directly for JMD, avoiding the intermediate BTC conversion.

### Remaining Work (not in this PR)
- Mobile-side fixes (`TxItem.tsx`, `use-price-conversion.ts`, `useBreezPayments.ts`)
- Passing `displayCurrency` through to the transaction adaptor (requires function signature changes)
- Full JMD conversion in transaction history display amounts