### PR TITLE
feat: add bankAccounts query and unify BankAccount type

### DIFF
--- a/dev/apollo-federation/supergraph.graphql
+++ b/dev/apollo-federation/supergraph.graphql
@@ -207,11 +207,18 @@ type Bank
 type BankAccount
   @join__type(graph: PUBLIC)
 {
+  accountName: String!
   accountNumber: String!
-  accountType: String!
-  bankBranch: String!
-  bankName: String!
+
+  """Name of the bank institution"""
+  bank: String!
+
+  """Account currency (e.g. JMD, USD)"""
   currency: String!
+
+  """ERPNext bank account identifier"""
+  id: ID!
+  isDefault: Boolean!
 }
 
 input BankAccountInput
@@ -1917,6 +1924,9 @@ type UsdWallet implements Wallet
 type User
   @join__type(graph: PUBLIC)
 {
+  """Bank accounts available for cashout"""
+  bankAccounts: [BankAccount!]!
+
   """
   Get single contact details.
   Can include the transactions associated with the contact.

--- a/dev/bruno/Flash GraphQL API/token/queries/me.bru
+++ b/dev/bruno/Flash GraphQL API/token/queries/me.bru
@@ -40,6 +40,7 @@ body:graphql {
                   balance
               }
           }
+        bankAccounts { id accountName bank currency }
       }
   }
 }
@@ -57,4 +58,5 @@ script:post-response {
 
 settings {
   encodeUrl: true
+  timeout: 0
 }

--- a/src/app/accounts/business-account-upgrade-request.ts
+++ b/src/app/accounts/business-account-upgrade-request.ts
@@ -3,6 +3,7 @@ import { IdentityRepository } from "@services/kratos"
 import ErpNext from "@services/frappe/ErpNext"
 
 import { AccountUpgradeRequest, RequestStatus } from "@services/frappe/models/AccountUpgradeRequest"
+import { BankAccount } from "@services/frappe/models/BankAccount"
 import { DomainError, ValidationError } from "@domain/shared"
 import { AccountLevel } from "@domain/accounts"
 import { SetDocTypeValueError, UpgradeRequestQueryError } from "@services/frappe/errors"
@@ -25,14 +26,6 @@ export type Address = {
   state: string
   postalCode?: string
   country: string // Should fetch from ErpNext options
-}
-
-export type BankAccount = {
-  bankName: string
-  bankBranch: string
-  accountType: string
-  currency: string
-  accountNumber: string
 }
 
 type ProUpgradeRequest = {

--- a/src/graphql/public/root/mutation/business-account-upgrade-request.ts
+++ b/src/graphql/public/root/mutation/business-account-upgrade-request.ts
@@ -18,6 +18,15 @@ const BankAccountInput = GT.Input({
   }),
 })
 
+type BankAccountInputType = { bankName: string, bankBranch: string, accountType: string, currency: string, accountNumber: string }
+const parseBankAccountInput = ({ bankName, bankBranch, accountType, currency, accountNumber }: BankAccountInputType) => ({
+  bank: bankName,
+  branch_code: bankBranch,
+  account_type: accountType,
+  currency,
+  bank_account_no: accountNumber,
+})
+
 const AddressInput = GT.Input({
   name: "AddressInput",
   fields: () => ({
@@ -67,7 +76,11 @@ const BusinessAccountUpgradeRequestMutation = GT.Field({
     input: { type: GT.NonNull(BusinessAccountUpgradeRequestInput) },
   },
   resolve: async (_, args, { domainAccount }: { domainAccount: Account }) => {
-    const result = await Accounts.createUpgradeRequest(domainAccount.id, args.input)
+    const { bankAccount, ...rest } = args.input
+    const result = await Accounts.createUpgradeRequest(domainAccount.id, {
+      ...rest,
+      bankAccount: bankAccount ? parseBankAccountInput(bankAccount) : undefined,
+    })
     if (result instanceof SetDocTypeValueError) return apolloErrorResponse(new InternalServerError({ message: "Pending upgrade request(s) failed to update." }))
     if (result instanceof Error) return { errors: mapToGqlErrorList(result) }
     else return result

--- a/src/graphql/public/schema.graphql
+++ b/src/graphql/public/schema.graphql
@@ -195,11 +195,18 @@ type Bank {
 }
 
 type BankAccount {
+  accountName: String!
   accountNumber: String!
-  accountType: String!
-  bankBranch: String!
-  bankName: String!
+
+  """Name of the bank institution"""
+  bank: String!
+
+  """Account currency (e.g. JMD, USD)"""
   currency: String!
+
+  """ERPNext bank account identifier"""
+  id: ID!
+  isDefault: Boolean!
 }
 
 input BankAccountInput {
@@ -1521,6 +1528,9 @@ type UsdWallet implements Wallet {
 }
 
 type User {
+  """Bank accounts available for cashout"""
+  bankAccounts: [BankAccount!]!
+
   """
   Get single contact details.
   Can include the transactions associated with the contact.

--- a/src/graphql/public/types/object/bank-account.ts
+++ b/src/graphql/public/types/object/bank-account.ts
@@ -1,14 +1,46 @@
 import { GT } from "@graphql/index"
+import { BankAccount } from "@services/frappe/models/BankAccount"
+import { GraphQLObjectType } from "graphql"
 
-const BankAccount = GT.Object({
+const GraphQLBankAccount: GraphQLObjectType<BankAccount> = GT.Object({
   name: "BankAccount",
   fields: () => ({
-    bankName: { type: GT.NonNull(GT.String) },
-    bankBranch: { type: GT.NonNull(GT.String) },
-    accountType: { type: GT.NonNull(GT.String) },
-    currency: { type: GT.NonNull(GT.String) },
-    accountNumber: { type: GT.NonNull(GT.String) },
+    id: {
+      type: GT.NonNullID,
+      description: "ERPNext bank account identifier",
+      resolve: (o) => o.name,
+    },
+    accountName: {
+      type: GT.NonNull(GT.String),
+      resolve: (o) => o.account_name,
+    },
+    bank: {
+      type: GT.NonNull(GT.String),
+      description: "Name of the bank institution",
+      resolve: (o) => o.bank,
+    },
+    accountNumber: {
+      type: GT.NonNull(GT.String),
+      resolve: (o) => o.bank_account_no,
+    },
+    branchCode: {
+      type: GT.NonNull(GT.String),
+      resolve: (o) => o.branch_code,
+    },
+    accountType: {
+      type: GT.NonNull(GT.String),
+      resolve: (o) => o.account_type,
+    },
+    currency: {
+      type: GT.NonNull(GT.String),
+      description: "Account currency (e.g. JMD, USD)",
+      resolve: (o) => o.currency,
+    },
+    isDefault: {
+      type: GT.NonNull(GT.Boolean),
+      resolve: (o) => o.is_default === 1,
+    },
   }),
 })
 
-export default BankAccount
+export default GraphQLBankAccount

--- a/src/graphql/public/types/object/user.ts
+++ b/src/graphql/public/types/object/user.ts
@@ -25,6 +25,9 @@ import GraphQLEmail from "../../../shared/types/object/email"
 import AccountContact from "./account-contact"
 import UserQuizQuestion from "./user-quiz-question"
 import Npub from "@graphql/shared/types/scalar/npub"
+import GraphQLBankAccount from "./bank-account"
+import ErpNext from "@services/frappe/ErpNext"
+import { BankAccountQueryError } from "@services/frappe/errors"
 
 const GraphQLUser = GT.Object<User, GraphQLPublicContextAuth>({
   name: "User",
@@ -141,6 +144,20 @@ const GraphQLUser = GT.Object<User, GraphQLPublicContextAuth>({
       description: "Nostr public key",
       resolve: async (source, args, { domainAccount }) => {
         return domainAccount?.npub
+      },
+    },
+
+    bankAccounts: {
+      type: GT.NonNullList(GraphQLBankAccount),
+      description: "Bank accounts available for cashout",
+      resolve: async (_source, _args, { domainAccount }) => {
+        if (!domainAccount.erpParty) {
+          console.log("No ERP party associated with account, cannot fetch bank accounts")
+          return []
+        }
+        const accounts = await ErpNext.getBankAccountsByCustomer(domainAccount.erpParty)
+        if (accounts instanceof BankAccountQueryError) return []
+        return accounts
       },
     },
 

--- a/src/services/frappe/ErpNext.ts
+++ b/src/services/frappe/ErpNext.ts
@@ -13,6 +13,7 @@ import {
   UpgradeRequestCreateError,
   UpgradeRequestQueryError,
   BanksQueryError,
+  BankAccountQueryError,
   SetDocTypeValueError,
 } from "./errors"
 import {
@@ -20,6 +21,7 @@ import {
   RequestStatus,
 } from "./models/AccountUpgradeRequest"
 import { Bank } from "./models/Bank"
+import { BankAccount } from "./models/BankAccount"
 import { Filter } from "./SearchFilters"
 
 export type AccountUpgradeRequestFilters = { username?: Filter, status?: Filter }
@@ -242,6 +244,23 @@ class ErpNext {
         baseLogger.error({ err, names, status }, "Error bulk updating upgrade request status")
         return new SetDocTypeValueError(err)
       }
+    }
+  }
+
+  async getBankAccountsByCustomer(
+    customerName: string,
+  ): Promise<BankAccount[] | BankAccountQueryError> {
+    try {
+      const filters = `[["party_type","=","Customer"],["party","=","${customerName}"]]`
+      const fields = `["name","account_name","bank","bank_account_no","branch_code","account_type","currency","is_default"]`
+      const resp = await axios.get(
+        `${this.url}/api/resource/Bank%20Account?filters=${filters}&fields=${fields}`,
+        { headers: this.headers },
+      )
+      return resp.data?.data ?? []
+    } catch (err) {
+      baseLogger.error({ err, customerName }, "Error querying Bank Account from ERPNext")
+      return new BankAccountQueryError(err)
     }
   }
 

--- a/src/services/frappe/errors.ts
+++ b/src/services/frappe/errors.ts
@@ -9,3 +9,4 @@ export class UpgradeRequestCreateError extends ErpNextError {}
 export class UpgradeRequestQueryError extends ErpNextError {}
 export class SetDocTypeValueError extends ErpNextError {}
 export class BanksQueryError extends ErpNextError {}
+export class BankAccountQueryError extends ErpNextError {}

--- a/src/services/frappe/models/AccountUpgradeRequest.ts
+++ b/src/services/frappe/models/AccountUpgradeRequest.ts
@@ -1,7 +1,8 @@
 import { erpStringToLevel, levelToErpString } from "./AccountLevel"
 import { Validated, ValidationError, validator } from "@domain/shared"
 import { isActiveAccount } from "@domain/accounts"
-import { Address, BankAccount } from "@app/accounts"
+import { Address } from "@app/accounts"
+import { BankAccount } from "./BankAccount"
 
 export enum RequestStatus {
   Pending = "Pending",
@@ -85,11 +86,11 @@ export class AccountUpgradeRequest {
       pincode: this.address.postalCode,
       country: this.address.country,
       terminal_requested: this.terminalsRequested.toString(),
-      bank_name: this.bankAccount?.bankName,
-      bank_branch: this.bankAccount?.bankBranch,
-      account_type: this.bankAccount?.accountType,
+      bank_name: this.bankAccount?.bank,
+      bank_branch: this.bankAccount?.branch_code,
+      account_type: this.bankAccount?.account_type,
       currency: this.bankAccount?.currency,
-      account_number: this.bankAccount?.accountNumber,
+      account_number: this.bankAccount?.bank_account_no,
       id_document: this.idDocument,
     }
   }
@@ -116,11 +117,11 @@ export class AccountUpgradeRequest {
       },
       Number(data.terminal_requested) || 0,
       data.bank_name ? {
-        bankName: data.bank_name,
-        bankBranch: data.bank_branch,
-        accountType: data.account_type,
+        bank: data.bank_name,
+        branch_code: data.bank_branch,
+        account_type: data.account_type,
         currency: data.currency,
-        accountNumber: data.account_number,
+        bank_account_no: data.account_number,
       } : undefined
     )
   }

--- a/src/services/frappe/models/BankAccount.ts
+++ b/src/services/frappe/models/BankAccount.ts
@@ -1,0 +1,12 @@
+export type BankAccount = {
+  name?: string
+  account_name?: string
+  bank: string
+  bank_account_no: string
+  branch_code: string
+  account_type: string
+  currency: string
+  party_type?: string
+  party?: string
+  is_default?: 0 | 1
+}

--- a/test/flash/unit/services/frappe/models/AccountUpgradeRequest.spec.ts
+++ b/test/flash/unit/services/frappe/models/AccountUpgradeRequest.spec.ts
@@ -1,6 +1,7 @@
 import { AccountLevel, AccountStatus } from "@domain/accounts"
 import { ValidationError } from "@domain/shared"
-import { Address, BankAccount } from "@app/accounts"
+import { Address } from "@app/accounts"
+import { BankAccount } from "@services/frappe/models/BankAccount"
 import {
   AccountUpgradeRequest,
   RequestStatus,
@@ -17,11 +18,11 @@ const mockAddress: Address = {
 }
 
 const mockBankAccount: BankAccount = {
-  bankName: "Test Bank",
-  bankBranch: "Main Branch",
-  accountType: "Savings",
+  bank: "Test Bank",
+  branch_code: "Main Branch",
+  account_type: "Savings",
   currency: "USD",
-  accountNumber: 123456789,
+  bank_account_no: "123456789",
 }
 
 type RequestOverrides = {


### PR DESCRIPTION
- Add BankAccount frappe model with full ERPNext field set
- Add getBankAccountsByCustomer to ErpNext service
- Expose bankAccounts on the Me GraphQL type
- Unify domain BankAccount type with frappe model (snake_case fields), mapping camelCase at the GraphQL boundary via parseBankAccountInput
- Update AccountUpgradeRequest toErpnext/fromErpnext field names accordingly

Sample query:
```
query me {
    me {
      bankAccounts { id accountName bank currency }
    }
}
```

depends on: https://github.com/lnflash/frappe-flash-admin/pull/23