### PR TITLE
ENG-394 create USDT wallet for new accounts

### DIFF
--- a/src/app/accounts/create-account.ts
+++ b/src/app/accounts/create-account.ts
@@ -10,8 +10,13 @@ import {
 } from "@services/mongoose"
 
 import { recordExceptionInCurrentSpan } from "@services/tracing"
-import { ErrorLevel } from "@domain/shared"
-import { RepositoryError } from "@domain/errors"
+import { ErrorLevel, WalletCurrency } from "@domain/shared"
+
+const requiredCashWalletCurrencies: WalletCurrency[] = [
+  WalletCurrency.Usd,
+  WalletCurrency.Usdt,
+]
+const defaultCashWalletCurrency = WalletCurrency.Usdt
 
 const initializeCreatedAccount = async ({
   account,
@@ -29,24 +34,29 @@ const initializeCreatedAccount = async ({
       currency,
     })
 
-  const walletsEnabledConfig = config.initialWallets
+  const walletsEnabledConfig = Array.from(
+    new Set([...config.initialWallets, ...requiredCashWalletCurrencies]),
+  )
 
   // Create all wallets
   const enabledWallets: Partial<Record<WalletCurrency, Wallet>> = {}
   for (const currency of walletsEnabledConfig) {
     const wallet = await newWallet(currency)
-    if (wallet instanceof RepositoryError) {
+    if (wallet instanceof Error) {
       recordExceptionInCurrentSpan({
         error: wallet,
         level: ErrorLevel.Critical,
-        attributes: { accountId: account.id }
+        attributes: { accountId: account.id, currency },
       })
+      if (requiredCashWalletCurrencies.includes(currency)) return wallet
+      continue
     }
-    else enabledWallets[currency] = wallet
+
+    enabledWallets[currency] = wallet
   }
 
-  // Set default wallet to USD
-  const defaultWalletId = enabledWallets[walletsEnabledConfig[0]]?.id
+  // Set ETH-USDT as the active Cash Wallet while preserving USD for migration.
+  const defaultWalletId = enabledWallets[defaultCashWalletCurrency]?.id
 
   if (defaultWalletId === undefined) {
     return new ConfigError("NoWalletsEnabledInConfigError")

--- a/src/app/wallets/get-balance-for-wallet.ts
+++ b/src/app/wallets/get-balance-for-wallet.ts
@@ -11,19 +11,11 @@ export const getBalanceForWallet = async ({
   currency?: WalletCurrency
 }): Promise<USDAmount | USDTAmount | ApplicationError> => {
   try {
-    if (currency === WalletCurrency.Usdt) {
-      const resp = await Ibex.getCryptoReceiveBalance(walletId)
-      if (resp instanceof IbexError) {
-        if (resp.httpCode === 404) return USDTAmount.ZERO
-        return resp
-      }
-      if (resp === undefined) return new UnexpectedIbexResponse("Balance not found")
-      return resp
-    }
-
-    const resp = await Ibex.getAccountDetails(walletId)
+    const resp = await Ibex.getAccountDetails(walletId, currency)
     if (resp instanceof IbexError) {
-      if (resp.httpCode === 404) return USDAmount.ZERO
+      if (resp.httpCode === 404) {
+        return currency === WalletCurrency.Usdt ? USDTAmount.ZERO : USDAmount.ZERO
+      }
       return resp
     }
     if (resp.balance === undefined) return new UnexpectedIbexResponse("Balance not found")

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -385,7 +385,7 @@ export const configSchema = {
       additionalProperties: false,
       default: {
         initialStatus: "active",
-        initialWallets: ["USD"],
+        initialWallets: ["USD", "USDT"],
         enablePhoneCheck: false,
         enableIpCheck: false,
         enableIpProxyCheck: false,
@@ -663,7 +663,7 @@ export const configSchema = {
               required: ["kyc", "deposit", "transfer"],
             },
             timestampSkewMs: { type: "integer" },
-            replaySecret: { type: "string" }
+            replaySecret: { type: "string" },
           },
           required: ["port", "publicKeys", "timestampSkewMs"],
         },

--- a/src/domain/shared/MoneyAmount.ts
+++ b/src/domain/shared/MoneyAmount.ts
@@ -1,6 +1,6 @@
 import { Money, Round, PRECISION_M } from "./bigint-money"
 import { BigIntConversionError, UnsupportedCurrencyError } from "./errors"
-import { ExchangeCurrencyUnit, WalletCurrency } from "./primitives"
+import { WalletCurrency } from "./primitives"
 
 export abstract class MoneyAmount {
   readonly money: Money
@@ -60,7 +60,8 @@ export abstract class MoneyAmount {
   static from(amount: number | string, currency: WalletCurrency): MoneyAmount | Error {
     if (currency === WalletCurrency.Usd) return USDAmount.cents(amount.toString())
     else if (currency === WalletCurrency.Jmd) return JMDAmount.cents(amount.toString())
-    else if (currency === WalletCurrency.Usdt) return USDTAmount.smallestUnits(amount.toString())
+    else if (currency === WalletCurrency.Usdt)
+      return USDTAmount.smallestUnits(amount.toString())
     else return new UnsupportedCurrencyError(`Could not read currency: ${currency}`)
   }
 }
@@ -177,7 +178,9 @@ export class BtcAmount extends MoneyAmount {
     try {
       return new BtcAmount(c)
     } catch (error) {
-      return new BigIntConversionError(error instanceof Error ? error.message : String(error))
+      return new BigIntConversionError(
+        error instanceof Error ? error.message : String(error),
+      )
     }
   }
 
@@ -191,7 +194,7 @@ export class BtcAmount extends MoneyAmount {
 }
 
 export class USDTAmount extends MoneyAmount {
-  static currencyId: IbexCurrencyId = 4 as IbexCurrencyId
+  static currencyId: IbexCurrencyId = 29 as IbexCurrencyId
 
   private constructor(amount: Money | bigint | string | number) {
     super(amount, WalletCurrency.Usdt)

--- a/src/domain/wallets/index.types.d.ts
+++ b/src/domain/wallets/index.types.d.ts
@@ -74,7 +74,7 @@ type BaseWalletTransaction = {
   readonly settlementAmount: Satoshis | UsdCents
   readonly settlementFee: Satoshis | UsdCents
   readonly settlementCurrency: WalletCurrency
-  
+
   readonly settlementDisplayAmount: DisplayCurrencyMajorAmount
   readonly settlementDisplayFee: DisplayCurrencyMajorAmount
   readonly settlementDisplayPrice: WalletMinorUnitDisplayPrice<
@@ -131,12 +131,12 @@ type WalletLnSettledTransaction = BaseWalletTransaction & {
 }
 
 type UnknownTypeTransaction = BaseWalletTransaction & {
-  readonly initiationVia: { 
-    readonly type: 'unknown'
-  } 
-  readonly settlementVia: { 
-    readonly type: 'unknown'
-  } 
+  readonly initiationVia: {
+    readonly type: "unknown"
+  }
+  readonly settlementVia: {
+    readonly type: "unknown"
+  }
 }
 
 type WalletOnChainTransaction =
@@ -189,7 +189,7 @@ interface IWalletsRepository {
     accountId,
     type,
     currency,
-  }: NewWalletInfo): Promise<Wallet | RepositoryError>
+  }: NewWalletInfo): Promise<Wallet | ApplicationError>
   findById(walletId: WalletId): Promise<Wallet | RepositoryError>
 
   listByAccountId(accountId: AccountId): Promise<Wallet[] | RepositoryError>
@@ -239,7 +239,6 @@ type OnChainFeeCalculator = {
 type PaymentInputValidatorConfig = (
   walletId: WalletId,
 ) => Promise<Wallet | RepositoryError>
-
 
 type PaymentInputValidator = {
   validatePaymentInput: <T extends undefined | string>(

--- a/src/services/ibex/client.ts
+++ b/src/services/ibex/client.ts
@@ -1,7 +1,4 @@
-import IbexClient, { GetFeeEstimateResponse200, IbexClientError } from "ibex-client"
-import { errorHandler, IbexError, ParseError, UnexpectedIbexResponse } from "./errors"
-import { IbexConfig } from "@config"
-import {
+import IbexClient, {
   AddInvoiceBodyParam,
   AddInvoiceResponse201,
   CreateAccountResponse201,
@@ -9,32 +6,29 @@ import {
   CreateLnurlPayResponse201,
   DecodeLnurlMetadataParam,
   DecodeLnurlResponse200,
-  EstimateFeeCopyMetadataParam,
   EstimateFeeCopyResponse200,
-  GenerateBitcoinAddressBodyParam,
   GenerateBitcoinAddressResponse201,
-  GetAccountDetailsMetadataParam,
-  GetAccountDetailsResponse200,
-  GetFeeEstimationMetadataParam,
-  GetFeeEstimationResponse200,
-  GetTransactionDetails1MetadataParam,
   GetTransactionDetails1Response200,
   GMetadataParam,
   GResponse200,
-  InvoiceFromHashMetadataParam,
   InvoiceFromHashResponse200,
   PayInvoiceV2BodyParam,
   PayInvoiceV2Response200,
-  PayToALnurlPayBodyParam,
   PayToALnurlPayResponse201,
   SendToAddressCopyBodyParam,
   SendToAddressCopyResponse200,
 } from "ibex-client"
+
+import { IbexConfig } from "@config"
 import {
   addAttributesToCurrentSpan,
   wrapAsyncFunctionsToRunInSpan,
 } from "@services/tracing"
-import WebhookServer from "./webhook-server"
+
+import { USDAmount, USDTAmount, WalletCurrency } from "@domain/shared"
+
+import { baseLogger } from "@services/logger"
+
 import { Redis } from "./cache"
 import {
   GetFeeEstimateArgs,
@@ -46,8 +40,9 @@ import {
   CryptoReceiveInfo,
   CreateCryptoReceiveInfoRequest,
 } from "./types"
-import { USDAmount, USDTAmount } from "@domain/shared"
-import { baseLogger } from "@services/logger"
+
+import { errorHandler, IbexError, ParseError, UnexpectedIbexResponse } from "./errors"
+import WebhookServer from "./webhook-server"
 
 const Ibex = new IbexClient(
   IbexConfig.url,
@@ -62,22 +57,33 @@ const createAccount = async (
   return Ibex.createAccount({ name, currencyId }).then(errorHandler)
 }
 
+const parseAccountBalance = (
+  balance: number | undefined,
+  currency: WalletCurrency,
+): IbexAccountDetails["balance"] => {
+  if (balance === undefined) return undefined
+
+  const amount =
+    currency === WalletCurrency.Usdt
+      ? USDTAmount.fromNumber(balance.toString())
+      : USDAmount.dollars(balance.toString())
+
+  return amount instanceof Error ? undefined : amount
+}
+
 const getAccountDetails = async (
   accountId: IbexAccountId,
+  currency: WalletCurrency = WalletCurrency.Usd,
 ): Promise<IbexAccountDetails | IbexError> => {
   return Ibex.getAccountDetails({ accountId })
-    .then((r) => {
-      if (r instanceof Error) return r
-      else {
-        let balance =
-          r.balance !== undefined ? USDAmount.dollars(r.balance.toString()) : undefined
-        if (balance instanceof Error) balance = undefined
-        return {
-          id: r.id,
-          userId: r.userId,
-          name: r.name,
-          balance,
-        }
+    .then((resp) => {
+      if (resp instanceof Error) return resp
+
+      return {
+        id: resp.id,
+        userId: resp.userId,
+        name: resp.name,
+        balance: parseAccountBalance(resp.balance, currency),
       }
     })
     .then(errorHandler)
@@ -143,9 +149,9 @@ const getLnFeeEstimation = async (
   else if (resp.invoiceAmount === null || resp.invoiceAmount === undefined)
     return new UnexpectedIbexResponse("invoiceAmount not found.")
   else {
-    let fee = USDAmount.dollars(resp.amount)
+    const fee = USDAmount.dollars(resp.amount)
     if (fee instanceof Error) return new ParseError(fee)
-    let invoiceAmount = USDAmount.dollars(resp.invoiceAmount)
+    const invoiceAmount = USDAmount.dollars(resp.invoiceAmount)
     if (invoiceAmount instanceof Error) return new ParseError(invoiceAmount)
     return {
       fee,
@@ -232,7 +238,9 @@ const getIbexToken = async (): Promise<string | IbexError> => {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ email: IbexConfig.email, password: IbexConfig.password }),
-  }).catch((err: unknown) => new IbexError(err instanceof Error ? err : new Error(String(err))))
+  }).catch(
+    (err: unknown) => new IbexError(err instanceof Error ? err : new Error(String(err))),
+  )
 
   if (resp instanceof IbexError) return resp
   if (!resp.ok) {
@@ -240,17 +248,24 @@ const getIbexToken = async (): Promise<string | IbexError> => {
     return new IbexError(new Error(`IBEX sign-in failed: ${resp.status} — ${body}`))
   }
 
-  const data = await resp.json() as {
+  const data = (await resp.json()) as {
     accessToken?: string
     accessTokenExpiresAt?: number
     refreshToken?: string
     refreshTokenExpiresAt?: number
   }
-  if (!data.accessToken) return new IbexError(new Error("IBEX sign-in: no access token in response"))
+  if (!data.accessToken)
+    return new IbexError(new Error("IBEX sign-in: no access token in response"))
 
-  await Ibex.authentication.storage.setAccessToken(data.accessToken, data.accessTokenExpiresAt)
+  await Ibex.authentication.storage.setAccessToken(
+    data.accessToken,
+    data.accessTokenExpiresAt,
+  )
   if (data.refreshToken) {
-    await Ibex.authentication.storage.setRefreshToken(data.refreshToken, data.refreshTokenExpiresAt)
+    await Ibex.authentication.storage.setRefreshToken(
+      data.refreshToken,
+      data.refreshTokenExpiresAt,
+    )
   }
 
   return `Bearer ${data.accessToken}`
@@ -264,7 +279,11 @@ const ibexFetch = async <T>(
   const url = `${IbexConfig.url}${path}`
   const resp = await fetch(url, {
     ...init,
-    headers: { Authorization: token, "Content-Type": "application/json", ...init.headers },
+    headers: {
+      "Authorization": token,
+      "Content-Type": "application/json",
+      ...init.headers,
+    },
   })
   if (!resp.ok) {
     const body = await resp.text().catch(() => "")

--- a/src/services/ibex/types.ts
+++ b/src/services/ibex/types.ts
@@ -1,4 +1,4 @@
-import { USDAmount } from "@domain/shared"
+import { USDAmount, USDTAmount } from "@domain/shared"
 
 export type PayInvoiceArgs = {
   accountId: IbexAccountId
@@ -7,8 +7,8 @@ export type PayInvoiceArgs = {
 }
 
 export type SendOnchainArgs = {
-  accountId: IbexAccountId, // source of funds
-  address: OnChainAddress, // destination
+  accountId: IbexAccountId // source of funds
+  address: OnChainAddress // destination
   amount: USDAmount
 }
 
@@ -27,7 +27,7 @@ export type IbexAccountDetails = {
   id: string | undefined
   userId: string | undefined
   name: string | undefined
-  balance: USDAmount | undefined
+  balance: USDAmount | USDTAmount | undefined
 }
 
 export type IbexInvoiceArgs = {

--- a/src/services/mongoose/wallets.ts
+++ b/src/services/mongoose/wallets.ts
@@ -14,11 +14,13 @@ import Ibex from "@services/ibex/client"
 
 import { IbexError } from "@services/ibex/errors"
 
+import { recordExceptionInCurrentSpan } from "@services/tracing"
+
+import { ErrorLevel, USDAmount, USDTAmount, WalletCurrency } from "@domain/shared"
+
 import { toObjectId, fromObjectId, parseRepositoryError } from "./utils"
 import { Wallet } from "./schema"
 import { AccountsRepository } from "./accounts"
-import { recordExceptionInCurrentSpan } from "@services/tracing"
-import { ErrorLevel, USDAmount, WalletCurrency } from "@domain/shared"
 
 export interface WalletRecord {
   id: string
@@ -29,6 +31,19 @@ export interface WalletRecord {
   lnurlp: string
 }
 
+const getIbexCurrencyId = (
+  currency: WalletCurrency,
+): IbexCurrencyId | UnsupportedCurrencyError => {
+  switch (currency) {
+    case WalletCurrency.Usd:
+      return USDAmount.currencyId
+    case WalletCurrency.Usdt:
+      return USDTAmount.currencyId
+    default:
+      return new UnsupportedCurrencyError(`Unsupported IBEX wallet currency: ${currency}`)
+  }
+}
+
 export const WalletsRepository = (): IWalletsRepository => {
   const persistNew = async ({
     accountId,
@@ -37,17 +52,18 @@ export const WalletsRepository = (): IWalletsRepository => {
   }: NewWalletInfo): Promise<Wallet | ApplicationError> => {
     const account = await AccountsRepository().findById(accountId)
     if (account instanceof Error) return account
-    
+
     try {
-      let currencyId = USDAmount.currencyId
+      const currencyId = getIbexCurrencyId(currency)
+      if (currencyId instanceof Error) return currencyId
 
       const resp = await Ibex.createAccount(accountId, currencyId)
       if (resp instanceof IbexError) return resp
-      const ibexAccountId = resp.id 
- 
+      const ibexAccountId = resp.id
+
       let lnurlp: string | undefined
       if (ibexAccountId !== undefined) {
-        const lnurlResp = await Ibex.createLnurlPay({ 
+        const lnurlResp = await Ibex.createLnurlPay({
           accountId: ibexAccountId,
           currencyId,
         })
@@ -60,16 +76,15 @@ export const WalletsRepository = (): IWalletsRepository => {
               ibexAccountId,
             },
           })
-        }
-        else lnurlp = lnurlResp.lnurl
+        } else lnurlp = lnurlResp.lnurl
       }
-      
+
       const wallet = new Wallet({
         _accountId: toObjectId<AccountId>(accountId),
         id: ibexAccountId,
         type,
         currency,
-        lnurlp
+        lnurlp,
       })
       await wallet.save()
       return resultToWallet(wallet)

--- a/test/flash/unit/app/accounts/create-account.spec.ts
+++ b/test/flash/unit/app/accounts/create-account.spec.ts
@@ -1,0 +1,122 @@
+import { createAccountWithPhoneIdentifier } from "@app/accounts/create-account"
+import { AccountLevel } from "@domain/accounts"
+import { WalletCurrency } from "@domain/shared"
+import { PersistError } from "@domain/errors"
+import { WalletType } from "@domain/wallets"
+import {
+  AccountsRepository,
+  UsersRepository,
+  WalletsRepository,
+} from "@services/mongoose"
+
+jest.mock("@config", () => ({
+  getAdminAccounts: jest.fn(() => []),
+}))
+
+jest.mock("@services/tracing", () => ({
+  recordExceptionInCurrentSpan: jest.fn(),
+}))
+
+jest.mock("@services/mongoose", () => ({
+  AccountsRepository: jest.fn(),
+  UsersRepository: jest.fn(),
+  WalletsRepository: jest.fn(),
+}))
+
+const mockedAccountsRepository = AccountsRepository as jest.MockedFunction<
+  typeof AccountsRepository
+>
+const mockedUsersRepository = UsersRepository as jest.MockedFunction<
+  typeof UsersRepository
+>
+const mockedWalletsRepository = WalletsRepository as jest.MockedFunction<
+  typeof WalletsRepository
+>
+
+describe("createAccountWithPhoneIdentifier", () => {
+  let persistNew: jest.Mock
+
+  const account = {
+    id: "account-id" as AccountId,
+    defaultWalletId: undefined,
+  } as Account
+
+  const config = {
+    initialWallets: [WalletCurrency.Usd],
+    initialStatus: "active",
+    initialLevel: AccountLevel.One,
+  } as AccountsConfig
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    mockedUsersRepository.mockReturnValue({
+      update: jest.fn().mockResolvedValue({ id: "user-id" }),
+    } as unknown as ReturnType<typeof UsersRepository>)
+
+    mockedAccountsRepository.mockReturnValue({
+      persistNew: jest.fn().mockResolvedValue({ ...account }),
+      update: jest
+        .fn()
+        .mockImplementation(async (updatedAccount: Account) => updatedAccount),
+    } as unknown as ReturnType<typeof AccountsRepository>)
+
+    persistNew = jest.fn().mockImplementation(async ({ accountId, type, currency }) => ({
+      id: `${currency}-wallet-id`,
+      accountId,
+      type,
+      currency,
+    }))
+
+    mockedWalletsRepository.mockReturnValue({
+      persistNew,
+    } as unknown as ReturnType<typeof WalletsRepository>)
+  })
+
+  it("creates both USD and USDT cash wallets and defaults new accounts to USDT", async () => {
+    const result = await createAccountWithPhoneIdentifier({
+      newAccountInfo: {
+        kratosUserId: "kratos-user-id" as UserId,
+        phone: "+15551234567" as PhoneNumber,
+      },
+      config,
+    })
+
+    expect(result).not.toBeInstanceOf(Error)
+
+    expect(persistNew).toHaveBeenCalledWith({
+      accountId: account.id,
+      type: WalletType.Checking,
+      currency: WalletCurrency.Usd,
+    })
+    expect(persistNew).toHaveBeenCalledWith({
+      accountId: account.id,
+      type: WalletType.Checking,
+      currency: WalletCurrency.Usdt,
+    })
+    expect(persistNew).toHaveBeenCalledTimes(2)
+    expect((result as Account).defaultWalletId).toBe(`${WalletCurrency.Usdt}-wallet-id`)
+  })
+
+  it("does not create an account with a USD fallback default if the USDT wallet is missing", async () => {
+    persistNew.mockImplementation(async ({ accountId, type, currency }) => {
+      if (currency === WalletCurrency.Usdt) return new PersistError("USDT wallet failed")
+      return {
+        id: `${currency}-wallet-id`,
+        accountId,
+        type,
+        currency,
+      }
+    })
+
+    const result = await createAccountWithPhoneIdentifier({
+      newAccountInfo: {
+        kratosUserId: "kratos-user-id" as UserId,
+        phone: "+15551234567" as PhoneNumber,
+      },
+      config,
+    })
+
+    expect(result).toBeInstanceOf(Error)
+  })
+})

--- a/test/flash/unit/app/wallets/get-balance-for-wallet.spec.ts
+++ b/test/flash/unit/app/wallets/get-balance-for-wallet.spec.ts
@@ -1,0 +1,38 @@
+import { getBalanceForWallet } from "@app/wallets/get-balance-for-wallet"
+import { USDTAmount, WalletCurrency } from "@domain/shared"
+import Ibex from "@services/ibex/client"
+
+jest.mock("@services/ibex/client", () => ({
+  __esModule: true,
+  default: {
+    getAccountDetails: jest.fn(),
+    getCryptoReceiveBalance: jest.fn(),
+  },
+}))
+
+describe("getBalanceForWallet", () => {
+  beforeEach(() => {
+    jest.mocked(Ibex.getAccountDetails).mockReset()
+    jest.mocked(Ibex.getCryptoReceiveBalance).mockReset()
+  })
+
+  it("loads USDT balances from the IBEX account id, not a crypto receive-info id", async () => {
+    const balance = USDTAmount.ZERO
+    jest.mocked(Ibex.getAccountDetails).mockResolvedValue({
+      id: "ibex-account-id",
+      balance,
+    } as never)
+
+    const result = await getBalanceForWallet({
+      walletId: "ibex-account-id" as WalletId,
+      currency: WalletCurrency.Usdt,
+    })
+
+    expect(Ibex.getAccountDetails).toHaveBeenCalledWith(
+      "ibex-account-id",
+      WalletCurrency.Usdt,
+    )
+    expect(Ibex.getCryptoReceiveBalance).not.toHaveBeenCalled()
+    expect(result).toBe(balance)
+  })
+})

--- a/test/flash/unit/services/mongoose/wallets.spec.ts
+++ b/test/flash/unit/services/mongoose/wallets.spec.ts
@@ -1,0 +1,82 @@
+import { UnsupportedCurrencyError } from "@domain/errors"
+import { WalletCurrency } from "@domain/shared"
+import Ibex from "@services/ibex/client"
+import { AccountsRepository } from "@services/mongoose/accounts"
+import { WalletsRepository } from "@services/mongoose/wallets"
+
+const save = jest.fn()
+const walletConstructor = jest.fn().mockImplementation((record) => ({
+  ...record,
+  save,
+}))
+
+jest.mock("@services/ibex/client", () => ({
+  __esModule: true,
+  default: {
+    createAccount: jest.fn(),
+    createLnurlPay: jest.fn(),
+  },
+}))
+
+jest.mock("@services/mongoose/accounts", () => ({
+  AccountsRepository: jest.fn(),
+}))
+
+jest.mock("@services/mongoose/schema", () => ({
+  Wallet: jest.fn().mockImplementation((record) => walletConstructor(record)),
+}))
+
+jest.mock("@services/mongoose/utils", () => ({
+  toObjectId: jest.fn((id) => id),
+  fromObjectId: jest.fn((id) => id),
+  parseRepositoryError: jest.fn((err) => err),
+}))
+
+describe("WalletsRepository.persistNew", () => {
+  beforeEach(() => {
+    save.mockReset().mockResolvedValue(undefined)
+    walletConstructor.mockClear()
+    jest.mocked(AccountsRepository).mockReturnValue({
+      findById: jest.fn().mockResolvedValue({ id: "account-id" }),
+    } as never)
+    jest
+      .mocked(Ibex.createAccount)
+      .mockReset()
+      .mockResolvedValue({
+        id: "ibex-account-id",
+      } as never)
+    jest
+      .mocked(Ibex.createLnurlPay)
+      .mockReset()
+      .mockResolvedValue({
+        lnurl: "lnurlp",
+      } as never)
+  })
+
+  it("rejects currencies without an IBEX account currency id", async () => {
+    const result = await WalletsRepository().persistNew({
+      accountId: "account-id" as AccountId,
+      type: "checking" as WalletType,
+      currency: WalletCurrency.Btc,
+    })
+
+    expect(result).toBeInstanceOf(UnsupportedCurrencyError)
+    expect(Ibex.createAccount).not.toHaveBeenCalled()
+    expect(Ibex.createLnurlPay).not.toHaveBeenCalled()
+  })
+
+  it("creates USDT wallets as IBEX currency 29 accounts", async () => {
+    const result = await WalletsRepository().persistNew({
+      accountId: "account-id" as AccountId,
+      type: "checking" as WalletType,
+      currency: WalletCurrency.Usdt,
+    })
+
+    expect(result).not.toBeInstanceOf(Error)
+    expect(Ibex.createAccount).toHaveBeenCalledWith("account-id", 29)
+    expect(Ibex.createLnurlPay).toHaveBeenCalledWith({
+      accountId: "ibex-account-id",
+      currencyId: 29,
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Create both USD and USDT cash wallets during raw account creation
- Default new accounts to the USDT wallet while preserving the USD wallet for migration compatibility
- Provision USDT wallets as IBEX currency `29` accounts and LNURL Pay endpoints
- Load USDT wallet balances from the IBEX account id via account details instead of crypto receive-info balance endpoints
- Guard unsupported wallet currencies from silently provisioning USD IBEX accounts

## Verification
- `git diff --check`
- `TEST="test/flash/unit/app/accounts/create-account.spec.ts test/flash/unit/app/wallets/get-balance-for-wallet.spec.ts test/flash/unit/services/mongoose/wallets.spec.ts" yarn test:unit`
- `yarn tsc-check-noimplicitany`
- changed-file ESLint
- changed-file Prettier
- `yarn build`

## Notes
- Backend/IBEX balance loading for the USDT wallet now returns non-zero balances after receive.
- Mobile currently still displays the legacy USD wallet in the home Cash card (`getUsdWallet(...)`), so the mobile UI needs a follow-up to show the default/USDT wallet balance and regenerate GraphQL types for `UsdtWallet`.
