### PR TITLE
fix(cash-wallet): guard cutover start

### DIFF
--- a/src/app/cash-wallet-cutover/lifecycle.ts
+++ b/src/app/cash-wallet-cutover/lifecycle.ts
@@ -2,6 +2,7 @@ import { CashWalletCutoverRepository } from "@services/mongoose"
 
 import {
   CashWalletCutoverInProgressError,
+  CashWalletCutoverPreflightError,
   CashWalletMigrationFailedError,
   InvalidCashWalletCutoverStateTransitionError,
 } from "./errors"
@@ -85,6 +86,18 @@ export const startPrimaryCashWalletCutover = async ({
     if (config.runId === runId && config.cutoverVersion === cutoverVersion) return config
     return new CashWalletCutoverInProgressError(
       "Cash wallet cutover is already in progress",
+    )
+  }
+
+  const runnable = await migrationsRepo.listRunnableMigrations({
+    cutoverVersion,
+    runId,
+    limit: 1,
+  })
+  if (runnable instanceof Error) return runnable
+  if (runnable.length === 0) {
+    return new CashWalletCutoverPreflightError(
+      "Cash wallet cutover has no prepared migrations for this run",
     )
   }
 

--- a/src/app/cash-wallet-cutover/lifecycle.ts
+++ b/src/app/cash-wallet-cutover/lifecycle.ts
@@ -97,7 +97,7 @@ export const startPrimaryCashWalletCutover = async ({
   if (runnable instanceof Error) return runnable
   if (runnable.length === 0) {
     return new CashWalletCutoverPreflightError(
-      "Cash wallet cutover has no prepared migrations for this run",
+      `Cash wallet cutover has no runnable migrations for runId=${runId} cutoverVersion=${cutoverVersion}. Run 'prepare' before starting.`,
     )
   }
 

--- a/test/flash/unit/app/cash-wallet-cutover/lifecycle.spec.ts
+++ b/test/flash/unit/app/cash-wallet-cutover/lifecycle.spec.ts
@@ -1,0 +1,139 @@
+jest.mock("@services/mongoose", () => ({
+  CashWalletCutoverRepository: jest.fn(),
+}))
+
+import { startPrimaryCashWalletCutover } from "@app/cash-wallet-cutover/lifecycle"
+import { CashWalletCutoverPreflightError } from "@app/cash-wallet-cutover/errors"
+import { UnknownRepositoryError } from "@domain/errors"
+
+const cutoverVersion = 7
+const runId = "cash-wallet-cutover-2026-06-03"
+const actor = "operator@example.com"
+const now = new Date("2026-06-03T18:00:00.000Z")
+
+const preConfig = {
+  state: "pre",
+  cutoverVersion: 6,
+  updatedAt: new Date("2026-06-03T17:00:00.000Z"),
+} as CashWalletCutoverConfig
+
+const startedConfig = {
+  ...preConfig,
+  state: "in_progress",
+  cutoverVersion,
+  runId,
+  startedAt: now,
+} as CashWalletCutoverConfig
+
+const runnableMigration = {
+  id: "migration-id",
+  accountId: "account-id" as AccountId,
+  legacyUsdWalletId: "11111111-1111-4111-8111-111111111111" as WalletId,
+  destinationUsdtWalletId: "22222222-2222-4222-8222-222222222222" as WalletId,
+  cutoverVersion,
+  runId,
+  status: "not_started",
+  idempotencyKey: `${runId}:account-id`,
+  attempts: 0,
+  updatedAt: now,
+} as CashWalletMigration
+
+const makeRepo = ({
+  config = preConfig,
+  runnable = [runnableMigration],
+  updateResult = startedConfig,
+}: {
+  config?: CashWalletCutoverConfig | RepositoryError
+  runnable?: CashWalletMigration[] | RepositoryError
+  updateResult?: CashWalletCutoverConfig | RepositoryError
+} = {}) => ({
+  getConfig: jest.fn().mockResolvedValue(config),
+  updateConfig: jest.fn().mockResolvedValue(updateResult),
+  listRunnableMigrations: jest.fn().mockResolvedValue(runnable),
+  countByStatus: jest.fn(),
+})
+
+describe("startPrimaryCashWalletCutover", () => {
+  it("rejects start when the requested run has no prepared runnable migrations", async () => {
+    const repo = makeRepo({ runnable: [] })
+
+    const result = await startPrimaryCashWalletCutover({
+      cutoverVersion,
+      runId,
+      actor,
+      now,
+      migrationsRepo: repo,
+    })
+
+    expect(result).toBeInstanceOf(CashWalletCutoverPreflightError)
+    expect(repo.listRunnableMigrations).toHaveBeenCalledWith({
+      cutoverVersion,
+      runId,
+      limit: 1,
+    })
+    expect(repo.updateConfig).not.toHaveBeenCalled()
+  })
+
+  it("propagates prepared-run repository errors before updating config", async () => {
+    const repoError = new UnknownRepositoryError("list runnable migrations failed")
+    const repo = makeRepo({ runnable: repoError })
+
+    const result = await startPrimaryCashWalletCutover({
+      cutoverVersion,
+      runId,
+      actor,
+      now,
+      migrationsRepo: repo,
+    })
+
+    expect(result).toBe(repoError)
+    expect(repo.updateConfig).not.toHaveBeenCalled()
+  })
+
+  it("starts when the requested run has a prepared runnable migration", async () => {
+    const repo = makeRepo()
+
+    const result = await startPrimaryCashWalletCutover({
+      cutoverVersion,
+      runId,
+      actor,
+      now,
+      migrationsRepo: repo,
+    })
+
+    expect(result).toBe(startedConfig)
+    expect(repo.listRunnableMigrations).toHaveBeenCalledWith({
+      cutoverVersion,
+      runId,
+      limit: 1,
+    })
+    expect(repo.updateConfig).toHaveBeenCalledWith(
+      {
+        state: "in_progress",
+        cutoverVersion,
+        runId,
+        startedAt: now,
+        scheduledAt: undefined,
+        pausedAt: undefined,
+        pauseReason: undefined,
+      },
+      actor,
+    )
+  })
+
+  it("keeps same-run in-progress start idempotent without rechecking migrations", async () => {
+    const repo = makeRepo({ config: startedConfig, runnable: [] })
+
+    const result = await startPrimaryCashWalletCutover({
+      cutoverVersion,
+      runId,
+      actor,
+      now,
+      migrationsRepo: repo,
+    })
+
+    expect(result).toBe(startedConfig)
+    expect(repo.listRunnableMigrations).not.toHaveBeenCalled()
+    expect(repo.updateConfig).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- require a prepared/runnable migration row before `startPrimaryCashWalletCutover()` can move config to `in_progress`
- preserve same-run idempotent start behavior for an already `in_progress` cutover
- add focused lifecycle coverage for missing prepared rows, repository errors, successful starts, and idempotency

## Verification
- `TEST='test/flash/unit/app/cash-wallet-cutover/lifecycle.spec.ts' yarn test:unit`
- `./node_modules/.bin/eslint --resolve-plugins-relative-to . --no-ignore src/app/cash-wallet-cutover/lifecycle.ts test/flash/unit/app/cash-wallet-cutover/lifecycle.spec.ts`
- `git diff --check`
- `yarn build`

## Notes
- The wider `TEST='test/flash/unit/app/cash-wallet-cutover' yarn test:unit` slice still exposes the existing Bridge webhook public-key config failure in `recipient-routing.spec.ts`; the new lifecycle spec passes.