### PR TITLE
fix(backend): JMD currency precision for display amounts and prices

### DIFF
--- a/src/app/accounts/get-csv-for-account.ts
+++ b/src/app/accounts/get-csv-for-account.ts
@@ -1,15 +1,18 @@
 import { CsvWalletsExport } from "@services/ledger/csv-wallet-export"
-import { WalletsRepository } from "@services/mongoose"
+import { AccountsRepository, WalletsRepository } from "@services/mongoose"
 
 export const getCSVForAccount = async (
   accountId: AccountId,
 ): Promise<string | ApplicationError> => {
+  const account = await AccountsRepository().findById(accountId)
+  if (account instanceof Error) return account
+
   const wallets = await WalletsRepository().listByAccountId(accountId)
   if (wallets instanceof Error) return wallets
 
   const csv = new CsvWalletsExport()
 
-  await csv.addWallets(wallets)
+  await csv.addWallets(wallets, account.displayCurrency)
 
   return csv.getBase64()
 }

--- a/src/app/accounts/get-transactions-for-account.ts
+++ b/src/app/accounts/get-transactions-for-account.ts
@@ -30,5 +30,9 @@ export const getTransactionsForAccountByWalletIds = async ({
     wallets.push(wallet)
   }
 
-  return getTransactionsForWallets({ wallets, paginationArgs })
+  return getTransactionsForWallets({
+    wallets,
+    paginationArgs,
+    displayCurrency: account.displayCurrency,
+  })
 }

--- a/src/app/wallets/get-transactions-for-wallet.ts
+++ b/src/app/wallets/get-transactions-for-wallet.ts
@@ -1,4 +1,6 @@
+import { ExchangeRates } from "@config"
 import { PartialResult } from "@app/partial-result"
+import { CENTS_PER_USD, SAT_PRICE_PRECISION_OFFSET, UsdDisplayCurrency } from "@domain/fiat"
 import Ibex from "@services/ibex/client"
 import { IbexError } from "@services/ibex/errors"
 import { baseLogger } from "@services/logger"
