### PR TITLE
Revert "fix(config): remove hardcoded IBEX webhook secret (ENG-246)"

### DIFF
--- a/dev/config/base-config.yaml
+++ b/dev/config/base-config.yaml
@@ -10,7 +10,7 @@ ibex:
   webhook:
     uri: "" # external uri defined in overrides
     port: 4008
-    secret: "" # injected at deploy time via Terraform
+    secret: "not-so-secret"
 
 # See Foreign Exchange Rates: https://www.firstglobal-bank.com/
 exchangeRates:


### PR DESCRIPTION
dev is not set by terraform. this should not have been merged