### PR TITLE
fix: BTC wallet balance serialization — return number instead of object

### DIFF
--- a/src/graphql/shared/types/object/btc-wallet.ts
+++ b/src/graphql/shared/types/object/btc-wallet.ts
@@ -50,7 +50,7 @@ const BtcWallet = GT.Object<Wallet>({
         if (balanceSats instanceof Error) {
           throw mapError(balanceSats)
         }
-        return balanceSats
+        return Number(balanceSats.asCents(8))
       },
     },
     pendingIncomingBalance: {


### PR DESCRIPTION
Fixes #282 (backend portion)

## Problem

`BtcWallet.balance` resolver returned the `USDAmount` class instance directly, which serialized as `{}` in GraphQL responses instead of a numeric value.

## Root Cause

```typescript
// btc-wallet.ts (line 53)
return balanceSats  // Returns class instance, serializes as {}
```

vs the correct pattern in `usd-wallet.ts`:

```typescript
return Number(balance.asCents(8))  // Returns number
```

## Fix

```diff
- return balanceSats
+ return Number(balanceSats.asCents(8))
```

## File Changed
- `src/graphql/shared/types/object/btc-wallet.ts` (1 line)