### PR TITLE
Fix JMD transaction display precision

### DIFF
--- a/src/app/accounts/get-transactions-for-account.ts
+++ b/src/app/accounts/get-transactions-for-account.ts
@@ -30,5 +30,9 @@ export const getTransactionsForAccountByWalletIds = async ({
     wallets.push(wallet)
   }
 
-  return getTransactionsForWallets({ wallets, paginationArgs })
+  return getTransactionsForWallets({
+    wallets,
+    paginationArgs,
+    displayCurrency: account.displayCurrency,
+  })
 }

--- a/src/app/wallets/get-transactions-for-wallet.ts
+++ b/src/app/wallets/get-transactions-for-wallet.ts
@@ -4,55 +4,94 @@ import { IbexError } from "@services/ibex/errors"
 import { baseLogger } from "@services/logger"
 import { GResponse200 } from "ibex-client"
 import { ConnectionArguments, ConnectionCursor } from "graphql-relay"
+import { ExchangeRates } from "@config"
+import {
+  getCurrencyMajorExponent,
+  SAT_PRICE_PRECISION_OFFSET,
+  UsdDisplayCurrency,
+  USD_PRICE_PRECISION_OFFSET,
+} from "@domain/fiat"
+import { WalletCurrency } from "@domain/shared"
 
 export const getTransactionsForWallets = async ({
   wallets,
   paginationArgs,
+  displayCurrency = UsdDisplayCurrency,
 }: {
   wallets: Wallet[]
   paginationArgs?: PaginationArgs
+  displayCurrency?: DisplayCurrency
 }): Promise<PartialResult<PaginatedArray<IbexTransaction>>> => {
   const walletIds = wallets.map((wallet) => wallet.id)
-  
-  const ibexCalls = await Promise.all(walletIds
-    .map(id => Ibex.getAccountTransactions({ 
-      account_id: id,
-      ...toIbexPaginationArgs(paginationArgs)
-    }))
+
+  const ibexCalls = await Promise.all(
+    walletIds.map((id) =>
+      Ibex.getAccountTransactions({
+        account_id: id,
+        ...toIbexPaginationArgs(paginationArgs),
+      }),
+    ),
   )
 
-  const transactions = ibexCalls.flatMap(resp => {
-    if (resp instanceof IbexError) return [] 
-    else return toWalletTransactions(resp)
+  const transactions = ibexCalls.flatMap((resp) => {
+    if (resp instanceof IbexError) return []
+    else return toWalletTransactions(resp, displayCurrency)
   })
 
   return PartialResult.ok({
     slice: transactions,
-    total: transactions.length
+    total: transactions.length,
   })
 }
 
-export const toWalletTransactions = (ibexResp: GResponse200): IbexTransaction[] => {
-  return ibexResp.map(trx => {
+export const toWalletTransactions = (
+  ibexResp: GResponse200,
+  displayCurrency: DisplayCurrency = UsdDisplayCurrency,
+): IbexTransaction[] => {
+  return ibexResp.map((trx) => {
     const currency = (trx.currencyId === 3 ? "USD" : "BTC") as WalletCurrency // WalletCurrency: "USD" | "BTC",
+    const signedSettlementAmount = toSettlementAmount(
+      trx.amount,
+      trx.transactionTypeId,
+      currency,
+    )
+    const settlementFee = asCurrency(trx.networkFee, currency)
 
-    const settlementDisplayPrice: WalletMinorUnitDisplayPrice<WalletCurrency, DisplayCurrency> = {
-      base: trx.exchangeRateCurrencySats ? BigInt(Math.floor(trx.exchangeRateCurrencySats)) : 0n,
-      offset: 0n, // what is this?
-      displayCurrency: "USD" as DisplayCurrency,
-      walletCurrency: currency
+    const settlementDisplayPrice: WalletMinorUnitDisplayPrice<
+      WalletCurrency,
+      DisplayCurrency
+    > = {
+      ...displayPriceFromMinorUnit({
+        displayMinorPerWalletMinorUnit: displayMinorPerWalletMinorUnit({
+          walletCurrency: currency,
+          displayCurrency,
+          usdMajorPerSat: trx.exchangeRateCurrencySats,
+        }),
+        displayCurrency,
+        walletCurrency: currency,
+      }),
     }
 
     const baseTrx: BaseWalletTransaction = {
-      walletId: (trx.accountId || "") as WalletId, 
-      settlementAmount: toSettlementAmount(trx.amount, trx.transactionTypeId, currency),
-      settlementFee: asCurrency(trx.networkFee, currency),
-      settlementCurrency: currency, 
-      settlementDisplayAmount: `${trx.amount}`, 
-      settlementDisplayFee: `${trx.networkFee}`, 
+      walletId: (trx.accountId || "") as WalletId,
+      settlementAmount: signedSettlementAmount,
+      settlementFee,
+      settlementCurrency: currency,
+      settlementDisplayAmount: toDisplayMajorAmount({
+        walletAmount: signedSettlementAmount,
+        walletCurrency: currency,
+        displayCurrency,
+        usdMajorPerSat: trx.exchangeRateCurrencySats,
+      }),
+      settlementDisplayFee: toDisplayMajorAmount({
+        walletAmount: settlementFee,
+        walletCurrency: currency,
+        displayCurrency,
+        usdMajorPerSat: trx.exchangeRateCurrencySats,
+      }),
       settlementDisplayPrice: settlementDisplayPrice,
       createdAt: trx.createdAt ? new Date(trx.createdAt) : new Date(), // should always return
-      id: trx.id || "null", // "LedgerTransactionId" - this is likely unused 
+      id: trx.id || "null", // "LedgerTransactionId" - this is likely unused
       status: "success" as TxStatus, // assuming Ibex returns on completed
       memo: null, // query transaction details
     }
@@ -63,68 +102,154 @@ export const toWalletTransactions = (ibexResp: GResponse200): IbexTransaction[] 
         return {
           ...baseTrx,
           // Ibex does not provide paymentHash, pubkey and preimage in transactions endpoint. To get these fields,
-          // we need to query the transaction details for each trx individually. 
-          initiationVia: { type: 'lightning', paymentHash: "", pubkey: "" },
-          settlementVia: { type: 'lightning', revealedPreImage: undefined }
+          // we need to query the transaction details for each trx individually.
+          initiationVia: { type: "lightning", paymentHash: "", pubkey: "" },
+          settlementVia: { type: "lightning", revealedPreImage: undefined },
         } as WalletLnSettledTransaction
       case 3:
       case 4:
         return {
           ...baseTrx,
           // Ibex does not provide paymentHash, pubkey and preimage in transactions endpoint. To get these fields,
-          // we need to query the transaction details for each trx individually. 
-          initiationVia: { type: 'onchain', address: "" },
-          settlementVia: { type: 'onchain', transactionHash: '', vout: undefined }
+          // we need to query the transaction details for each trx individually.
+          initiationVia: { type: "onchain", address: "" },
+          settlementVia: { type: "onchain", transactionHash: "", vout: undefined },
         } as WalletOnChainSettledTransaction // assuming Ibex only gives us settled
       default:
-        baseLogger.error(`Failed to parse Ibex transaction type. { WalletId: ${baseTrx.walletId}, TransactionId: ${trx.id}, transactionTypeId: ${trx.transactionTypeId}`)
-        return { 
+        baseLogger.error(
+          `Failed to parse Ibex transaction type. { WalletId: ${baseTrx.walletId}, TransactionId: ${trx.id}, transactionTypeId: ${trx.transactionTypeId}`,
+        )
+        return {
           ...baseTrx,
-          initiationVia: { type: 'unknown' },
-          settlementVia: { type: 'unknown' }
+          initiationVia: { type: "unknown" },
+          settlementVia: { type: "unknown" },
         } as UnknownTypeTransaction
     }
   })
 }
 
-const asCurrency = (amount: number | undefined, currency: WalletCurrency): Satoshis | UsdCents => {
-  return currency === "USD" ? amount as UsdCents : amount as Satoshis
+const jmdCentsPerUsdDollar = () => Number(ExchangeRates.jmd.sell.asCents())
+
+const displayPriceFromMinorUnit = <S extends WalletCurrency, T extends DisplayCurrency>({
+  displayMinorPerWalletMinorUnit,
+  displayCurrency,
+  walletCurrency,
+}: {
+  displayMinorPerWalletMinorUnit: number
+  displayCurrency: T
+  walletCurrency: S
+}): WalletMinorUnitDisplayPrice<S, T> => {
+  const offset =
+    walletCurrency === WalletCurrency.Btc
+      ? SAT_PRICE_PRECISION_OFFSET
+      : USD_PRICE_PRECISION_OFFSET
+
+  return {
+    base: BigInt(Math.round(displayMinorPerWalletMinorUnit * 10 ** offset)),
+    offset: BigInt(offset),
+    displayCurrency,
+    walletCurrency,
+  }
+}
+
+const displayMinorPerWalletMinorUnit = ({
+  walletCurrency,
+  displayCurrency,
+  usdMajorPerSat,
+}: {
+  walletCurrency: WalletCurrency
+  displayCurrency: DisplayCurrency
+  usdMajorPerSat: number | undefined
+}): number => {
+  if (walletCurrency === WalletCurrency.Usd) {
+    if (displayCurrency === UsdDisplayCurrency) return 1
+    if (displayCurrency === WalletCurrency.Jmd) return jmdCentsPerUsdDollar() / 100
+  }
+
+  const usdPerSat = usdMajorPerSat ?? 0
+  if (displayCurrency === WalletCurrency.Jmd) {
+    return usdPerSat * jmdCentsPerUsdDollar()
+  }
+
+  const displayMajorExponent = getCurrencyMajorExponent(displayCurrency)
+  return usdPerSat * 10 ** displayMajorExponent
+}
+
+const toDisplayMajorAmount = ({
+  walletAmount,
+  walletCurrency,
+  displayCurrency,
+  usdMajorPerSat,
+}: {
+  walletAmount: Satoshis | UsdCents
+  walletCurrency: WalletCurrency
+  displayCurrency: DisplayCurrency
+  usdMajorPerSat: number | undefined
+}): DisplayCurrencyMajorAmount => {
+  const displayMajorExponent = getCurrencyMajorExponent(displayCurrency)
+  const amount = Number(walletAmount ?? 0)
+  let displayMinorAmount: number
+
+  if (walletCurrency === WalletCurrency.Usd) {
+    displayMinorAmount =
+      displayCurrency === WalletCurrency.Jmd
+        ? (amount * jmdCentsPerUsdDollar()) / 100
+        : amount
+  } else {
+    displayMinorAmount =
+      amount *
+      displayMinorPerWalletMinorUnit({
+        walletCurrency,
+        displayCurrency,
+        usdMajorPerSat,
+      })
+  }
+
+  return (displayMinorAmount / 10 ** displayMajorExponent).toFixed(
+    displayMajorExponent,
+  ) as DisplayCurrencyMajorAmount
+}
+
+const asCurrency = (
+  amount: number | undefined,
+  currency: WalletCurrency,
+): Satoshis | UsdCents => {
+  return currency === "USD" ? (amount as UsdCents) : (amount as Satoshis)
 }
 
 const toSettlementAmount = (
-  ibexAmount: number | undefined, 
-  transactionTypeId: number | undefined, 
-  currency: WalletCurrency
+  ibexAmount: number | undefined,
+  transactionTypeId: number | undefined,
+  currency: WalletCurrency,
 ): Satoshis | UsdCents => {
   if (ibexAmount === undefined) {
     baseLogger.warn("Ibex did not return transaction amount")
-    return asCurrency(ibexAmount, currency) 
+    return asCurrency(ibexAmount, currency)
   }
   // When sending, make negative
-  const amt = (transactionTypeId === 2 || transactionTypeId === 4) 
-    ? -1 * ibexAmount 
-    : ibexAmount
+  const amt =
+    transactionTypeId === 2 || transactionTypeId === 4 ? -1 * ibexAmount : ibexAmount
   return asCurrency(amt, currency)
 }
 
 enum SortOrder {
   RECENT = "settledAt",
-  OLDEST = "-settledAt"
+  OLDEST = "-settledAt",
 }
 
 type IbexPaginationArgs = {
-  page?: number | undefined; // ibex default (0) start at page 0
-  limit?: number | undefined; // ibex default (0) returns all
-  sort?: SortOrder | undefined; // defaults to SortOrder.RECENT
+  page?: number | undefined // ibex default (0) start at page 0
+  limit?: number | undefined // ibex default (0) returns all
+  sort?: SortOrder | undefined // defaults to SortOrder.RECENT
 }
 
 export function toIbexPaginationArgs(
-  args: ConnectionArguments | undefined
+  args: ConnectionArguments | undefined,
 ): IbexPaginationArgs {
   const DEFAULTS = {
-    page: 0, 
-    limit: 0, 
-    sort: SortOrder.RECENT, 
+    page: 0,
+    limit: 0,
+    sort: SortOrder.RECENT,
   }
 
   // Prefer 'first' over 'last')
@@ -132,13 +257,13 @@ export function toIbexPaginationArgs(
     return {
       ...DEFAULTS,
       limit: args.first,
-      sort: SortOrder.RECENT, 
+      sort: SortOrder.RECENT,
     }
   } else if (args && args.last != null) {
     return {
       ...DEFAULTS,
       limit: args.last,
-      sort: SortOrder.OLDEST, 
+      sort: SortOrder.OLDEST,
     }
   } else return DEFAULTS
 }

--- a/src/graphql/shared/types/object/btc-wallet.ts
+++ b/src/graphql/shared/types/object/btc-wallet.ts
@@ -7,7 +7,7 @@ import {
 } from "@graphql/connections"
 import { mapError } from "@graphql/error-map"
 
-import { Wallets } from "@app"
+import { Accounts, Wallets } from "@app"
 
 import { WalletCurrency as WalletCurrencyDomain } from "@domain/shared"
 
@@ -46,11 +46,11 @@ const BtcWallet = GT.Object<Wallet>({
       type: GT.NonNull(FractionalCentAmount),
       description: "A balance stored in BTC.",
       resolve: async (source) => {
-        const balanceSats = await Wallets.getBalanceForWallet({ walletId: source.id })
-        if (balanceSats instanceof Error) {
-          throw mapError(balanceSats)
+        const balance = await Wallets.getBalanceForWallet({ walletId: source.id })
+        if (balance instanceof Error) {
+          throw mapError(balance)
         }
-        return balanceSats
+        return Number(balance.asCents(8))
       },
     },
     pendingIncomingBalance: {
@@ -73,9 +73,15 @@ const BtcWallet = GT.Object<Wallet>({
           throw paginationArgs
         }
 
+        const account = await Accounts.getAccount(source.accountId)
+        if (account instanceof Error) {
+          throw mapError(account)
+        }
+
         const { result, error } = await Wallets.getTransactionsForWallets({
           wallets: [source],
           paginationArgs,
+          displayCurrency: account.displayCurrency,
         })
         if (error instanceof Error) {
           throw mapError(error)

--- a/src/graphql/shared/types/object/usd-wallet.ts
+++ b/src/graphql/shared/types/object/usd-wallet.ts
@@ -7,7 +7,7 @@ import {
 import { normalizePaymentAmount } from "@graphql/shared/root/mutation"
 import { mapError } from "@graphql/error-map"
 
-import { Wallets } from "@app"
+import { Accounts, Wallets } from "@app"
 
 import { WalletCurrency as WalletCurrencyDomain } from "@domain/shared"
 
@@ -39,12 +39,12 @@ const UsdWallet = GT.Object<Wallet>({
       type: GT.NonNull(WalletCurrency),
       resolve: (source) => source.currency,
     },
-    
+
     lnurlp: {
       type: Lnurl,
       resolve: (source) => source.lnurlp,
     },
-    
+
     balance: {
       type: GT.NonNull(FractionalCentAmount),
       resolve: async (source) => {
@@ -75,9 +75,15 @@ const UsdWallet = GT.Object<Wallet>({
           throw paginationArgs
         }
 
+        const account = await Accounts.getAccount(source.accountId)
+        if (account instanceof Error) {
+          throw mapError(account)
+        }
+
         const { result, error } = await Wallets.getTransactionsForWallets({
           wallets: [source],
           paginationArgs,
+          displayCurrency: account.displayCurrency,
         })
         if (error instanceof Error) {
           throw mapError(error)

--- a/src/services/price/index.ts
+++ b/src/services/price/index.ts
@@ -14,7 +14,13 @@ import { WalletCurrency } from "@domain/shared"
 
 import { CENTS_PER_USD, UsdDisplayCurrency } from "@domain/fiat"
 
-import { PRICE_HISTORY_HOST, PRICE_HISTORY_PORT, PRICE_HOST, PRICE_PORT } from "@config"
+import {
+  ExchangeRates,
+  PRICE_HISTORY_HOST,
+  PRICE_HISTORY_PORT,
+  PRICE_HOST,
+  PRICE_PORT,
+} from "@config"
 
 import { baseLogger } from "../logger"
 
@@ -83,6 +89,14 @@ export const PriceService = (): IPriceService => {
 
       let displayCurrencyPrice = price / SATS_PER_BTC
       if (walletCurrency === WalletCurrency.Usd) {
+        if (displayCurrency === ("JMD" as DisplayCurrency)) {
+          return {
+            timestamp: new Date(),
+            price: Number(ExchangeRates.jmd.sell.asDollars()) / CENTS_PER_USD,
+            currency: displayCurrency,
+          }
+        }
+
         const { price: usdBtcPrice } = await getPrice({
           currency: UsdDisplayCurrency,
         })

--- a/test/flash/unit/app/wallets/get-transactions-for-wallet.spec.ts
+++ b/test/flash/unit/app/wallets/get-transactions-for-wallet.spec.ts
@@ -1,0 +1,58 @@
+import { ExchangeRates } from "@config"
+import { toWalletTransactions } from "@app/wallets/get-transactions-for-wallet"
+
+const jmdCentsPerUsdDollar = () => Number(ExchangeRates.jmd.sell.asCents())
+
+const usdCentsForJmdMajor = (jmdMajor: number) =>
+  (jmdMajor * 100 * 100) / jmdCentsPerUsdDollar()
+
+const ibexUsdTransaction = (amount: number) =>
+  [
+    {
+      accountId: "wallet-id",
+      amount,
+      createdAt: "2026-03-20T00:00:00.000Z",
+      currencyId: 3,
+      exchangeRateCurrencySats: 0.001,
+      id: `tx-${amount}`,
+      networkFee: 0,
+      transactionTypeId: 1,
+    },
+  ] as Parameters<typeof toWalletTransactions>[0]
+
+describe("toWalletTransactions", () => {
+  it.each([
+    [15.15, "15.15"],
+    [100, "100.00"],
+    [12_500.01, "12500.01"],
+  ])("returns JMD settlement display amount for JMD$%s", (jmdMajor, expected) => {
+    const [transaction] = toWalletTransactions(
+      ibexUsdTransaction(usdCentsForJmdMajor(jmdMajor)),
+      "JMD" as DisplayCurrency,
+    )
+
+    expect(transaction.settlementDisplayAmount).toBe(expected)
+    expect(transaction.settlementDisplayPrice.displayCurrency).toBe("JMD")
+  })
+
+  it("uses a precise non-zero settlement display price for sub-cent BTC rates", () => {
+    const [transaction] = toWalletTransactions(
+      [
+        {
+          accountId: "wallet-id",
+          amount: 1,
+          createdAt: "2026-03-20T00:00:00.000Z",
+          currencyId: 1,
+          exchangeRateCurrencySats: 0.001,
+          id: "btc-tx",
+          networkFee: 0,
+          transactionTypeId: 1,
+        },
+      ] as Parameters<typeof toWalletTransactions>[0],
+      "JMD" as DisplayCurrency,
+    )
+
+    expect(transaction.settlementDisplayPrice.base).toBeGreaterThan(0n)
+    expect(transaction.settlementDisplayPrice.displayCurrency).toBe("JMD")
+  })
+})


### PR DESCRIPTION
## Summary

Part of #282 / #284 / #267.

This fixes the backend side of the JMD transaction-history precision bundle:

- passes the account display currency into Ibex transaction mapping for account and wallet transaction resolvers
- computes settlement display amounts/fees from the user's display currency instead of returning raw Ibex USD values
- uses rounded price-ratio bases with the same BTC/USD precision offsets as the realtime price API
- derives USD-wallet -> JMD pricing from `ExchangeRates.jmd.sell` instead of triangulating through BTC
- serializes `BtcWallet.balance` as a numeric satoshi amount instead of returning a domain object

## Tests

- Added unit coverage for canonical JMD amounts: JMD$15.15, JMD$100.00, and JMD$12,500.01.
- Added coverage for non-zero BTC display price ratios at sub-cent rates.
- Ran `prettier --check` on changed files.

I could not run the Jest suite locally because this checkout has no `node_modules`; the changed files are formatted and the tests are included for CI.
