### PR TITLE
Fix JMD display precision handling in wallet transaction mapping

### DIFF
--- a/src/app/wallets/get-transactions-for-wallet.ts
+++ b/src/app/wallets/get-transactions-for-wallet.ts
@@ -34,12 +34,13 @@ export const getTransactionsForWallets = async ({
 
 export const toWalletTransactions = (ibexResp: GResponse200): IbexTransaction[] => {
   return ibexResp.map(trx => {
+    const displayCurrency = ((trx as { displayCurrency?: string }).displayCurrency || (trx as { settlementDisplayCurrency?: string }).settlementDisplayCurrency || "USD") as DisplayCurrency
     const currency = (trx.currencyId === 3 ? "USD" : "BTC") as WalletCurrency // WalletCurrency: "USD" | "BTC",
 
     const settlementDisplayPrice: WalletMinorUnitDisplayPrice<WalletCurrency, DisplayCurrency> = {
-      base: trx.exchangeRateCurrencySats ? BigInt(Math.floor(trx.exchangeRateCurrencySats)) : 0n,
-      offset: 0n, // what is this?
-      displayCurrency: "USD" as DisplayCurrency,
+      base: trx.exchangeRateCurrencySats ? BigInt(Math.round(trx.exchangeRateCurrencySats)) : 0n,
+      offset: 0n,
+      displayCurrency,
       walletCurrency: currency
     }
 
@@ -48,8 +49,8 @@ export const toWalletTransactions = (ibexResp: GResponse200): IbexTransaction[] 
       settlementAmount: toSettlementAmount(trx.amount, trx.transactionTypeId, currency),
       settlementFee: asCurrency(trx.networkFee, currency),
       settlementCurrency: currency, 
-      settlementDisplayAmount: `${trx.amount}`, 
-      settlementDisplayFee: `${trx.networkFee}`, 
+      settlementDisplayAmount: `${(trx as { settlementDisplayAmount?: number | string }).settlementDisplayAmount ?? trx.amount}`, 
+      settlementDisplayFee: `${(trx as { settlementDisplayFee?: number | string }).settlementDisplayFee ?? trx.networkFee}`, 
       settlementDisplayPrice: settlementDisplayPrice,
       createdAt: trx.createdAt ? new Date(trx.createdAt) : new Date(), // should always return
       id: trx.id || "null", // "LedgerTransactionId" - this is likely unused 

--- a/src/graphql/shared/types/object/btc-wallet.ts
+++ b/src/graphql/shared/types/object/btc-wallet.ts
@@ -56,7 +56,7 @@ const BtcWallet = GT.Object<Wallet>({
         if (balanceSats instanceof Error) {
           throw mapError(balanceSats)
         }
-        return balanceSats
+        return normalizePaymentAmount(balanceSats).amount
       },
     },
     pendingIncomingBalance: {


### PR DESCRIPTION
## Summary

Backend-side fixes for JMD precision and display consistency from issue #282.

## Included changes

- `src/app/wallets/get-transactions-for-wallet.ts`
  - stop hardcoding `displayCurrency: "USD"`; now uses transaction display currency when available
  - replace `Math.floor(...)` with `Math.round(...)` for exchange-rate base conversion to avoid systematic downward truncation
  - prefer `settlementDisplayAmount` / `settlementDisplayFee` values from upstream transaction payload when provided
- `src/graphql/shared/types/object/btc-wallet.ts`
  - normalize BTC wallet balance before exposing via GraphQL resolver to avoid object-like serialization issues

## Notes

- This PR intentionally focuses on backend fixes in `lnflash/flash`.
- Mobile-side changes mentioned in the issue belong to `lnflash/flash-mobile` and should be handled in a paired PR.

## Validation

- Dependency install completed successfully with engine override in this environment.
- Typecheck in this environment reports several unrelated pre-existing repo errors under Node 22 / local setup; no new compile errors were introduced in the touched files.

BTC fallback address: `1BL4eV82zZ64Dp4cj3s9EgJ3ae8xPx5ZuJ`
