### PR TITLE
fix(dev): update local dev setup for ibex-client v3 OAuth2 auth

### DIFF
--- a/.env
+++ b/.env
@@ -123,8 +123,8 @@ export ERPNEXT_JWT_SECRET="not-so-secret"
 
 COMPOSE_FILE=docker-compose.yml:docker-compose.override.yml:docker-compose.local.yml
 
-# Ibex API (used by docker compose; app reads from yaml config)
-export IBEX_URL="https://api-sandbox.poweredbyibex.io"
-export IBEX_EMAIL=""
-export IBEX_PASSWORD=""
+# Ibex API — app reads from yaml config, not env vars
+# Get sandbox credentials from your team lead
+# export IBEX_CLIENT_ID=""
+# export IBEX_CLIENT_SECRET=""
 

--- a/DEV.md
+++ b/DEV.md
@@ -38,30 +38,11 @@ If you prefer to set things up yourself, or if the setup script fails:
 
 ### 1. Environment Variables
 
-The project loads environment variables from `.env` (committed) and `.env.local` (git-ignored, for secrets).
-
-Create `.env.local` with your Ibex sandbox credentials:
-
-```bash
-echo "export IBEX_EMAIL='your-ibex-email'" >> .env.local
-echo "export IBEX_PASSWORD='your-ibex-password'" >> .env.local
-```
-
-If you use direnv, allow it:
-
-```bash
-direnv allow
-```
-
-If not using direnv, source the env files manually before running commands:
-
-```bash
-source .env && source .env.local
-```
+Flash uses YAML config files. Ibex OAuth2 credentials go in local config overrides, not env vars.
 
 ### 2. App Config Overrides
 
-Flash uses YAML config files. The base config is at `dev/config/base-config.yaml`. Secrets and local overrides go in `$CONFIG_PATH/dev-overrides.yaml` (default: `~/.config/flash/dev-overrides.yaml`).
+The base config is at `dev/config/base-config.yaml`. Secrets and local overrides go in `$CONFIG_PATH/dev-overrides.yaml` (default: `~/.config/flash/dev-overrides.yaml`).
 
 **Option A — Run the interactive script:**
 
@@ -74,8 +55,9 @@ Flash uses YAML config files. The base config is at `dev/config/base-config.yaml
 ```yaml
 # ~/.config/flash/dev-overrides.yaml
 ibex:
-  email: your-ibex-email
-  password: your-ibex-password
+  clientId: your-sandbox-client-id
+  clientSecret: your-sandbox-client-secret
+  environment: sandbox
 ```
 
 Additional overrides you might need:

--- a/dev/config/set-overrides.sh
+++ b/dev/config/set-overrides.sh
@@ -7,8 +7,8 @@ mkdir -p "$(dirname "$OUTPUT_FILE")"
 
 # Define YAML paths and their descriptions directly in the script
 declare -a yaml_paths=(
-  "ibex.email, Email address to Ibex Account"
-  "ibex.password, Password to Ibex Account"
+  "ibex.clientId, Ibex sandbox client ID"
+  "ibex.clientSecret, Ibex sandbox client secret"
   "ibex.webhook.uri, The URI where Ibex will send payment events"
   "sendgrid.apiKey, API key to SendGrid email service (from Twilio)"
   "cashout.email.to, Recipient email address for cashout notifications"

--- a/dev/setup.sh
+++ b/dev/setup.sh
@@ -73,24 +73,24 @@ echo ""
 # ── 5. Configure Ibex credentials ────────────────────
 echo "Checking Ibex credentials..."
 
-if [ -f .env.local ] && grep -q "IBEX_PASSWORD" .env.local 2>/dev/null; then
+if [ -f .env.local ] && grep -q "IBEX_CLIENT_ID" .env.local 2>/dev/null; then
   info "Ibex credentials found in .env.local"
 else
   echo ""
-  echo "Flash requires Ibex sandbox credentials to connect to the payment backend."
+  echo "Flash requires Ibex sandbox credentials (OAuth2 client credentials) to connect to the payment backend."
   echo "If you don't have credentials, ask your team lead."
   echo ""
-  read -rp "Ibex email (or press Enter to skip): " IBEX_EMAIL
-  if [ -n "$IBEX_EMAIL" ]; then
-    read -rsp "Ibex password: " IBEX_PASSWORD
+  read -rp "Ibex client ID (or press Enter to skip): " IBEX_CLIENT_ID
+  if [ -n "$IBEX_CLIENT_ID" ]; then
+    read -rsp "Ibex client secret: " IBEX_CLIENT_SECRET
     echo ""
     cat > .env.local << EOF
-export IBEX_EMAIL='${IBEX_EMAIL}'
-export IBEX_PASSWORD='${IBEX_PASSWORD}'
+export IBEX_CLIENT_ID='${IBEX_CLIENT_ID}'
+export IBEX_CLIENT_SECRET='${IBEX_CLIENT_SECRET}'
 EOF
     info "Credentials saved to .env.local (git-ignored)"
   else
-    warn "Skipped — you'll need to create .env.local with IBEX_EMAIL and IBEX_PASSWORD before starting"
+    warn "Skipped — you'll need to create .env.local with IBEX_CLIENT_ID and IBEX_CLIENT_SECRET before starting"
   fi
 fi
 
@@ -109,11 +109,12 @@ else
   if [ -f .env.local ]; then
     source .env.local 2>/dev/null || true
   fi
-  if [ -n "${IBEX_EMAIL:-}" ] && [ -n "${IBEX_PASSWORD:-}" ]; then
+  if [ -n "${IBEX_CLIENT_ID:-}" ] && [ -n "${IBEX_CLIENT_SECRET:-}" ]; then
     cat > "$OVERRIDES" << EOF
 ibex:
-  email: ${IBEX_EMAIL}
-  password: ${IBEX_PASSWORD}
+  clientId: ${IBEX_CLIENT_ID}
+  clientSecret: ${IBEX_CLIENT_SECRET}
+  environment: sandbox
 EOF
     info "Generated $OVERRIDES with Ibex credentials"
   else

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,9 +79,8 @@ services:
       - REDIS_TYPE=standalone
       - REDIS_0_DNS=redis
       - REDIS_0_PORT=6378
-      - IBEX_URL=${IBEX_URL}
-      - IBEX_EMAIL=${IBEX_EMAIL}
-      - IBEX_PASSWORD=${IBEX_PASSWORD}
+      - IBEX_CLIENT_ID=${IBEX_CLIENT_ID:-}
+      - IBEX_CLIENT_SECRET=${IBEX_CLIENT_SECRET:-}
   price-history:
     image: docker.io/lnflash/price-history:edge
     # image: us.gcr.io/galoy-org/price-history:edge


### PR DESCRIPTION
The ENG-38 Ibex auth migration replaced email/password login with OAuth2 client credentials (clientId + clientSecret). The dev setup scripts and docs still referenced the old auth method.

Changes:
- Replace `IBEX_EMAIL`/`IBEX_PASSWORD` prompts with `IBEX_CLIENT_ID`/`IBEX_CLIENT_SECRET` in `dev/setup.sh`
- Update `dev/config/set-overrides.sh` to prompt for `clientId`/`clientSecret` instead of `email`/`password`
- Update `DEV.md` docs to document the new config format
- Replace stale `IBEX_URL`/`IBEX_EMAIL`/`IBEX_PASSWORD` env vars in `.env` and `docker-compose.yml`

Multiple devs can share the same sandbox clientId/clientSecret.