### PR TITLE
fix(graphql): serialize USDT fee probe amounts

### DIFF
--- a/src/graphql/shared/types/scalar/usd-cents.ts
+++ b/src/graphql/shared/types/scalar/usd-cents.ts
@@ -1,4 +1,4 @@
-import { USDAmount } from "@domain/shared"
+import { USDAmount, USDTAmount } from "@domain/shared"
 import { GT } from "@graphql/index"
 
 const USDCentsScalar = GT.Scalar({
@@ -15,6 +15,9 @@ const USDCentsScalar = GT.Scalar({
     serialize(value: unknown): number {
         if (value instanceof USDAmount) {
             return Number(value.asCents(2)) 
+        }
+        if (value instanceof USDTAmount) {
+            return Number(value.asSmallestUnits())
         }
         else throw new Error(`Failed to serialize USDAmount: ${value}`)
     }

--- a/test/flash/unit/graphql/shared/types/scalar/usd-cents.spec.ts
+++ b/test/flash/unit/graphql/shared/types/scalar/usd-cents.spec.ts
@@ -1,0 +1,18 @@
+import { USDAmount, USDTAmount } from "@domain/shared"
+import USDCentsScalar from "@graphql/shared/types/scalar/usd-cents"
+
+describe("USDCentsScalar", () => {
+  it("serializes USD amounts as cents", () => {
+    const amount = USDAmount.cents("123")
+    if (amount instanceof Error) throw amount
+
+    expect(USDCentsScalar.serialize(amount)).toBe(123)
+  })
+
+  it("serializes USDT amounts as micro-USDT units", () => {
+    const amount = USDTAmount.smallestUnits("1234567")
+    if (amount instanceof Error) throw amount
+
+    expect(USDCentsScalar.serialize(amount)).toBe(1234567)
+  })
+})


### PR DESCRIPTION
## Summary
- allow the existing USD cents GraphQL scalar to serialize USDTAmount values as micro-USDT units
- add focused coverage for USD and USDT amount serialization

## Verification
- `jest --config ./test/flash/unit/jest.config.js --runInBand test/flash/unit/graphql/shared/types/scalar/usd-cents.spec.ts`
- `tsc --noEmit -p tsconfig.d.json`
- `eslint test/flash/unit/graphql/shared/types/scalar/usd-cents.spec.ts`
- `git diff --check HEAD~1..HEAD`

Note: intentionally avoided formatting `src/graphql/shared/types/scalar/usd-cents.ts`; scoped ESLint on that existing file still reports pre-existing prettier/prefer-const issues outside this surgical fix.