### PR TITLE
feat: add closestMerchants query to find top 3 nearest merchants by GPS

### DIFF
--- a/src/app/merchants/index.ts
+++ b/src/app/merchants/index.ts
@@ -36,3 +36,13 @@ export const getMerchantsByUsername = async (
 
   return result
 }
+
+export const getClosestMerchants = async ({
+  latitude,
+  longitude,
+}: {
+  latitude: number
+  longitude: number
+}): Promise<BusinessMapMarker[] | RepositoryError> => {
+  return merchants.findClosest({ latitude, longitude, limit: 3 })
+}

--- a/src/graphql/public/queries.ts
+++ b/src/graphql/public/queries.ts
@@ -13,6 +13,7 @@ import OnChainUsdTxFeeQuery from "@graphql/public/root/query/on-chain-usd-tx-fee
 import OnChainUsdTxFeeAsBtcDenominatedQuery from "@graphql/public/root/query/on-chain-usd-tx-fee-query-as-sats"
 import UsernameAvailableQuery from "@graphql/public/root/query/username-available"
 import BusinessMapMarkersQuery from "@graphql/public/root/query/business-map-markers"
+import ClosestMerchantsQuery from "@graphql/public/root/query/closest-merchants"
 import AccountDefaultWalletQuery from "@graphql/public/root/query/account-default-wallet"
 import AccountDefaultWalletIdQuery from "@graphql/public/root/query/account-default-wallet-id"
 import LnInvoicePaymentStatusQuery from "@graphql/public/root/query/ln-invoice-payment-status"
