### PR TITLE
fix: btc-wallet balance returns numeric satoshi count (JMD bounty #282)

### DIFF
--- a/src/graphql/shared/types/object/btc-wallet.ts
+++ b/src/graphql/shared/types/object/btc-wallet.ts
@@ -50,7 +50,7 @@ const BtcWallet = GT.Object<Wallet>({
         if (balanceSats instanceof Error) {
           throw mapError(balanceSats)
         }
-        return balanceSats
+        return Number(balanceSats.asCents(8))
       },
     },
     pendingIncomingBalance: {


### PR DESCRIPTION
## Fix: BTC Wallet Balance Serialization

### Problem
The tcWallet.balance GraphQL resolver was returning a serialized WalletBalance class instance instead of its numeric value, causing queries like me.btcWallet.balance to return {} instead of the actual satoshi count.

### Fix
Return Number(balanceSats.asCents(8)) — the raw satoshi count as a number.

File: src/graphql/shared/types/object/btc-wallet.ts (line ~49)

### Context
Part of [[Bounty] JMD Currency Precision — Full-Stack Fix #282](https://github.com/lnflash/flash/issues/282)

This is one of three affected surfaces identified in the bounty:
1. ✅ Wallet balance (this fix)
2. ⬜ Send/receive flows (JMD→USD float truncation)
3. ⬜ Transaction history (price service triangulation + display currency)

### Testing
- me.btcWallet.balance should return a number (e.g., 500000) not {}
- Verify balance matches Wallets.getBalanceForWallet() output