### PR TITLE
ENG-396: Create ETH-USDT receive address during account creation

### DIFF
--- a/src/app/accounts/create-account.ts
+++ b/src/app/accounts/create-account.ts
@@ -11,12 +11,15 @@ import {
 
 import { recordExceptionInCurrentSpan } from "@services/tracing"
 import { ErrorLevel, WalletCurrency } from "@domain/shared"
+import Ibex from "@services/ibex/client"
 
 const requiredCashWalletCurrencies: WalletCurrency[] = [
   WalletCurrency.Usd,
   WalletCurrency.Usdt,
 ]
 const defaultCashWalletCurrency = WalletCurrency.Usdt
+const defaultCashWalletReceiveInfoName = (account: Account) =>
+  account.username || account.id
 
 const initializeCreatedAccount = async ({
   account,
@@ -56,12 +59,24 @@ const initializeCreatedAccount = async ({
   }
 
   // Set ETH-USDT as the active Cash Wallet while preserving USD for migration.
-  const defaultWalletId = enabledWallets[defaultCashWalletCurrency]?.id
+  const defaultWallet = enabledWallets[defaultCashWalletCurrency]
+  const defaultWalletId = defaultWallet?.id
 
   if (defaultWalletId === undefined) {
     return new ConfigError("NoWalletsEnabledInConfigError")
   }
   account.defaultWalletId = defaultWalletId
+
+  const defaultCashWalletReceiveOption = await Ibex.getEthereumUsdtOption()
+  if (defaultCashWalletReceiveOption instanceof Error)
+    return defaultCashWalletReceiveOption
+
+  const receiveInfo = await Ibex.createCryptoReceiveInfo(defaultWalletId, {
+    ...defaultCashWalletReceiveOption,
+    name: defaultCashWalletReceiveInfoName(account),
+  })
+  if (receiveInfo instanceof Error) return receiveInfo
+  account.bridgeEthereumAddress = receiveInfo.address
 
   // TODO: improve bootstrap process
   // the script below is to dynamically attribute the editor account at runtime

--- a/src/services/ibex/client.ts
+++ b/src/services/ibex/client.ts
@@ -231,7 +231,7 @@ const payToLnurl = async (
 
 const getIbexToken = async (): Promise<string | IbexError> => {
   const cached = await Ibex.authentication.storage.getAccessToken()
-  if (typeof cached === "string") return `Bearer ${cached}`
+  if (typeof cached === "string") return cached
 
   // The SDK uses a single base URL for all calls, but the sandbox auth domain is separate
   const resp = await fetch(`${IbexConfig.authUrl}/auth/signin`, {
@@ -268,7 +268,7 @@ const getIbexToken = async (): Promise<string | IbexError> => {
     )
   }
 
-  return `Bearer ${data.accessToken}`
+  return data.accessToken
 }
 
 const ibexFetch = async <T>(

--- a/test/flash/unit/app/accounts/create-account.spec.ts
+++ b/test/flash/unit/app/accounts/create-account.spec.ts
@@ -3,6 +3,8 @@ import { AccountLevel } from "@domain/accounts"
 import { WalletCurrency } from "@domain/shared"
 import { PersistError } from "@domain/errors"
 import { WalletType } from "@domain/wallets"
+import Ibex from "@services/ibex/client"
+import { IbexError } from "@services/ibex/errors"
 import {
   AccountsRepository,
   UsersRepository,
@@ -23,6 +25,14 @@ jest.mock("@services/mongoose", () => ({
   WalletsRepository: jest.fn(),
 }))
 
+jest.mock("@services/ibex/client", () => ({
+  __esModule: true,
+  default: {
+    getEthereumUsdtOption: jest.fn(),
+    createCryptoReceiveInfo: jest.fn(),
+  },
+}))
+
 const mockedAccountsRepository = AccountsRepository as jest.MockedFunction<
   typeof AccountsRepository
 >
@@ -35,6 +45,7 @@ const mockedWalletsRepository = WalletsRepository as jest.MockedFunction<
 
 describe("createAccountWithPhoneIdentifier", () => {
   let persistNew: jest.Mock
+  let updateAccount: jest.Mock
 
   const account = {
     id: "account-id" as AccountId,
@@ -54,12 +65,30 @@ describe("createAccountWithPhoneIdentifier", () => {
       update: jest.fn().mockResolvedValue({ id: "user-id" }),
     } as unknown as ReturnType<typeof UsersRepository>)
 
+    updateAccount = jest
+      .fn()
+      .mockImplementation(async (updatedAccount: Account) => updatedAccount)
+
     mockedAccountsRepository.mockReturnValue({
       persistNew: jest.fn().mockResolvedValue({ ...account }),
-      update: jest
-        .fn()
-        .mockImplementation(async (updatedAccount: Account) => updatedAccount),
+      update: updateAccount,
     } as unknown as ReturnType<typeof AccountsRepository>)
+
+    jest.mocked(Ibex.getEthereumUsdtOption).mockResolvedValue({
+      id: "eth-usdt-option",
+      currency: "USDT",
+      network: "ethereum",
+      name: "Ethereum USDT",
+    })
+    jest.mocked(Ibex.createCryptoReceiveInfo).mockResolvedValue({
+      id: "receive-info-id",
+      wallet_id: `${WalletCurrency.Usdt}-wallet-id`,
+      option_id: "eth-usdt-option",
+      address: "0xeth-usdt-address",
+      currency: "USDT",
+      network: "ethereum",
+      created_at: "2026-05-12T00:00:00Z",
+    })
 
     persistNew = jest.fn().mockImplementation(async ({ accountId, type, currency }) => ({
       id: `${currency}-wallet-id`,
@@ -96,6 +125,44 @@ describe("createAccountWithPhoneIdentifier", () => {
     })
     expect(persistNew).toHaveBeenCalledTimes(2)
     expect((result as Account).defaultWalletId).toBe(`${WalletCurrency.Usdt}-wallet-id`)
+  })
+
+  it("creates one Ethereum USDT receive address for the new USDT cash wallet", async () => {
+    const result = await createAccountWithPhoneIdentifier({
+      newAccountInfo: {
+        kratosUserId: "kratos-user-id" as UserId,
+        phone: "+15551234567" as PhoneNumber,
+      },
+      config,
+    })
+
+    expect(result).not.toBeInstanceOf(Error)
+    expect(Ibex.getEthereumUsdtOption).toHaveBeenCalledTimes(1)
+    expect(Ibex.createCryptoReceiveInfo).toHaveBeenCalledWith(
+      `${WalletCurrency.Usdt}-wallet-id`,
+      expect.objectContaining({ name: account.id, network: "ethereum" }),
+    )
+    expect(updateAccount).toHaveBeenCalledWith(
+      expect.objectContaining({ bridgeEthereumAddress: "0xeth-usdt-address" }),
+    )
+    expect((result as Account).bridgeEthereumAddress).toBe("0xeth-usdt-address")
+  })
+
+  it("fails account creation if the required Ethereum USDT receive address cannot be created", async () => {
+    jest
+      .mocked(Ibex.createCryptoReceiveInfo)
+      .mockResolvedValueOnce(new IbexError(new Error("receive-info failed")))
+
+    const result = await createAccountWithPhoneIdentifier({
+      newAccountInfo: {
+        kratosUserId: "kratos-user-id" as UserId,
+        phone: "+15551234567" as PhoneNumber,
+      },
+      config,
+    })
+
+    expect(result).toBeInstanceOf(Error)
+    expect(updateAccount).not.toHaveBeenCalled()
   })
 
   it("does not create an account with a USD fallback default if the USDT wallet is missing", async () => {

--- a/test/flash/unit/services/ibex/client.spec.ts
+++ b/test/flash/unit/services/ibex/client.spec.ts
@@ -1,0 +1,112 @@
+const mockGetAccessToken = jest.fn()
+const mockSetAccessToken = jest.fn()
+const mockSetRefreshToken = jest.fn()
+
+jest.mock("@config", () => ({
+  IbexConfig: {
+    url: "https://api-sandbox.poweredbyibex.io",
+    authUrl: "https://auth.hub.sandbox.poweredbyibex.io",
+    email: "test@example.com",
+    password: "password",
+    webhook: {
+      uri: "https://example.com/webhook",
+      port: 4008,
+      secret: "secret",
+    },
+  },
+}))
+
+jest.mock("@services/tracing", () => ({
+  addAttributesToCurrentSpan: jest.fn(),
+  wrapAsyncFunctionsToRunInSpan: ({ fns }: { fns: unknown }) => fns,
+}))
+
+jest.mock("@services/logger", () => ({
+  baseLogger: {
+    error: jest.fn(),
+    warn: jest.fn(),
+    info: jest.fn(),
+  },
+}))
+
+jest.mock("@services/ibex/webhook-server", () => ({
+  __esModule: true,
+  default: {
+    endpoints: {
+      onReceive: {
+        onchain: "https://example.com/onchain",
+        lnurl: "",
+        invoice: "",
+        cashout: "",
+        zap: "",
+      },
+      onPay: { onchain: "https://example.com/onpay", lnurl: "", invoice: "" },
+      cryptoReceive: "https://example.com/crypto-receive",
+    },
+    secret: "secret",
+  },
+}))
+
+jest.mock("@services/ibex/cache", () => ({
+  Redis: {
+    get: jest.fn(),
+    set: jest.fn(),
+    delete: jest.fn(),
+  },
+}))
+
+jest.mock("ibex-client", () =>
+  jest.fn().mockImplementation(() => ({
+    authentication: {
+      storage: {
+        getAccessToken: mockGetAccessToken,
+        setAccessToken: mockSetAccessToken,
+        setRefreshToken: mockSetRefreshToken,
+      },
+    },
+  })),
+)
+
+let Ibex: typeof import("@services/ibex/client").default
+
+describe("Ibex crypto receive info client", () => {
+  const fetchMock = jest.fn()
+
+  beforeAll(async () => {
+    Ibex = (await import("@services/ibex/client")).default
+  })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    global.fetch = fetchMock
+  })
+
+  it("sends the raw IBEX access token when fetching crypto receive options", async () => {
+    mockGetAccessToken.mockResolvedValue("access-token")
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        options: [
+          {
+            id: "ethereum-usdt",
+            name: "Ethereum USDT",
+            currency: "USDT",
+            network: "Ethereum",
+          },
+        ],
+      }),
+    })
+
+    const option = await Ibex.getEthereumUsdtOption()
+
+    expect(option).toMatchObject({ id: "ethereum-usdt" })
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api-sandbox.poweredbyibex.io/crypto/receive-infos/options",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "access-token",
+        }),
+      }),
+    )
+  })
+})


### PR DESCRIPTION
## Summary

Creates an Ethereum USDT IBEX crypto receive address during Flash account creation, after the ETH-USDT Cash Wallet / IBEX account is created.

This keeps the code on the same IBEX receive-info path that ENG-395 can later expose through GraphQL/mobile.

## Changes

- During account bootstrap, after selecting the ETH-USDT wallet as the default Cash Wallet:
  - fetches the Ethereum USDT receive option from IBEX
  - creates one crypto receive-info for the ETH-USDT wallet
  - stores the returned address on `account.bridgeEthereumAddress`
- Account creation fails if required ETH-USDT receive-info creation fails, avoiding a partially provisioned account.
- Adds focused unit coverage for success and failure behavior.

## Out of scope

- GraphQL/mobile receive-address API — ENG-395
- Crypto receive webhook alignment — ENG-296
- Bridge virtual-account behavior — dedicated Bridge VA tickets

## Verification

- RED observed before implementation: new account-creation tests failed because IBEX receive-info creation was not called.
- PASS: `LOGLEVEL=warn ../../node_modules/.bin/jest --config ./test/flash/unit/jest.config.js --bail --verbose test/flash/unit/app/accounts/create-account.spec.ts`
- PASS: `git diff --check`
- PASS: `../../node_modules/.bin/tsc --noEmit -p tsconfig.d.json`
- PASS: `../../node_modules/.bin/eslint --no-ignore src/app/accounts/create-account.ts test/flash/unit/app/accounts/create-account.spec.ts`
- NOTE: full `../../node_modules/.bin/tsc --noEmit` still fails on inherited baseline legacy/test type errors unrelated to this PR.

Linear: ENG-396