@@ -26,9 +27,10 @@ export const queryFields = {
   unauthed: {
     globals: GlobalsQuery,
     usernameAvailable: UsernameAvailableQuery,
-    userDefaultWalletId: AccountDefaultWalletIdQuery, // FIXME: migrate to AccountDefaultWalletId
+    userDefaultWalletId: AccountDefaultWalletIdQuery,
     accountDefaultWallet: AccountDefaultWalletQuery,
     businessMapMarkers: BusinessMapMarkersQuery,
+    closestMerchants: ClosestMerchantsQuery,
     currencyList: CurrencyListQuery,
     mobileVersions: MobileVersionsQuery,
     quizQuestions: QuizQuestionsQuery,

--- a/src/graphql/public/root/query/closest-merchants.ts
+++ b/src/graphql/public/root/query/closest-merchants.ts
@@ -1,0 +1,44 @@
+import { GT } from "@graphql/index"
+
+import MapMarker from "@graphql/public/types/object/map-marker"
+import { mapError } from "@graphql/error-map"
+import { Merchants } from "@app"
+
+const ClosestMerchantsQuery = GT.Field({
+  type: GT.NonNullList(MapMarker),
+  args: {
+    latitude: { type: GT.NonNull(GT.Float) },
+    longitude: { type: GT.NonNull(GT.Float) },
+  },
+  resolve: async (
+    _,
+    args,
+  ): Promise<BusinessMapMarkerLegacy[] | { errors: IError[] }> => {
+    const { latitude, longitude } = args
+
+    if (latitude instanceof Error) throw latitude
+    if (longitude instanceof Error) throw longitude
+
+    const merchants = await Merchants.getClosestMerchants({
+      latitude,
+      longitude,
+    })
+
+    if (merchants instanceof Error) {
+      throw mapError(merchants)
+    }
+
+    return merchants.map((merchant) => ({
+      username: merchant.username,
+      mapInfo: {
+        title: merchant.title,
+        coordinates: {
+          latitude: merchant.coordinates.latitude,
+          longitude: merchant.coordinates.longitude,
+        },
+      },
+    }))
+  },
+})
+
+export default ClosestMerchantsQuery

--- a/src/graphql/public/schema.graphql
+++ b/src/graphql/public/schema.graphql
@@ -1208,6 +1208,7 @@ type Query {
   btcPrice(currency: DisplayCurrency! = "USD"): Price @deprecated(reason: "Deprecated in favor of realtimePrice")
   btcPriceList(range: PriceGraphRange!): [PricePoint]
   businessMapMarkers: [MapMarker!]!
+  closestMerchants(latitude: Float!, longitude: Float!): [MapMarker!]!
   currencyList: [Currency!]!
   globals: Globals
   isFlashNpub(input: IsFlashNpubInput!): IsFlashNpubPayload

--- a/src/services/mongoose/merchants.ts
+++ b/src/services/mongoose/merchants.ts
@@ -1,173 +1,199 @@
-import {
-  CouldNotFindMerchantFromIdError,
-  CouldNotFindMerchantFromUsernameError,
-} from "@domain/errors"
-
-import { Merchant } from "./schema"
-import { caseInsensitiveRegex, parseRepositoryError } from "./utils"
-
-interface IMerchantRepository {
-  listForMap(): Promise<BusinessMapMarker[] | RepositoryError>
-  listPendingApproval(): Promise<BusinessMapMarker[] | RepositoryError>
-  findById(id: MerchantId): Promise<BusinessMapMarker | RepositoryError>
-  findByUsername(username: Username): Promise<BusinessMapMarker[] | RepositoryError>
-  create(args: {
-    username: Username
-    coordinates: Coordinates
-    title: BusinessMapTitle
-    validated: boolean
-  }): Promise<BusinessMapMarker | RepositoryError>
-  update(args: {
-    id: MerchantId
-    coordinates: Coordinates
-    title: BusinessMapTitle
-    username: Username
-    validated: boolean
-  }): Promise<BusinessMapMarker | RepositoryError>
-  findOneAndUpdate(args: {
-    id: MerchantId
-    updates: Partial<{
-      coordinates: Coordinates
-      title: BusinessMapTitle
-      username: Username
-      validated: boolean
-    }>
-  }): Promise<BusinessMapMarker | RepositoryError>
-  remove(id: MerchantId): Promise<void | RepositoryError>
-}
-
-export const MerchantsRepository = (): IMerchantRepository => {
-  const findById = async (
-    id: MerchantId,
-  ): Promise<BusinessMapMarker | RepositoryError> => {
+1|import {
+     2|  CouldNotFindMerchantFromIdError,
+     3|  CouldNotFindMerchantFromUsernameError,
+     4|} from "@domain/errors"
+     5|
+     6|import { Merchant } from "./schema"
+     7|import { caseInsensitiveRegex, parseRepositoryError } from "./utils"
+     8|
+     9|interface IMerchantRepository {
+    10|  listForMap(): Promise<BusinessMapMarker[] | RepositoryError>
+  findClosest(args: {
+    latitude: number
+    longitude: number
+    limit: number
+  }): Promise<BusinessMapMarker[] | RepositoryError>
+    11|  listPendingApproval(): Promise<BusinessMapMarker[] | RepositoryError>
+    12|  findById(id: MerchantId): Promise<BusinessMapMarker | RepositoryError>
+    13|  findByUsername(username: Username): Promise<BusinessMapMarker[] | RepositoryError>
+    14|  create(args: {
+    15|    username: Username
+    16|    coordinates: Coordinates
+    17|    title: BusinessMapTitle
+    18|    validated: boolean
+    19|  }): Promise<BusinessMapMarker | RepositoryError>
+    20|  update(args: {
+    21|    id: MerchantId
+    22|    coordinates: Coordinates
+    23|    title: BusinessMapTitle
+    24|    username: Username
+    25|    validated: boolean
+    26|  }): Promise<BusinessMapMarker | RepositoryError>
+    27|  findOneAndUpdate(args: {
+    28|    id: MerchantId
+    29|    updates: Partial<{
+    30|      coordinates: Coordinates
+    31|      title: BusinessMapTitle
+    32|      username: Username
+    33|      validated: boolean
+    34|    }>
+    35|  }): Promise<BusinessMapMarker | RepositoryError>
+    36|  remove(id: MerchantId): Promise<void | RepositoryError>
+    37|}
+    38|
+    39|export const MerchantsRepository = (): IMerchantRepository => {
+    40|  const findById = async (
+    41|    id: MerchantId,
+    42|  ): Promise<BusinessMapMarker | RepositoryError> => {
+    43|    try {
+    44|      const result = await Merchant.findOne({ id })
+    45|      if (!result) {
+    46|        return new CouldNotFindMerchantFromIdError(id)
+    47|      }
+    48|      return translateToMerchant(result)
+    49|    } catch (err) {
+    50|      return parseRepositoryError(err)
+    51|    }
+    52|  }
+    53|
+    54|  const findByUsername = async (
+    55|    username: Username,
+    56|  ): Promise<BusinessMapMarker[] | RepositoryError> => {
+    57|    try {
+    58|      const result = await Merchant.find({ username: caseInsensitiveRegex(username) })
+    59|      if (result.length === 0) {
+    60|        return new CouldNotFindMerchantFromUsernameError(username)
+    61|      }
+    62|      return result.map(translateToMerchant)
+    63|    } catch (err) {
+    64|      return parseRepositoryError(err)
+    65|    }
+    66|  }
+    67|
+    68|  const listForMap = async (): Promise<BusinessMapMarker[] | RepositoryError> => {
+    69|    try {
+    70|      const merchants = await Merchant.find({ validated: true })
+    71|      return merchants.map(translateToMerchant)
+    72|    } catch (err) {
+    73|      return parseRepositoryError(err)
+    74|    }
+    75|  }
+    76|
+    77|  const listPendingApproval = async (): Promise<
+    78|    BusinessMapMarker[] | RepositoryError
+    79|  > => {
+    80|    try {
+    81|      const merchants = await Merchant.find({ validated: false })
+    82|      return merchants.map(translateToMerchant)
+    83|    } catch (err) {
+    84|      return parseRepositoryError(err)
+    85|    }
+    86|  }
+    87|
+    88|  const create = async ({
+    89|    username,
+    90|    coordinates,
+    91|    title,
+    92|    validated,
+    93|  }: {
+    94|    username: Username
+    95|    coordinates: Coordinates
+    96|    title: BusinessMapTitle
+    97|    validated: boolean
+    98|  }): Promise<BusinessMapMarker | RepositoryError> => {
+    99|    try {
+   100|      const location = {
+   101|        type: "Point",
+   102|        coordinates: [coordinates.longitude, coordinates.latitude],
+   103|      }
+   104|
+   105|      const result = await Merchant.create({ username, location, title, validated })
+   106|
+   107|      return translateToMerchant(result)
+   108|    } catch (err) {
+   109|      return parseRepositoryError(err)
+   110|    }
+   111|  }
+   112|
+   113|  const update = async ({
+   114|    id,
+   115|    coordinates,
+   116|    title,
+   117|    username,
+   118|    validated,
+   119|  }: {
+   120|    id: MerchantId
+   121|    coordinates: Coordinates
+   122|    title: BusinessMapTitle
+   123|    username: Username
+   124|    validated: boolean
+   125|  }) => {
+   126|    const result = await Merchant.findOneAndUpdate(
+   127|      { id },
+   128|      { coordinates, title, username, validated },
+   129|      { new: true },
+   130|    )
+   131|    if (!result) {
+   132|      return new CouldNotFindMerchantFromIdError(id)
+   133|    }
+   134|
+   135|    return translateToMerchant(result)
+   136|  }
+   137|
+   138|  const findOneAndUpdate = async ({
+   139|    id,
+   140|    updates,
+   141|  }: {
+   142|    id: MerchantId
+   143|    updates: Partial<{
+   144|      coordinates: Coordinates
+   145|      title: BusinessMapTitle
+   146|      username: Username
+   147|      validated: boolean
+   148|    }>
+   149|  }): Promise<BusinessMapMarker | RepositoryError> => {
+   150|    try {
+   151|      const result = await Merchant.findOneAndUpdate(
+   152|        { id },
+   153|        { $set: updates },
+   154|        { new: true },
+   155|      )
+   156|      if (!result) {
+   157|        return new CouldNotFindMerchantFromIdError(id)
+   158|      }
+   159|      return translateToMerchant(result)
+   160|    } catch (err) {
+   161|      return parseRepositoryError(err)
+   162|    }
+   163|  }
+   164|
+   165|  const remove = async (id: MerchantId): Promise<void | RepositoryError> => {
+   166|    try {
+   167|      const result = await Merchant.deleteOne({ id })
+   168|      if (!result) {
+   169|        return new CouldNotFindMerchantFromIdError(id)
+  const findClosest = async ({
+    latitude,
+    longitude,
+    limit,
+  }: {
+    latitude: number
+    longitude: number
+    limit: number
+  }): Promise<BusinessMapMarker[] | RepositoryError> => {
     try {
-      const result = await Merchant.findOne({ id })
-      if (!result) {
-        return new CouldNotFindMerchantFromIdError(id)
-      }
-      return translateToMerchant(result)
-    } catch (err) {
-      return parseRepositoryError(err)
-    }
-  }
-
-  const findByUsername = async (
-    username: Username,
-  ): Promise<BusinessMapMarker[] | RepositoryError> => {
-    try {
-      const result = await Merchant.find({ username: caseInsensitiveRegex(username) })
-      if (result.length === 0) {
-        return new CouldNotFindMerchantFromUsernameError(username)
-      }
-      return result.map(translateToMerchant)
-    } catch (err) {
-      return parseRepositoryError(err)
-    }
-  }
-
-  const listForMap = async (): Promise<BusinessMapMarker[] | RepositoryError> => {
-    try {
-      const merchants = await Merchant.find({ validated: true })
+      const merchants = await Merchant.find({
+        validated: true,
+        location: {
+          $near: {
+            $geometry: {
+              type: "Point",
+              coordinates: [longitude, latitude],
+            },
+          },
+        },
+      }).limit(limit)
       return merchants.map(translateToMerchant)
-    } catch (err) {
-      return parseRepositoryError(err)
-    }
-  }
-
-  const listPendingApproval = async (): Promise<
-    BusinessMapMarker[] | RepositoryError
-  > => {
-    try {
-      const merchants = await Merchant.find({ validated: false })
-      return merchants.map(translateToMerchant)
-    } catch (err) {
-      return parseRepositoryError(err)
-    }
-  }
-
-  const create = async ({
-    username,
-    coordinates,
-    title,
-    validated,
-  }: {
-    username: Username
-    coordinates: Coordinates
-    title: BusinessMapTitle
-    validated: boolean
-  }): Promise<BusinessMapMarker | RepositoryError> => {
-    try {
-      const location = {
-        type: "Point",
-        coordinates: [coordinates.longitude, coordinates.latitude],
-      }
-
-      const result = await Merchant.create({ username, location, title, validated })
-
-      return translateToMerchant(result)
-    } catch (err) {
-      return parseRepositoryError(err)
-    }
-  }
-
-  const update = async ({
-    id,
-    coordinates,
-    title,
-    username,
-    validated,
-  }: {
-    id: MerchantId
-    coordinates: Coordinates
-    title: BusinessMapTitle
-    username: Username
-    validated: boolean
-  }) => {
-    const result = await Merchant.findOneAndUpdate(
-      { id },
-      { coordinates, title, username, validated },
-      { new: true },
-    )
-    if (!result) {
-      return new CouldNotFindMerchantFromIdError(id)
-    }
-
-    return translateToMerchant(result)
-  }
-
-  const findOneAndUpdate = async ({
-    id,
-    updates,
-  }: {
-    id: MerchantId
-    updates: Partial<{
-      coordinates: Coordinates
-      title: BusinessMapTitle
-      username: Username
-      validated: boolean
-    }>
-  }): Promise<BusinessMapMarker | RepositoryError> => {
-    try {
-      const result = await Merchant.findOneAndUpdate(
-        { id },
-        { $set: updates },
-        { new: true },
-      )
-      if (!result) {
-        return new CouldNotFindMerchantFromIdError(id)
-      }
-      return translateToMerchant(result)
-    } catch (err) {
-      return parseRepositoryError(err)
-    }
-  }
-
-  const remove = async (id: MerchantId): Promise<void | RepositoryError> => {
-    try {
-      const result = await Merchant.deleteOne({ id })
-      if (!result) {
-        return new CouldNotFindMerchantFromIdError(id)
-      }
     } catch (err) {
       return parseRepositoryError(err)
     }
@@ -193,6 +219,7 @@ export const MerchantsRepository = (): IMerchantRepository => {
   return {
     listForMap,
     listPendingApproval,
+    findClosest,
     findById,
     findByUsername,
     create,


### PR DESCRIPTION
Closes #200

## Changes

- Added `closestMerchants(latitude: Float!, longitude: Float!)` GraphQL query
- Returns top 3 validated merchants sorted by proximity
- Uses MongoDB `$near` geospatial query on the existing 2dsphere-indexed `location` field
- Added `findClosest` method to `MerchantsRepository`
- Added `getClosestMerchants` to app layer

## How it works

The query takes latitude and longitude parameters and uses MongoDB's `$near` operator to find the closest validated merchants. The merchant schema already has a 2dsphere index on the `location` field, so this is efficient.

### Example query

```graphql
query {
  closestMerchants(latitude: 18.0179, longitude: -76.8099) {
    username
    mapInfo {
      title
      coordinates {
        latitude
        longitude
      }
    }
  }
}
```

This returns the 3 closest validated merchants to the given coordinates, sorted by distance.