### PR TITLE
fix(graphql): make USDT wallet balance nullable

### DIFF
--- a/dev/apollo-federation/supergraph.graphql
+++ b/dev/apollo-federation/supergraph.graphql
@@ -2039,7 +2039,7 @@ type UsdtWallet implements Wallet
   @join__type(graph: PUBLIC)
 {
   accountId: ID!
-  balance: FractionalCentAmount!
+  balance: FractionalCentAmount
   id: ID!
   isExternal: Boolean!
   lnurlp: Lnurl

--- a/src/graphql/admin/schema.graphql
+++ b/src/graphql/admin/schema.graphql
@@ -572,7 +572,7 @@ A wallet belonging to an account which contains a USDT balance and a list of tra
 """
 type UsdtWallet implements Wallet {
   accountId: ID!
-  balance: FractionalCentAmount!
+  balance: FractionalCentAmount
   id: ID!
   isExternal: Boolean!
   lnurlp: Lnurl

--- a/src/graphql/public/schema.graphql
+++ b/src/graphql/public/schema.graphql
@@ -1654,7 +1654,7 @@ A wallet belonging to an account which contains a USDT balance and a list of tra
 """
 type UsdtWallet implements Wallet {
   accountId: ID!
-  balance: FractionalCentAmount!
+  balance: FractionalCentAmount
   id: ID!
   isExternal: Boolean!
   lnurlp: Lnurl

--- a/src/graphql/shared/types/object/usdt-wallet.ts
+++ b/src/graphql/shared/types/object/usdt-wallet.ts
@@ -56,7 +56,7 @@ const UsdtWallet = GT.Object<Wallet>({
     },
 
     balance: {
-      type: GT.NonNull(FractionalCentAmount),
+      type: FractionalCentAmount,
       resolve: async (source) => {
         const balance = await Wallets.getBalanceForWallet({
           walletId: source.id,

--- a/test/flash/unit/graphql/wallet-balance-validation.spec.ts
+++ b/test/flash/unit/graphql/wallet-balance-validation.spec.ts
@@ -1,0 +1,30 @@
+import { parse, validate } from "graphql"
+
+import { gqlMainSchema } from "@graphql/public"
+
+describe("wallet balance query validation", () => {
+  it("allows querying USD and USDT wallet balances with the same response name", () => {
+    const query = parse(`
+      query Me {
+        me {
+          defaultAccount {
+            wallets {
+              ... on UsdtWallet {
+                id
+                balance
+              }
+              ... on UsdWallet {
+                id
+                balance
+              }
+            }
+          }
+        }
+      }
+    `)
+
+    const errors = validate(gqlMainSchema, query)
+
+    expect(errors).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary
- Make `UsdtWallet.balance` nullable to match `UsdWallet.balance` and the shared `Wallet.balance` interface
- Regenerate public/admin/supergraph SDL for the nullability change
- Add a regression test for querying USD and USDT wallet balances with the same response name

## Verification
- `TEST='test/flash/unit/graphql/wallet-balance-validation.spec.ts --forceExit' yarn test:unit`
- `yarn build`
- `./node_modules/.bin/eslint src/graphql/shared/types/object/usdt-wallet.ts test/flash/unit/graphql/wallet-balance-validation.spec.ts`

Note: the focused Jest test imports the public GraphQL schema and leaves existing open handles, so the verification uses `--forceExit`. It also prints existing local env warnings for missing Google credentials / placeholder SendGrid key.