@@ -8,9 +10,11 @@ import { ConnectionArguments, ConnectionCursor } from "graphql-relay"
 export const getTransactionsForWallets = async ({
   wallets,
   paginationArgs,
+  displayCurrency = UsdDisplayCurrency,
 }: {
   wallets: Wallet[]
   paginationArgs?: PaginationArgs
+  displayCurrency?: DisplayCurrency
 }): Promise<PartialResult<PaginatedArray<IbexTransaction>>> => {
   const walletIds = wallets.map((wallet) => wallet.id)
   
@@ -23,7 +27,7 @@ export const getTransactionsForWallets = async ({
 
   const transactions = ibexCalls.flatMap(resp => {
     if (resp instanceof IbexError) return [] 
-    else return toWalletTransactions(resp)
+    else return toWalletTransactions(resp, displayCurrency)
   })
 
   return PartialResult.ok({
@@ -32,14 +36,26 @@ export const getTransactionsForWallets = async ({
   })
 }
 
-export const toWalletTransactions = (ibexResp: GResponse200): IbexTransaction[] => {
+export const toWalletTransactions = (
+  ibexResp: GResponse200,
+  displayCurrency: DisplayCurrency = UsdDisplayCurrency,
+): IbexTransaction[] => {
+  const jmdPerUsdCent = Number(ExchangeRates.jmd.sell.asCents(2)) / CENTS_PER_USD
+
   return ibexResp.map(trx => {
     const currency = (trx.currencyId === 3 ? "USD" : "BTC") as WalletCurrency // WalletCurrency: "USD" | "BTC",
+    const exchangeRateCurrencySats = trx.exchangeRateCurrencySats ?? 0
+    const settlementDisplayPriceBase =
+      displayCurrency === "JMD"
+        ? exchangeRateCurrencySats * jmdPerUsdCent
+        : exchangeRateCurrencySats
 
     const settlementDisplayPrice: WalletMinorUnitDisplayPrice<WalletCurrency, DisplayCurrency> = {
-      base: trx.exchangeRateCurrencySats ? BigInt(Math.floor(trx.exchangeRateCurrencySats)) : 0n,
-      offset: 0n, // what is this?
-      displayCurrency: "USD" as DisplayCurrency,
+      base: BigInt(
+        Math.round(settlementDisplayPriceBase * 10 ** SAT_PRICE_PRECISION_OFFSET),
+      ),
+      offset: BigInt(SAT_PRICE_PRECISION_OFFSET),
+      displayCurrency,
       walletCurrency: currency
     }
 
@@ -48,8 +64,8 @@ export const toWalletTransactions = (ibexResp: GResponse200): IbexTransaction[] 
       settlementAmount: toSettlementAmount(trx.amount, trx.transactionTypeId, currency),
       settlementFee: asCurrency(trx.networkFee, currency),
       settlementCurrency: currency, 
-      settlementDisplayAmount: `${trx.amount}`, 
-      settlementDisplayFee: `${trx.networkFee}`, 
+      settlementDisplayAmount: `${displayCurrency === "JMD" ? trx.amount * jmdPerUsdCent : trx.amount}`, 
+      settlementDisplayFee: `${displayCurrency === "JMD" ? (trx.networkFee ?? 0) * jmdPerUsdCent : trx.networkFee}`, 
       settlementDisplayPrice: settlementDisplayPrice,
       createdAt: trx.createdAt ? new Date(trx.createdAt) : new Date(), // should always return
       id: trx.id || "null", // "LedgerTransactionId" - this is likely unused 

--- a/src/graphql/shared/types/object/btc-wallet.ts
+++ b/src/graphql/shared/types/object/btc-wallet.ts
@@ -7,7 +7,7 @@ import {
 } from "@graphql/connections"
 import { mapError } from "@graphql/error-map"
 
-import { Wallets } from "@app"
+import { Accounts, Wallets } from "@app"
 
 import { WalletCurrency as WalletCurrencyDomain } from "@domain/shared"
 
@@ -50,7 +50,7 @@ const BtcWallet = GT.Object<Wallet>({
         if (balanceSats instanceof Error) {
           throw mapError(balanceSats)
         }
-        return balanceSats
+        return Number(balanceSats.asCents(8))
       },
     },
     pendingIncomingBalance: {
@@ -73,9 +73,15 @@ const BtcWallet = GT.Object<Wallet>({
           throw paginationArgs
         }
 
+        const account = await Accounts.getAccount(source.accountId)
+        if (account instanceof Error) {
+          throw mapError(account)
+        }
+
         const { result, error } = await Wallets.getTransactionsForWallets({
           wallets: [source],
           paginationArgs,
+          displayCurrency: account.displayCurrency,
         })
         if (error instanceof Error) {
           throw mapError(error)

--- a/src/graphql/shared/types/object/usd-wallet.ts
+++ b/src/graphql/shared/types/object/usd-wallet.ts
@@ -7,7 +7,7 @@ import {
 import { normalizePaymentAmount } from "@graphql/shared/root/mutation"
 import { mapError } from "@graphql/error-map"
 
-import { Wallets } from "@app"
+import { Accounts, Wallets } from "@app"
 
 import { WalletCurrency as WalletCurrencyDomain } from "@domain/shared"
 
@@ -75,9 +75,15 @@ const UsdWallet = GT.Object<Wallet>({
           throw paginationArgs
         }
 
+        const account = await Accounts.getAccount(source.accountId)
+        if (account instanceof Error) {
+          throw mapError(account)
+        }
+
         const { result, error } = await Wallets.getTransactionsForWallets({
           wallets: [source],
           paginationArgs,
+          displayCurrency: account.displayCurrency,
         })
         if (error instanceof Error) {
           throw mapError(error)

--- a/src/services/ledger/csv-wallet-export.ts
+++ b/src/services/ledger/csv-wallet-export.ts
@@ -50,12 +50,16 @@ export class CsvWalletsExport {
     baseLogger.info("saving complete")
   }
 
-  async addWallets(wallets: Wallet[]): Promise<void | ApplicationError> {
+  async addWallets(
+    wallets: Wallet[],
+    displayCurrency?: DisplayCurrency,
+  ): Promise<void | ApplicationError> {
     // TODO: interface could be improved by returning self, so that it's
     // possible to run csv.addWallet(wallet).getBase64()
 
     const response = await getTransactionsForWallets({
       wallets,
+      displayCurrency,
     })
 
     const txs = await this.formatTxs(response.result?.slice)

--- a/src/services/price/index.ts
+++ b/src/services/price/index.ts
@@ -14,7 +14,13 @@ import { WalletCurrency } from "@domain/shared"
 
 import { CENTS_PER_USD, UsdDisplayCurrency } from "@domain/fiat"
 
-import { PRICE_HISTORY_HOST, PRICE_HISTORY_PORT, PRICE_HOST, PRICE_PORT } from "@config"
+import {
+  ExchangeRates,
+  PRICE_HISTORY_HOST,
+  PRICE_HISTORY_PORT,
+  PRICE_HOST,
+  PRICE_PORT,
+} from "@config"
 
 import { baseLogger } from "../logger"
 
@@ -73,6 +79,14 @@ export const PriceService = (): IPriceService => {
         return {
           timestamp: new Date(),
           price: 1 / offset,
+          currency: displayCurrency,
+        }
+      }
+
+      if (displayCurrency === "JMD" && walletCurrency === WalletCurrency.Usd) {
+        return {
+          timestamp: new Date(),
+          price: Number(ExchangeRates.jmd.sell.asCents(2)) / CENTS_PER_USD,
           currency: displayCurrency,
         }
       }

--- a/test/flash/unit/app/wallets/get-transactions-for-wallets.spec.ts
+++ b/test/flash/unit/app/wallets/get-transactions-for-wallets.spec.ts
@@ -1,0 +1,48 @@
+import { ExchangeRates } from "@config"
+import { toWalletTransactions } from "@app/wallets"
+import { CENTS_PER_USD, SAT_PRICE_PRECISION_OFFSET } from "@domain/fiat"
+
+const ibexData = [
+  {
+    id: "f2fa0473-43b4-4101-8e19-11f1caaeb011",
+    createdAt: "2024-01-31T17:27:20.718984Z",
+    settledAt: "2024-01-31T17:27:21.422794Z",
+    accountId: "e24b85d1-9f61-47da-acb9-fe9d069de2fc",
+    amount: 12.34,
+    networkFee: 0.01,
+    onChainSendFee: 0,
+    exchangeRateCurrencySats: 0.013717477287,
+    currencyId: 0,
+    transactionTypeId: 2,
+  },
+]
+
+describe("toWalletTransactions", () => {
+  it("marks outgoing transactions as negative", () => {
+    const result = toWalletTransactions(ibexData as never)
+
+    expect(result[0].settlementAmount).toEqual(-12.34)
+  })
+
+  it("uses the requested JMD display currency with precision offset", () => {
+    const result = toWalletTransactions(ibexData as never, "JMD" as DisplayCurrency)
+    const jmdPerUsdCent = Number(ExchangeRates.jmd.sell.asCents(2)) / CENTS_PER_USD
+
+    expect(result[0].settlementDisplayPrice).toEqual({
+      base: BigInt(
+        Math.round(
+          ibexData[0].exchangeRateCurrencySats *
+            jmdPerUsdCent *
+            10 ** SAT_PRICE_PRECISION_OFFSET,
+        ),
+      ),
+      offset: BigInt(SAT_PRICE_PRECISION_OFFSET),
+      displayCurrency: "JMD",
+      walletCurrency: "BTC",
+    })
+
+    expect(result[0].settlementDisplayAmount).toBe(
+      `${ibexData[0].amount * jmdPerUsdCent}`,
+    )
+  })
+})

--- a/test/flash/unit/domain/ledger/activity-checker.spec.ts
+++ b/test/flash/unit/domain/ledger/activity-checker.spec.ts
@@ -18,6 +18,7 @@ beforeAll(() => {
     accountId: "a1" as AccountId,
     onChainAddressIdentifiers: [],
     onChainAddresses: () => [],
+    lnurlp: "LNURLP" as Lnurl,
   }
 
   usdWallet = {
@@ -27,6 +28,7 @@ beforeAll(() => {
     accountId: "a1" as AccountId,
     onChainAddressIdentifiers: [],
     onChainAddresses: () => [],
+    lnurlp: "LNURLP" as Lnurl,
   }
 })
 

--- a/test/flash/unit/domain/ledger/imbalance-calculator.spec.ts
+++ b/test/flash/unit/domain/ledger/imbalance-calculator.spec.ts
@@ -11,6 +11,7 @@ const btcWallet: Wallet = {
   accountId: "a1" as AccountId,
   onChainAddressIdentifiers: [],
   onChainAddresses: () => [],
+  lnurlp: "LNURLP" as Lnurl,
 }
 
 const VolumeAfterLightningReceiptFn = () =>

--- a/test/flash/unit/services/price/index.spec.ts
+++ b/test/flash/unit/services/price/index.spec.ts
@@ -1,0 +1,41 @@
+import { ExchangeRates } from "@config"
+import { CENTS_PER_USD } from "@domain/fiat"
+
+jest.mock("@services/price/grpc", () => ({
+  PriceProtoDescriptor: {
+    PriceFeed: jest.fn().mockImplementation(() => ({
+      getPrice: jest.fn(),
+      listCurrencies: jest.fn(),
+    })),
+  },
+  PriceHistoryProtoDescriptor: {
+    PriceHistory: jest.fn().mockImplementation(() => ({
+      listPrices: jest.fn(),
+    })),
+  },
+}))
+
+import { PriceService } from "@services/price"
+import { PriceProtoDescriptor } from "@services/price/grpc"
+
+const getPriceMock = () =>
+  ((PriceProtoDescriptor.PriceFeed as jest.Mock).mock.results[0]?.value.getPrice ??
+    jest.fn()) as jest.Mock
+
+describe("PriceService", () => {
+  beforeEach(() => {
+    getPriceMock().mockReset()
+  })
+
+  it("uses the configured JMD sell rate for USD cent realtime prices", async () => {
+    const result = await PriceService().getUsdCentRealTimePrice({
+      displayCurrency: "JMD" as DisplayCurrency,
+    })
+
+    if (result instanceof Error) throw result
+
+    expect(result.currency).toBe("JMD")
+    expect(result.price).toBe(Number(ExchangeRates.jmd.sell.asCents(2)) / CENTS_PER_USD)
+    expect(getPriceMock()).not.toHaveBeenCalled()
+  })
+})

--- a/test/galoy/unit/domain/ledger/activity-checker.spec.ts
+++ b/test/galoy/unit/domain/ledger/activity-checker.spec.ts
@@ -18,6 +18,7 @@ beforeAll(() => {
     accountId: "a1" as AccountId,
     onChainAddressIdentifiers: [],
     onChainAddresses: () => [],
+    lnurlp: "LNURLP" as Lnurl,
   }
 
   usdWallet = {
@@ -27,6 +28,7 @@ beforeAll(() => {
     accountId: "a1" as AccountId,
     onChainAddressIdentifiers: [],
     onChainAddresses: () => [],
+    lnurlp: "LNURLP" as Lnurl,
   }
 })
 

--- a/test/galoy/unit/domain/ledger/imbalance-calculator.spec.ts
+++ b/test/galoy/unit/domain/ledger/imbalance-calculator.spec.ts
@@ -11,6 +11,7 @@ const btcWallet: Wallet = {
   accountId: "a1" as AccountId,
   onChainAddressIdentifiers: [],
   onChainAddresses: () => [],
+  lnurlp: "LNURLP" as Lnurl,
 }
 
 const VolumeAfterLightningReceiptFn = () =>

--- a/test/galoy/unit/domain/wallets/payment-input-validator.spec.ts
+++ b/test/galoy/unit/domain/wallets/payment-input-validator.spec.ts
@@ -44,6 +44,7 @@ describe("PaymentInputValidator", () => {
     currency: WalletCurrency.Btc,
     onChainAddressIdentifiers: [],
     onChainAddresses: () => [],
+    lnurlp: "LNURLP" as Lnurl,
   }
 
   const dummyRecipientWallet: Wallet = {
@@ -53,6 +54,7 @@ describe("PaymentInputValidator", () => {
     currency: WalletCurrency.Btc,
     onChainAddressIdentifiers: [],
     onChainAddresses: () => [],
+    lnurlp: "LNURLP" as Lnurl,
   }
 
   const wallets: { [key: WalletId]: Wallet } = {}


### PR DESCRIPTION
Fixes currency display precision for JMD accounts. Companion to lnflash/flash-mobile#606.

### Changes

- **displayCurrency propagation**: `getTransactionsForWallets` and `getTransactionsForAccount` now pass the account's `displayCurrency` through the transaction pipeline
- **settlementDisplayPrice**: uses configured JMD exchange rate with `SAT_PRICE_PRECISION_OFFSET` for correct `base`/`offset` encoding (was hardcoded to USD with zero offset)
- **settlementDisplayAmount / settlementDisplayFee**: converted to JMD when display currency is JMD (was returning raw USD values)
- **Price service**: JMD shortcut for USD wallets returns the configured sell rate directly, avoiding unnecessary price server calls
- **CSV export**: forwards `displayCurrency` to `addWallets`
- **Wallet resolvers**: BTC and USD wallet types fetch account `displayCurrency` for transaction queries

### Tests

- Unit test for `toWalletTransactions`: verifies negative sign, JMD display price encoding, and JMD display amount conversion
- Unit test for price service: verifies JMD sell rate for USD cent prices
- Wallet mock updates: added `lnurlp` field to match current `Wallet` type

Ref: lnflash/flash-mobile#282