### PR TITLE
ENG-296: Align ETH-USDT Cash Wallet receive path

### DIFF
--- a/src/services/ibex/webhook-server/routes/crypto-receive.ts
+++ b/src/services/ibex/webhook-server/routes/crypto-receive.ts
@@ -21,8 +21,16 @@ interface CryptoReceiveResult {
 
 const cryptoReceiveHandler = async (req: Request, res: Response) => {
   const { tx_hash, address, amount, currency, network } = req.body
+  const normalizedCurrency = String(currency || "").toUpperCase()
+  const normalizedNetwork = String(network || "").toLowerCase()
 
-  if (!tx_hash || !address || !amount || currency !== "USDT" || network !== "tron") {
+  if (
+    !tx_hash ||
+    !address ||
+    !amount ||
+    normalizedCurrency !== "USDT" ||
+    normalizedNetwork !== "ethereum"
+  ) {
     baseLogger.warn(
       { tx_hash, address, amount, currency, network },
       "Invalid crypto receive payload",
@@ -44,8 +52,8 @@ const cryptoReceiveHandler = async (req: Request, res: Response) => {
           txHash: String(tx_hash),
           address: String(address),
           amount: String(amount),
-          currency: String(currency),
-          network: String(network),
+          currency: normalizedCurrency,
+          network: normalizedNetwork,
           accountId: account.id,
         })
         if (ibexLog instanceof Error) {
@@ -122,4 +130,4 @@ const cryptoReceiveHandler = async (req: Request, res: Response) => {
 
 router.post(paths.cryptoReceive, authenticate, logRequest, cryptoReceiveHandler)
 
-export { paths, router }
+export { cryptoReceiveHandler, paths, router }

--- a/test/flash/unit/services/ibex/webhook-server/routes/crypto-receive.spec.ts
+++ b/test/flash/unit/services/ibex/webhook-server/routes/crypto-receive.spec.ts
@@ -1,0 +1,113 @@
+jest.mock("@services/ibex/webhook-server/middleware", () => ({
+  authenticate: jest.fn((_req, _res, next) => next()),
+  logRequest: jest.fn((_req, _res, next) => next()),
+}))
+
+jest.mock("@services/mongoose/accounts", () => ({
+  AccountsRepository: jest.fn(),
+}))
+
+jest.mock("@services/mongoose/ibex-crypto-receive-log", () => ({
+  createIbexCryptoReceiveLog: jest.fn(),
+}))
+
+jest.mock("@app/wallets", () => ({
+  listWalletsByAccountId: jest.fn(),
+}))
+
+jest.mock("@services/logger", () => ({
+  baseLogger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}))
+
+jest.mock("@services/lock", () => ({
+  LockService: jest.fn(),
+}))
+
+import { cryptoReceiveHandler } from "@services/ibex/webhook-server/routes/crypto-receive"
+import { AccountsRepository } from "@services/mongoose/accounts"
+import { createIbexCryptoReceiveLog } from "@services/mongoose/ibex-crypto-receive-log"
+import { listWalletsByAccountId } from "@app/wallets"
+import { LockService } from "@services/lock"
+import { WalletCurrency } from "@domain/shared"
+
+const ACCOUNT_ID = "account-001" as AccountId
+const WALLET_ID = "wallet-usdt-001" as WalletId
+const ADDRESS = "0xabc123"
+const TX_HASH = "tx-001"
+
+const makeResponse = () => {
+  const res = {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+  }
+  return res
+}
+
+describe("cryptoReceiveHandler", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(LockService as jest.Mock).mockReturnValue({
+      lockPaymentHash: jest.fn((_hash, fn) => fn()),
+    })
+    ;(AccountsRepository as jest.Mock).mockReturnValue({
+      findByBridgeEthereumAddress: jest.fn().mockResolvedValue({ id: ACCOUNT_ID }),
+    })
+    ;(createIbexCryptoReceiveLog as jest.Mock).mockResolvedValue({ id: "log-001" })
+    ;(listWalletsByAccountId as jest.Mock).mockResolvedValue([
+      { id: WALLET_ID, currency: WalletCurrency.Usdt },
+    ])
+  })
+
+  it("accepts Ethereum USDT receive webhooks and normalizes persisted currency/network", async () => {
+    const res = makeResponse()
+
+    await cryptoReceiveHandler(
+      {
+        body: {
+          tx_hash: TX_HASH,
+          address: ADDRESS,
+          amount: "12.345678",
+          currency: "usdt",
+          network: "Ethereum",
+        },
+      } as never,
+      res as never,
+    )
+
+    expect(AccountsRepository().findByBridgeEthereumAddress).toHaveBeenCalledWith(ADDRESS)
+    expect(createIbexCryptoReceiveLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        txHash: TX_HASH,
+        address: ADDRESS,
+        amount: "12.345678",
+        currency: "USDT",
+        network: "ethereum",
+        accountId: ACCOUNT_ID,
+      }),
+    )
+    expect(res.status).toHaveBeenCalledWith(200)
+    expect(res.json).toHaveBeenCalledWith({ status: "success" })
+  })
+
+  it("rejects legacy Tron USDT receive webhooks for the ETH-USDT Cash Wallet path", async () => {
+    const res = makeResponse()
+
+    await cryptoReceiveHandler(
+      {
+        body: {
+          tx_hash: TX_HASH,
+          address: ADDRESS,
+          amount: "12.345678",
+          currency: "USDT",
+          network: "tron",
+        },
+      } as never,
+      res as never,
+    )
+
+    expect(LockService().lockPaymentHash).not.toHaveBeenCalled()
+    expect(createIbexCryptoReceiveLog).not.toHaveBeenCalled()
+    expect(res.status).toHaveBeenCalledWith(400)
+    expect(res.json).toHaveBeenCalledWith({ error: "Invalid payload" })
+  })
+})


### PR DESCRIPTION
Rebuilt on current `feature/bridge-integration` after ENG-394 landed.

ENG-296 is now narrowed to ETH-USDT Cash Wallet receive-path alignment. Wallet creation/defaulting is already handled by ENG-394, and Bridge virtual-account creation/query behavior is intentionally left to the dedicated Bridge VA tickets.

Changes:
- Accept IBEX `crypto.receive` webhooks for Ethereum USDT (`currency=USDT`, `network=ethereum`)
- Normalize persisted receive metadata to `USDT` / `ethereum`
- Reject stale Tron USDT payloads on this ETH-USDT Cash Wallet path
- Add focused unit coverage for Ethereum USDT receive handling

Tests:
- PASS: `LOGLEVEL=warn ../../node_modules/.bin/jest --config ./test/flash/unit/jest.config.js --bail --verbose test/flash/unit/services/ibex/webhook-server/routes/crypto-receive.spec.ts`
- PASS: `git diff --check`
- NOTE: full `tsc --noEmit -p tsconfig.d.json && tsc --noEmit` still fails on inherited baseline test/legacy-integration type errors unrelated to this PR.
