### PR TITLE
fix(config): remove hardcoded IBEX webhook secret (ENG-246)

### DIFF
--- a/dev/config/base-config.yaml
+++ b/dev/config/base-config.yaml
@@ -10,7 +10,7 @@ ibex:
   webhook:
     uri: "" # external uri defined in overrides
     port: 4008
-    secret: "not-so-secret"
+    secret: "" # injected at deploy time via Terraform
 
 # See Foreign Exchange Rates: https://www.firstglobal-bank.com/
 exchangeRates:


### PR DESCRIPTION
## Summary

Fixes **ENG-246** — removes the hardcoded `"not-so-secret"` IBEX webhook secret from the public config.

## Change

### `dev/config/base-config.yaml`
```yaml
# Before
ibex:
  webhook:
    secret: "not-so-secret"

# After
ibex:
  webhook:
    secret: "" # injected at deploy time via Terraform
```

## Why

This value was publicly readable in the repo. Any reader could forge IBEX webhook events — fake payment confirmations, fake cashouts — by using this secret. The real secret is now generated randomly per environment via Terraform and injected at deploy time.

## Companion PR

Infrastructure change (Terraform + Helm template): https://github.com/lnflash/deployments/pull/44

**These two PRs should be merged together.** Merge the deployments PR first (or simultaneously), so the secret is injected before the next deploy picks up this config change.

## Related
- Linear: https://linear.app/island-bitcoin/issue/ENG-246