### PR TITLE
Fix: reject device→phone upgrade when phone already exists (ENG-381)

### DIFF
--- a/src/app/authentication/login.ts
+++ b/src/app/authentication/login.ts
@@ -16,6 +16,7 @@ import {
   AuthWithPhonePasswordlessService,
   AuthWithUsernamePasswordDeviceIdService,
   IdentityRepository,
+  PhoneAccountAlreadyExistsCannotUpgradeError,
   PhoneAccountAlreadyExistsNeedToSweepFundsError,
 } from "@services/kratos"
 
@@ -315,13 +316,20 @@ export const loginDeviceUpgradeWithPhone = async ({
       deviceAccountHasBalance = true
     }
   }
-  if (deviceAccountHasBalance) return new PhoneAccountAlreadyExistsNeedToSweepFundsError()
+  if (deviceAccountHasBalance) {
+    addAttributesToCurrentSpan({
+      "login.upgrade.collisionRejected": true,
+      "login.upgrade.collisionHasDeviceBalance": true,
+    })
+    return new PhoneAccountAlreadyExistsNeedToSweepFundsError()
+  }
 
-  // no txns on device account but phone account exists, just log the user in with the phone account
-  const authService = AuthWithPhonePasswordlessService()
-  const kratosResult = await authService.loginToken({ phone })
-  if (kratosResult instanceof Error) return kratosResult
-  return { success: true, authToken: kratosResult.authToken }
+  addAttributesToCurrentSpan({
+    "login.upgrade.collisionRejected": true,
+    "login.upgrade.collisionHasDeviceBalance": false,
+  })
+
+  return new PhoneAccountAlreadyExistsCannotUpgradeError()
 }
 
 export const loginWithDevice = async ({

--- a/src/app/authentication/login.ts
+++ b/src/app/authentication/login.ts
@@ -1,4 +1,6 @@
+import { upgradeAccountFromDeviceToPhone } from "@app/accounts"
 import { createAccountForDeviceAccount } from "@app/accounts/create-account"
+import { getBalanceForWallet } from "@app/wallets"
 
 import {
   EmailUnverifiedError,
@@ -20,14 +22,12 @@ import {
   PhoneAccountAlreadyExistsNeedToSweepFundsError,
 } from "@services/kratos"
 
-import { LedgerService } from "@services/ledger"
 import { WalletsRepository } from "@services/mongoose"
 import {
   addAttributesToCurrentSpan,
   recordExceptionInCurrentSpan,
 } from "@services/tracing"
 
-import { upgradeAccountFromDeviceToPhone } from "@app/accounts"
 import { checkedToEmailCode } from "@domain/authentication"
 import { isPhoneCodeValid, TwilioClient } from "@services/twilio"
 
@@ -55,7 +55,6 @@ import {
   rewardFailedLoginAttemptPerIpLimits,
   rewardFailedLoginAttemptPerLoginIdentifierLimits,
 } from "./ratelimits"
-import { getBalanceForWallet } from "@app/wallets"
 
 export const loginWithPhoneToken = async ({
   phone,

--- a/src/graphql/error-map.ts
+++ b/src/graphql/error-map.ts
@@ -22,6 +22,7 @@ import {
   DealerError,
   PhoneAccountAlreadyExistsError,
   PhoneAccountAlreadyExistsNeedToSweepFundsError,
+  PhoneAccountAlreadyExistsCannotUpgradeError,
   EmailUnverifiedError,
   AccountAlreadyHasEmailError,
   PhoneAlreadyExistsError,
@@ -409,6 +410,14 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
       message =
         "Error phone account already exists. You need to manually sweep funds to your phone account."
       return new PhoneAccountAlreadyExistsNeedToSweepFundsError({
+        message,
+        logger: baseLogger,
+      })
+
+    case "PhoneAccountAlreadyExistsCannotUpgradeError":
+      message =
+        "Phone number is already registered to another user. Please log out and log in with that phone account."
+      return new PhoneAccountAlreadyExistsCannotUpgradeError({
         message,
         logger: baseLogger,
       })

--- a/src/graphql/error.ts
+++ b/src/graphql/error.ts
@@ -409,6 +409,18 @@ export class InvalidPhoneMetadataForOnboardingError extends CustomApolloError {
   }
 }
 
+export class PhoneAccountAlreadyExistsCannotUpgradeError extends CustomApolloError {
+  constructor(errData: CustomApolloErrorData) {
+    super({
+      message:
+        "Phone number is already registered to another user. Please log out and log in with that phone account.",
+      forwardToClient: true,
+      code: "PHONE_ALREADY_REGISTERED_TO_ANOTHER_USER",
+      ...errData,
+    })
+  }
+}
+
 export class PhoneAccountAlreadyExistsNeedToSweepFundsError extends CustomApolloError {
   constructor(errData: CustomApolloErrorData) {
     super({

--- a/src/services/kratos/errors.ts
+++ b/src/services/kratos/errors.ts
@@ -23,6 +23,10 @@ export class PhoneAccountAlreadyExistsNeedToSweepFundsError extends KratosError 
   level = ErrorLevel.Info
 }
 
+export class PhoneAccountAlreadyExistsCannotUpgradeError extends KratosError {
+  level = ErrorLevel.Info
+}
+
 export class MissingCreatedAtKratosError extends KratosError {
   level = ErrorLevel.Critical
 }

--- a/test/flash/unit/app/authentication/login-device-upgrade.spec.ts
+++ b/test/flash/unit/app/authentication/login-device-upgrade.spec.ts
@@ -1,40 +1,40 @@
-/**
- * Unit tests for loginDeviceUpgradeWithPhone — device→phone upgrade collision handling.
- *
- * Verifies the two error paths when a phone number is already registered:
- * - Non-zero device balance → PhoneAccountAlreadyExistsNeedToSweepFundsError
- * - Zero device balance → PhoneAccountAlreadyExistsCannotUpgradeError
- */
+/* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { USDAmount } from "@domain/shared"
-import {
-  loginDeviceUpgradeWithPhone,
-} from "@app/authentication/login"
 import {
   PhoneAccountAlreadyExistsCannotUpgradeError,
   PhoneAccountAlreadyExistsNeedToSweepFundsError,
 } from "@services/kratos"
+import { loginDeviceUpgradeWithPhone } from "@app/authentication/login"
 
-// Mock all external service boundaries to isolate the function under test
-jest.mock("@services/rate-limit", () => ({
-  consumeLimiter: jest.fn().mockResolvedValue(true),
-  RedisRateLimitService: jest.fn(() => ({
-    reward: jest.fn().mockResolvedValue(true),
-  })),
+jest.mock("@app/accounts/create-account", () => ({
+  createAccountForDeviceAccount: jest.fn(),
+}))
+
+jest.mock("@services/ledger", () => ({
+  LedgerService: jest.fn(),
+}))
+
+jest.mock("@app/accounts", () => ({
+  upgradeAccountFromDeviceToPhone: jest.fn(),
 }))
 
 jest.mock("@services/twilio", () => ({
   isPhoneCodeValid: jest.fn().mockResolvedValue(true),
+  TwilioClient: jest.fn(),
 }))
 
 jest.mock("@services/kratos", () => {
+  const actual = jest.requireActual("@services/kratos")
   const mockIdentityRepo = {
     getUserIdFromIdentifier: jest.fn().mockResolvedValue("existing-user-id"),
   }
+
   return {
+    ...actual,
     IdentityRepository: jest.fn(() => mockIdentityRepo),
-    PhoneAccountAlreadyExistsCannotUpgradeError: jest.fn(),
-    PhoneAccountAlreadyExistsNeedToSweepFundsError: jest.fn(),
+    AuthWithEmailPasswordlessService: jest.fn(),
+    AuthWithPhonePasswordlessService: jest.fn(),
     AuthWithUsernamePasswordDeviceIdService: jest.fn(),
   }
 })
@@ -49,18 +49,27 @@ jest.mock("@app/wallets", () => ({
 
 jest.mock("@services/tracing", () => ({
   addAttributesToCurrentSpan: jest.fn(),
-  wrapAsyncFunctionsToRunInSpan: jest.fn(),
   recordExceptionInCurrentSpan: jest.fn(),
-  ErrorLevel: { Warn: "warn", Critical: "critical" },
 }))
 
-jest.mock("@config", () => {
-  const actual = jest.requireActual("@config")
-  return {
-    ...actual,
-    getTestAccounts: jest.fn(() => ({})),
-  }
-})
+jest.mock("@domain/accounts-ips/ip-metadata-authorizer", () => ({
+  IPMetadataAuthorizer: jest.fn(),
+}))
+
+jest.mock("@services/ipfetcher", () => ({
+  IpFetcher: jest.fn(),
+}))
+
+jest.mock("@app/authentication/ratelimits", () => ({
+  checkFailedLoginAttemptPerIpLimits: jest.fn().mockResolvedValue(true),
+  checkFailedLoginAttemptPerLoginIdentifierLimits: jest.fn().mockResolvedValue(true),
+  rewardFailedLoginAttemptPerIpLimits: jest.fn().mockResolvedValue(true),
+  rewardFailedLoginAttemptPerLoginIdentifierLimits: jest.fn().mockResolvedValue(true),
+}))
+
+jest.mock("@config", () => ({
+  getAccountsOnboardConfig: jest.fn(() => ({ requireCountry: false })),
+}))
 
 const mockWalletsRepo = (): { listByAccountId: jest.Mock } => ({
   listByAccountId: jest.fn().mockResolvedValue([]),
@@ -77,6 +86,9 @@ describe("loginDeviceUpgradeWithPhone", () => {
     ;(require("@services/mongoose").WalletsRepository as jest.Mock).mockReturnValue(
       mockWalletsRepo(),
     )
+    ;(require("@services/kratos").IdentityRepository as jest.Mock).mockReturnValue({
+      getUserIdFromIdentifier: jest.fn().mockResolvedValue("existing-user-id"),
+    })
   })
 
   it("returns NeedToSweepFunds when device account has balance", async () => {

--- a/test/flash/unit/app/authentication/login-device-upgrade.spec.ts
+++ b/test/flash/unit/app/authentication/login-device-upgrade.spec.ts
@@ -1,0 +1,140 @@
+/**
+ * Unit tests for loginDeviceUpgradeWithPhone — device→phone upgrade collision handling.
+ *
+ * Verifies the two error paths when a phone number is already registered:
+ * - Non-zero device balance → PhoneAccountAlreadyExistsNeedToSweepFundsError
+ * - Zero device balance → PhoneAccountAlreadyExistsCannotUpgradeError
+ */
+
+import { USDAmount } from "@domain/shared"
+import {
+  loginDeviceUpgradeWithPhone,
+} from "@app/authentication/login"
+import {
+  PhoneAccountAlreadyExistsCannotUpgradeError,
+  PhoneAccountAlreadyExistsNeedToSweepFundsError,
+} from "@services/kratos"
+
+// Mock all external service boundaries to isolate the function under test
+jest.mock("@services/rate-limit", () => ({
+  consumeLimiter: jest.fn().mockResolvedValue(true),
+  RedisRateLimitService: jest.fn(() => ({
+    reward: jest.fn().mockResolvedValue(true),
+  })),
+}))
+
+jest.mock("@services/twilio", () => ({
+  isPhoneCodeValid: jest.fn().mockResolvedValue(true),
+}))
+
+jest.mock("@services/kratos", () => {
+  const mockIdentityRepo = {
+    getUserIdFromIdentifier: jest.fn().mockResolvedValue("existing-user-id"),
+  }
+  return {
+    IdentityRepository: jest.fn(() => mockIdentityRepo),
+    PhoneAccountAlreadyExistsCannotUpgradeError: jest.fn(),
+    PhoneAccountAlreadyExistsNeedToSweepFundsError: jest.fn(),
+    AuthWithUsernamePasswordDeviceIdService: jest.fn(),
+  }
+})
+
+jest.mock("@services/mongoose", () => ({
+  WalletsRepository: jest.fn(),
+}))
+
+jest.mock("@app/wallets", () => ({
+  getBalanceForWallet: jest.fn(),
+}))
+
+jest.mock("@services/tracing", () => ({
+  addAttributesToCurrentSpan: jest.fn(),
+  wrapAsyncFunctionsToRunInSpan: jest.fn(),
+  recordExceptionInCurrentSpan: jest.fn(),
+  ErrorLevel: { Warn: "warn", Critical: "critical" },
+}))
+
+jest.mock("@config", () => {
+  const actual = jest.requireActual("@config")
+  return {
+    ...actual,
+    getTestAccounts: jest.fn(() => ({})),
+  }
+})
+
+const mockWalletsRepo = (): { listByAccountId: jest.Mock } => ({
+  listByAccountId: jest.fn().mockResolvedValue([]),
+})
+
+describe("loginDeviceUpgradeWithPhone", () => {
+  const mockAccount = { id: "account-id" } as any
+  const mockPhone = "+15551234567" as any
+  const mockCode = "123456" as any
+  const mockIp = "127.0.0.1" as any
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(require("@services/mongoose").WalletsRepository as jest.Mock).mockReturnValue(
+      mockWalletsRepo(),
+    )
+  })
+
+  it("returns NeedToSweepFunds when device account has balance", async () => {
+    const { WalletsRepository } = require("@services/mongoose")
+    const wallet = { id: "wallet-id" }
+    WalletsRepository().listByAccountId.mockResolvedValue([wallet])
+
+    const { getBalanceForWallet } = require("@app/wallets")
+    getBalanceForWallet.mockResolvedValue(USDAmount.cents(5000n))
+
+    const result = await loginDeviceUpgradeWithPhone({
+      account: mockAccount,
+      phone: mockPhone,
+      code: mockCode,
+      ip: mockIp,
+    })
+
+    expect(result).toBeInstanceOf(PhoneAccountAlreadyExistsNeedToSweepFundsError)
+    expect(getBalanceForWallet).toHaveBeenCalledWith({ walletId: "wallet-id" })
+  })
+
+  it("returns CannotUpgrade when device account has zero balance", async () => {
+    const { WalletsRepository } = require("@services/mongoose")
+    const wallet = { id: "wallet-id" }
+    WalletsRepository().listByAccountId.mockResolvedValue([wallet])
+
+    const { getBalanceForWallet } = require("@app/wallets")
+    getBalanceForWallet.mockResolvedValue(USDAmount.ZERO)
+
+    const result = await loginDeviceUpgradeWithPhone({
+      account: mockAccount,
+      phone: mockPhone,
+      code: mockCode,
+      ip: mockIp,
+    })
+
+    expect(result).toBeInstanceOf(PhoneAccountAlreadyExistsCannotUpgradeError)
+    expect(getBalanceForWallet).toHaveBeenCalledWith({ walletId: "wallet-id" })
+  })
+
+  it("returns NeedToSweepFunds when any wallet has balance among multiple", async () => {
+    const { WalletsRepository } = require("@services/mongoose")
+    const wallet0 = { id: "wallet-0" }
+    const wallet1 = { id: "wallet-1" }
+    WalletsRepository().listByAccountId.mockResolvedValue([wallet0, wallet1])
+
+    const { getBalanceForWallet } = require("@app/wallets")
+    getBalanceForWallet
+      .mockResolvedValueOnce(USDAmount.ZERO)
+      .mockResolvedValueOnce(USDAmount.cents(100n))
+
+    const result = await loginDeviceUpgradeWithPhone({
+      account: mockAccount,
+      phone: mockPhone,
+      code: mockCode,
+      ip: mockIp,
+    })
+
+    expect(result).toBeInstanceOf(PhoneAccountAlreadyExistsNeedToSweepFundsError)
+  })
+})

--- a/test/flash/unit/app/authentication/login-device-upgrade.spec.ts
+++ b/test/flash/unit/app/authentication/login-device-upgrade.spec.ts
@@ -4,11 +4,13 @@ import { loginDeviceUpgradeWithPhone } from "@app/authentication/login"
 import { getBalanceForWallet } from "@app/wallets"
 import { USDAmount } from "@domain/shared"
 import {
+  AuthWithPhonePasswordlessService,
   IdentityRepository,
   PhoneAccountAlreadyExistsCannotUpgradeError,
   PhoneAccountAlreadyExistsNeedToSweepFundsError,
 } from "@services/kratos"
 import { WalletsRepository } from "@services/mongoose"
+import { addAttributesToCurrentSpan } from "@services/tracing"
 
 jest.mock("@app/accounts/create-account", () => ({
   createAccountForDeviceAccount: jest.fn(),
@@ -80,9 +82,14 @@ const mockedWalletsRepository = WalletsRepository as jest.MockedFunction<
 const mockedIdentityRepository = IdentityRepository as jest.MockedFunction<
   typeof IdentityRepository
 >
+const mockedPhoneAuthService = AuthWithPhonePasswordlessService as jest.MockedFunction<
+  typeof AuthWithPhonePasswordlessService
+>
 const mockedGetBalanceForWallet = getBalanceForWallet as jest.MockedFunction<
   typeof getBalanceForWallet
 >
+const mockedAddAttributesToCurrentSpan =
+  addAttributesToCurrentSpan as jest.MockedFunction<typeof addAttributesToCurrentSpan>
 
 const mockWalletsRepo = (): { listByAccountId: jest.Mock } => ({
   listByAccountId: jest.fn().mockResolvedValue([]),
@@ -90,6 +97,7 @@ const mockWalletsRepo = (): { listByAccountId: jest.Mock } => ({
 
 describe("loginDeviceUpgradeWithPhone", () => {
   let walletsRepo: { listByAccountId: jest.Mock }
+  let phoneAuthService: { loginToken: jest.Mock }
 
   const mockAccount = { id: "account-id" } as any
   const mockPhone = "+15551234567" as any
@@ -99,13 +107,18 @@ describe("loginDeviceUpgradeWithPhone", () => {
   beforeEach(() => {
     jest.clearAllMocks()
     walletsRepo = mockWalletsRepo()
+    phoneAuthService = {
+      loginToken: jest.fn().mockResolvedValue({ authToken: "should-not-be-used" }),
+    }
+
     mockedWalletsRepository.mockReturnValue(walletsRepo as any)
     mockedIdentityRepository.mockReturnValue({
       getUserIdFromIdentifier: jest.fn().mockResolvedValue("existing-user-id"),
     } as any)
+    mockedPhoneAuthService.mockReturnValue(phoneAuthService as any)
   })
 
-  it("returns NeedToSweepFunds when device account has balance", async () => {
+  it("returns NeedToSweepFunds when device account has balance and does not log into the existing phone account", async () => {
     const wallet = { id: "wallet-id" }
     walletsRepo.listByAccountId.mockResolvedValue([wallet])
     mockedGetBalanceForWallet.mockResolvedValue(USDAmount.cents(5000n) as any)
@@ -119,9 +132,14 @@ describe("loginDeviceUpgradeWithPhone", () => {
 
     expect(result).toBeInstanceOf(PhoneAccountAlreadyExistsNeedToSweepFundsError)
     expect(mockedGetBalanceForWallet).toHaveBeenCalledWith({ walletId: "wallet-id" })
+    expect(phoneAuthService.loginToken).not.toHaveBeenCalled()
+    expect(mockedAddAttributesToCurrentSpan).toHaveBeenCalledWith({
+      "login.upgrade.collisionRejected": true,
+      "login.upgrade.collisionHasDeviceBalance": true,
+    })
   })
 
-  it("returns CannotUpgrade when device account has zero balance", async () => {
+  it("returns CannotUpgrade for zero-balance collision and does not silently log into the existing phone account", async () => {
     const wallet = { id: "wallet-id" }
     walletsRepo.listByAccountId.mockResolvedValue([wallet])
     mockedGetBalanceForWallet.mockResolvedValue(USDAmount.ZERO as any)
@@ -135,6 +153,11 @@ describe("loginDeviceUpgradeWithPhone", () => {
 
     expect(result).toBeInstanceOf(PhoneAccountAlreadyExistsCannotUpgradeError)
     expect(mockedGetBalanceForWallet).toHaveBeenCalledWith({ walletId: "wallet-id" })
+    expect(phoneAuthService.loginToken).not.toHaveBeenCalled()
+    expect(mockedAddAttributesToCurrentSpan).toHaveBeenCalledWith({
+      "login.upgrade.collisionRejected": true,
+      "login.upgrade.collisionHasDeviceBalance": false,
+    })
   })
 
   it("returns NeedToSweepFunds when any wallet has balance among multiple", async () => {
@@ -154,5 +177,6 @@ describe("loginDeviceUpgradeWithPhone", () => {
     })
 
     expect(result).toBeInstanceOf(PhoneAccountAlreadyExistsNeedToSweepFundsError)
+    expect(phoneAuthService.loginToken).not.toHaveBeenCalled()
   })
 })

--- a/test/flash/unit/app/authentication/login-device-upgrade.spec.ts
+++ b/test/flash/unit/app/authentication/login-device-upgrade.spec.ts
@@ -1,11 +1,14 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+import { loginDeviceUpgradeWithPhone } from "@app/authentication/login"
+import { getBalanceForWallet } from "@app/wallets"
 import { USDAmount } from "@domain/shared"
 import {
+  IdentityRepository,
   PhoneAccountAlreadyExistsCannotUpgradeError,
   PhoneAccountAlreadyExistsNeedToSweepFundsError,
 } from "@services/kratos"
-import { loginDeviceUpgradeWithPhone } from "@app/authentication/login"
+import { WalletsRepository } from "@services/mongoose"
 
 jest.mock("@app/accounts/create-account", () => ({
   createAccountForDeviceAccount: jest.fn(),
@@ -71,11 +74,23 @@ jest.mock("@config", () => ({
   getAccountsOnboardConfig: jest.fn(() => ({ requireCountry: false })),
 }))
 
+const mockedWalletsRepository = WalletsRepository as jest.MockedFunction<
+  typeof WalletsRepository
+>
+const mockedIdentityRepository = IdentityRepository as jest.MockedFunction<
+  typeof IdentityRepository
+>
+const mockedGetBalanceForWallet = getBalanceForWallet as jest.MockedFunction<
+  typeof getBalanceForWallet
+>
+
 const mockWalletsRepo = (): { listByAccountId: jest.Mock } => ({
   listByAccountId: jest.fn().mockResolvedValue([]),
 })
 
 describe("loginDeviceUpgradeWithPhone", () => {
+  let walletsRepo: { listByAccountId: jest.Mock }
+
   const mockAccount = { id: "account-id" } as any
   const mockPhone = "+15551234567" as any
   const mockCode = "123456" as any
@@ -83,21 +98,17 @@ describe("loginDeviceUpgradeWithPhone", () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
-    ;(require("@services/mongoose").WalletsRepository as jest.Mock).mockReturnValue(
-      mockWalletsRepo(),
-    )
-    ;(require("@services/kratos").IdentityRepository as jest.Mock).mockReturnValue({
+    walletsRepo = mockWalletsRepo()
+    mockedWalletsRepository.mockReturnValue(walletsRepo as any)
+    mockedIdentityRepository.mockReturnValue({
       getUserIdFromIdentifier: jest.fn().mockResolvedValue("existing-user-id"),
-    })
+    } as any)
   })
 
   it("returns NeedToSweepFunds when device account has balance", async () => {
-    const { WalletsRepository } = require("@services/mongoose")
     const wallet = { id: "wallet-id" }
-    WalletsRepository().listByAccountId.mockResolvedValue([wallet])
-
-    const { getBalanceForWallet } = require("@app/wallets")
-    getBalanceForWallet.mockResolvedValue(USDAmount.cents(5000n))
+    walletsRepo.listByAccountId.mockResolvedValue([wallet])
+    mockedGetBalanceForWallet.mockResolvedValue(USDAmount.cents(5000n) as any)
 
     const result = await loginDeviceUpgradeWithPhone({
       account: mockAccount,
@@ -107,16 +118,13 @@ describe("loginDeviceUpgradeWithPhone", () => {
     })
 
     expect(result).toBeInstanceOf(PhoneAccountAlreadyExistsNeedToSweepFundsError)
-    expect(getBalanceForWallet).toHaveBeenCalledWith({ walletId: "wallet-id" })
+    expect(mockedGetBalanceForWallet).toHaveBeenCalledWith({ walletId: "wallet-id" })
   })
 
   it("returns CannotUpgrade when device account has zero balance", async () => {
-    const { WalletsRepository } = require("@services/mongoose")
     const wallet = { id: "wallet-id" }
-    WalletsRepository().listByAccountId.mockResolvedValue([wallet])
-
-    const { getBalanceForWallet } = require("@app/wallets")
-    getBalanceForWallet.mockResolvedValue(USDAmount.ZERO)
+    walletsRepo.listByAccountId.mockResolvedValue([wallet])
+    mockedGetBalanceForWallet.mockResolvedValue(USDAmount.ZERO as any)
 
     const result = await loginDeviceUpgradeWithPhone({
       account: mockAccount,
@@ -126,19 +134,17 @@ describe("loginDeviceUpgradeWithPhone", () => {
     })
 
     expect(result).toBeInstanceOf(PhoneAccountAlreadyExistsCannotUpgradeError)
-    expect(getBalanceForWallet).toHaveBeenCalledWith({ walletId: "wallet-id" })
+    expect(mockedGetBalanceForWallet).toHaveBeenCalledWith({ walletId: "wallet-id" })
   })
 
   it("returns NeedToSweepFunds when any wallet has balance among multiple", async () => {
-    const { WalletsRepository } = require("@services/mongoose")
     const wallet0 = { id: "wallet-0" }
     const wallet1 = { id: "wallet-1" }
-    WalletsRepository().listByAccountId.mockResolvedValue([wallet0, wallet1])
+    walletsRepo.listByAccountId.mockResolvedValue([wallet0, wallet1])
 
-    const { getBalanceForWallet } = require("@app/wallets")
-    getBalanceForWallet
-      .mockResolvedValueOnce(USDAmount.ZERO)
-      .mockResolvedValueOnce(USDAmount.cents(100n))
+    mockedGetBalanceForWallet
+      .mockResolvedValueOnce(USDAmount.ZERO as any)
+      .mockResolvedValueOnce(USDAmount.cents(100n) as any)
 
     const result = await loginDeviceUpgradeWithPhone({
       account: mockAccount,

--- a/test/flash/unit/graphql/error-map.spec.ts
+++ b/test/flash/unit/graphql/error-map.spec.ts
@@ -8,6 +8,6 @@ describe("error-map", () => {
 
     expect(result).toBeDefined()
     expect(result.message).toContain("already registered")
-    expect(result.code).toBe("PHONE_ALREADY_REGISTERED_TO_ANOTHER_USER")
+    expect(result.extensions.code).toBe("PHONE_ALREADY_REGISTERED_TO_ANOTHER_USER")
   })
 })

--- a/test/flash/unit/graphql/error-map.spec.ts
+++ b/test/flash/unit/graphql/error-map.spec.ts
@@ -1,0 +1,13 @@
+import { mapError } from "@graphql/error-map"
+import { PhoneAccountAlreadyExistsCannotUpgradeError } from "@services/kratos"
+
+describe("error-map", () => {
+  it("maps PhoneAccountAlreadyExistsCannotUpgradeError to correct GQL error", () => {
+    const input = new PhoneAccountAlreadyExistsCannotUpgradeError()
+    const result = mapError(input)
+
+    expect(result).toBeDefined()
+    expect(result.message).toContain("already registered")
+    expect(result.code).toBe("PHONE_ALREADY_REGISTERED_TO_ANOTHER_USER")
+  })
+})


### PR DESCRIPTION
## Summary

Fixes ENG-381: When a device (trial) account tries to upgrade to phone-based login but the phone number already belongs to another identity, the zero-balance case silently logged the user into the existing phone account — confusing UX.

## Changes

- **src/services/kratos/errors.ts** — Added `PhoneAccountAlreadyExistsCannotUpgradeError` error class
- **src/app/authentication/login.ts** — Both balance and zero-balance collisions now return error; old code that logged user into someone else's phone account removed. Added OpenTelemetry span attributes for observability.
- **src/graphql/error.ts** — Added GQL error class with `PHONE_ALREADY_REGISTERED_TO_ANOTHER_USER` code
- **src/graphql/error-map.ts** — Maps the new kratos error to the GQL error for client consumption
- **Tests** — Added unit tests for both error paths (balance + zero-balance) and error-map mapping

## Testing

- `loginDeviceUpgradeWithPhone` returns `PhoneAccountAlreadyExistsNeedToSweepFundsError` when device has balance
- Returns `PhoneAccountAlreadyExistsCannotUpgradeError` when device has zero balance
- Error map produces correct GQL error with `PHONE_ALREADY_REGISTERED_TO_ANOTHER_USER` code