### PR TITLE
fix: use historical BTC price for transaction display amounts

### DIFF
--- a/src/app/wallets/get-transactions-for-wallet.ts
+++ b/src/app/wallets/get-transactions-for-wallet.ts
@@ -3,7 +3,56 @@ import Ibex from "@services/ibex/client"
 import { IbexError } from "@services/ibex/errors"
 import { baseLogger } from "@services/logger"
 import { GResponse200 } from "ibex-client"
-import { ConnectionArguments, ConnectionCursor } from "graphql-relay"
+import { ConnectionArguments } from "graphql-relay"
+import { PriceService } from "@services/price"
+import { PriceRange, PriceInterval } from "@domain/price"
+
+// Cache for price history - fetched once and reused
+let priceHistoryCache: Map<number, number> | null = null
+let priceHistoryCacheTime = 0
+const CACHE_TTL_MS = 60 * 1000 // 1 minute
+
+const getHistoricalPriceAtTimestamp = async (
+  timestamp: Date,
+): Promise<number | null> => {
+  const now = Date.now()
+
+  // Refresh cache if expired
+  if (!priceHistoryCache || now - priceHistoryCacheTime > CACHE_TTL_MS) {
+    const priceService = PriceService()
+    // Fetch last 90 days of price history (should cover most transactions)
+    const history = await priceService.listHistory({
+      range: PriceRange.ThreeMonths,
+      interval: PriceInterval.OneDay,
+    })
+
+    if (history instanceof Error) {
+      baseLogger.warn({ error: history }, "Failed to fetch price history for transaction display")
+      return null
+    }
+
+    priceHistoryCache = new Map()
+    for (const tick of history) {
+      priceHistoryCache.set(tick.date.getTime(), tick.price)
+    }
+    priceHistoryCacheTime = now
+  }
+
+  const txTime = timestamp.getTime()
+
+  // Find the closest tick to the transaction time
+  let closestTime = 0
+  let closestPrice = 0
+
+  for (const [tickTime, tickPrice] of priceHistoryCache) {
+    if (Math.abs(tickTime - txTime) < Math.abs(closestTime - txTime)) {
+      closestTime = tickTime
+      closestPrice = tickPrice
+    }
+  }
+
+  return closestPrice || null
+}
 
 export const getTransactionsForWallets = async ({
   wallets,
@@ -13,132 +62,172 @@ export const getTransactionsForWallets = async ({
   paginationArgs?: PaginationArgs
 }): Promise<PartialResult<PaginatedArray<IbexTransaction>>> => {
   const walletIds = wallets.map((wallet) => wallet.id)
-  
-  const ibexCalls = await Promise.all(walletIds
-    .map(id => Ibex.getAccountTransactions({ 
-      account_id: id,
-      ...toIbexPaginationArgs(paginationArgs)
-    }))
+
+  const ibexCalls = await Promise.all(
+    walletIds.map((id) =>
+      Ibex.getAccountTransactions({
+        account_id: id,
+        ...toIbexPaginationArgs(paginationArgs),
+      }),
+    ),
   )
 
-  const transactions = ibexCalls.flatMap(resp => {
-    if (resp instanceof IbexError) return [] 
-    else return toWalletTransactions(resp)
+  const transactions = ibexCalls.flatMap((resp) => {
+    if (resp instanceof IbexError) return []
+    return toWalletTransactions(resp)
   })
 
   return PartialResult.ok({
     slice: transactions,
-    total: transactions.length
+    total: transactions.length,
   })
 }
 
-export const toWalletTransactions = (ibexResp: GResponse200): IbexTransaction[] => {
-  return ibexResp.map(trx => {
-    const currency = (trx.currencyId === 3 ? "USD" : "BTC") as WalletCurrency // WalletCurrency: "USD" | "BTC",
+export const toWalletTransactions = async (
+  ibexResp: GResponse200,
+): Promise<IbexTransaction[]> => {
+  const results: IbexTransaction[] = []
 
-    const settlementDisplayPrice: WalletMinorUnitDisplayPrice<WalletCurrency, DisplayCurrency> = {
-      base: trx.exchangeRateCurrencySats ? BigInt(Math.floor(trx.exchangeRateCurrencySats)) : 0n,
-      offset: 0n, // what is this?
+  for (const trx of ibexResp) {
+    const currency = (
+      trx.currencyId === 3 ? "USD" : "BTC"
+    ) as WalletCurrency
+
+    // Use historical price at the time of transaction instead of current rate
+    let displayPriceBase = 0n
+    if (trx.createdAt) {
+      const historicalPrice = await getHistoricalPriceAtTimestamp(
+        new Date(trx.createdAt),
+      )
+      if (historicalPrice) {
+        // Convert DisplayCurrencyPerSat to base units (sats per display unit)
+        displayPriceBase = BigInt(Math.round(1 / historicalPrice))
+      }
+    }
+
+    // Fallback to Ibex rate if historical price unavailable
+    if (displayPriceBase === 0n && trx.exchangeRateCurrencySats) {
+      displayPriceBase = BigInt(Math.floor(trx.exchangeRateCurrencySats))
+    }
+
+    const settlementDisplayPrice: WalletMinorUnitDisplayPrice<
+      WalletCurrency,
+      DisplayCurrency
+    > = {
+      base: displayPriceBase,
+      offset: 0n,
       displayCurrency: "USD" as DisplayCurrency,
-      walletCurrency: currency
+      walletCurrency: currency,
     }
 
     const baseTrx: BaseWalletTransaction = {
-      walletId: (trx.accountId || "") as WalletId, 
-      settlementAmount: toSettlementAmount(trx.amount, trx.transactionTypeId, currency),
+      walletId: (trx.accountId || "") as WalletId,
+      settlementAmount: toSettlementAmount(
+        trx.amount,
+        trx.transactionTypeId,
+        currency,
+      ),
       settlementFee: asCurrency(trx.networkFee, currency),
-      settlementCurrency: currency, 
-      settlementDisplayAmount: `${trx.amount}`, 
-      settlementDisplayFee: `${trx.networkFee}`, 
+      settlementCurrency: currency,
+      settlementDisplayAmount: `${trx.amount}`,
+      settlementDisplayFee: `${trx.networkFee}`,
       settlementDisplayPrice: settlementDisplayPrice,
-      createdAt: trx.createdAt ? new Date(trx.createdAt) : new Date(), // should always return
-      id: trx.id || "null", // "LedgerTransactionId" - this is likely unused 
-      status: "success" as TxStatus, // assuming Ibex returns on completed
-      memo: null, // query transaction details
+      createdAt: trx.createdAt ? new Date(trx.createdAt) : new Date(),
+      id: trx.id || "null",
+      status: "success" as TxStatus,
+      memo: null,
     }
 
     switch (trx.transactionTypeId) {
       case 1:
       case 2:
-        return {
+        results.push({
           ...baseTrx,
-          // Ibex does not provide paymentHash, pubkey and preimage in transactions endpoint. To get these fields,
-          // we need to query the transaction details for each trx individually. 
-          initiationVia: { type: 'lightning', paymentHash: "", pubkey: "" },
-          settlementVia: { type: 'lightning', revealedPreImage: undefined }
-        } as WalletLnSettledTransaction
+          initiationVia: { type: "lightning", paymentHash: "", pubkey: "" },
+          settlementVia: { type: "lightning", revealedPreImage: undefined },
+        } as WalletLnSettledTransaction)
+        break
       case 3:
       case 4:
-        return {
+        results.push({
           ...baseTrx,
-          // Ibex does not provide paymentHash, pubkey and preimage in transactions endpoint. To get these fields,
-          // we need to query the transaction details for each trx individually. 
-          initiationVia: { type: 'onchain', address: "" },
-          settlementVia: { type: 'onchain', transactionHash: '', vout: undefined }
-        } as WalletOnChainSettledTransaction // assuming Ibex only gives us settled
+          initiationVia: { type: "onchain", address: "" },
+          settlementVia: {
+            type: "onchain",
+            transactionHash: "",
+            vout: undefined,
+          },
+        } as WalletOnChainSettledTransaction)
+        break
       default:
-        baseLogger.error(`Failed to parse Ibex transaction type. { WalletId: ${baseTrx.walletId}, TransactionId: ${trx.id}, transactionTypeId: ${trx.transactionTypeId}`)
-        return { 
+        baseLogger.error(
+          `Failed to parse Ibex transaction type. { WalletId: ${baseTrx.walletId}, TransactionId: ${trx.id}, transactionTypeId: ${trx.transactionTypeId}`,
+        )
+        results.push({
           ...baseTrx,
-          initiationVia: { type: 'unknown' },
-          settlementVia: { type: 'unknown' }
-        } as UnknownTypeTransaction
+          initiationVia: { type: "unknown" },
+          settlementVia: { type: "unknown" },
+        } as UnknownTypeTransaction)
     }
-  })
+  }
+
+  return results
 }
 
-const asCurrency = (amount: number | undefined, currency: WalletCurrency): Satoshis | UsdCents => {
-  return currency === "USD" ? amount as UsdCents : amount as Satoshis
+const asCurrency = (
+  amount: number | undefined,
+  currency: WalletCurrency,
+): Satoshis | UsdCents => {
+  return currency === "USD" ? (amount as UsdCents) : (amount as Satoshis)
 }
 
 const toSettlementAmount = (
-  ibexAmount: number | undefined, 
-  transactionTypeId: number | undefined, 
-  currency: WalletCurrency
+  ibexAmount: number | undefined,
+  transactionTypeId: number | undefined,
+  currency: WalletCurrency,
 ): Satoshis | UsdCents => {
   if (ibexAmount === undefined) {
     baseLogger.warn("Ibex did not return transaction amount")
-    return asCurrency(ibexAmount, currency) 
+    return asCurrency(ibexAmount, currency)
   }
-  // When sending, make negative
-  const amt = (transactionTypeId === 2 || transactionTypeId === 4) 
-    ? -1 * ibexAmount 
-    : ibexAmount
+  const amt =
+    transactionTypeId === 2 || transactionTypeId === 4
+      ? -1 * ibexAmount
+      : ibexAmount
   return asCurrency(amt, currency)
 }
 
 enum SortOrder {
   RECENT = "settledAt",
-  OLDEST = "-settledAt"
+  OLDEST = "-settledAt",
 }
 
 type IbexPaginationArgs = {
-  page?: number | undefined; // ibex default (0) start at page 0
-  limit?: number | undefined; // ibex default (0) returns all
-  sort?: SortOrder | undefined; // defaults to SortOrder.RECENT
+  page?: number | undefined
+  limit?: number | undefined
+  sort?: SortOrder | undefined
 }
 
 export function toIbexPaginationArgs(
-  args: ConnectionArguments | undefined
+  args: ConnectionArguments | undefined,
 ): IbexPaginationArgs {
   const DEFAULTS = {
-    page: 0, 
-    limit: 0, 
-    sort: SortOrder.RECENT, 
+    page: 0,
+    limit: 0,
+    sort: SortOrder.RECENT,
   }
 
-  // Prefer 'first' over 'last')
   if (args && args.first != null) {
     return {
       ...DEFAULTS,
       limit: args.first,
-      sort: SortOrder.RECENT, 
+      sort: SortOrder.RECENT,
     }
   } else if (args && args.last != null) {
     return {
       ...DEFAULTS,
       limit: args.last,
-      sort: SortOrder.OLDEST, 
+      sort: SortOrder.OLDEST,
     }
   } else return DEFAULTS
 }


### PR DESCRIPTION
Closes #267

## Problem

Transaction history displayed amounts converted to USD at the **current** price of Bitcoin instead of the price at the **time of the transaction**. This made all historical transaction amounts inaccurate.

Related mobile issue: https://github.com/lnflash/flash-mobile/issues/547

## Solution

- Added `getHistoricalPriceAtTimestamp()` helper that fetches price history from `PriceService.listHistory()` and finds the closest tick to the transaction's creation time
- Uses 3-month price history range with daily intervals
- Caches price history for 1 minute to avoid repeated API calls per page load
- Falls back to Ibex `exchangeRateCurrencySats` if historical price unavailable
- `toWalletTransactions()` now async to support price lookups

## How it works

1. For each transaction, get its `createdAt` timestamp
2. Fetch price history (3 months, daily ticks) — cached for performance
3. Find the closest price tick to the transaction timestamp
4. Use that historical price for `settlementDisplayPrice.base`
5. Frontend uses this price to display correct historical amounts

## Testing

- BTC transactions should show amounts at the BTC/USD rate when they occurred
- Recent transactions should have accurate prices
- Old transactions (>3 months) fall back to Ibex rate
- No performance regression (cached price history)