### PR TITLE
fix(bridge): lower account level requirement from level 2 to level > 0

### DIFF
--- a/src/graphql/public/root/mutation/bridge-add-external-account.ts
+++ b/src/graphql/public/root/mutation/bridge-add-external-account.ts
@@ -21,7 +21,7 @@ const bridgeAddExternalAccount = GT.Field({
       return { errors: [mapAndParseErrorForGqlResponse(new BridgeDisabledError())] }
     }
 
-    if (!domainAccount || domainAccount.level < 2) {
+    if (!domainAccount || domainAccount.level <= 0) {
       return { errors: [mapAndParseErrorForGqlResponse(new BridgeAccountLevelError())] }
     }
 

--- a/src/graphql/public/root/mutation/bridge-create-virtual-account.ts
+++ b/src/graphql/public/root/mutation/bridge-create-virtual-account.ts
@@ -21,7 +21,7 @@ const bridgeCreateVirtualAccount = GT.Field({
       return { errors: [mapAndParseErrorForGqlResponse(new BridgeDisabledError())] }
     }
 
-    if (!domainAccount || domainAccount.level < 2) {
+    if (!domainAccount || domainAccount.level <= 0) {
       return { errors: [mapAndParseErrorForGqlResponse(new BridgeAccountLevelError())] }
     }
 

--- a/src/graphql/public/root/mutation/bridge-initiate-kyc.ts
+++ b/src/graphql/public/root/mutation/bridge-initiate-kyc.ts
@@ -34,7 +34,7 @@ const bridgeInitiateKyc = GT.Field({
       return { errors: [mapAndParseErrorForGqlResponse(new BridgeDisabledError())] }
     }
 
-    if (!domainAccount || domainAccount.level < 2) {
+    if (!domainAccount || domainAccount.level <= 0) {
       return { errors: [mapAndParseErrorForGqlResponse(new BridgeAccountLevelError())] }
     }
 

--- a/src/graphql/public/root/mutation/bridge-initiate-withdrawal.ts
+++ b/src/graphql/public/root/mutation/bridge-initiate-withdrawal.ts
@@ -57,7 +57,7 @@ const bridgeInitiateWithdrawal = GT.Field({
       return { errors: [mapAndParseErrorForGqlResponse(new BridgeDisabledError())] }
     }
 
-    if (!domainAccount || domainAccount.level < 2) {
+    if (!domainAccount || domainAccount.level <= 0) {
       return { errors: [mapAndParseErrorForGqlResponse(new BridgeAccountLevelError())] }
     }
 

--- a/src/graphql/public/root/query/bridge-virtual-account.ts
+++ b/src/graphql/public/root/query/bridge-virtual-account.ts
@@ -14,7 +14,7 @@ const bridgeVirtualAccount = GT.Field({
 
     if (!domainAccount) return null
 
-    if (domainAccount.level < 2) {
+    if (domainAccount.level <= 0) {
       throw mapAndParseErrorForGqlResponse(new BridgeAccountLevelError())
     }
 

--- a/src/services/bridge/errors.ts
+++ b/src/services/bridge/errors.ts
@@ -58,7 +58,7 @@ export class BridgeInsufficientFundsError extends BridgeError {
 }
 
 export class BridgeAccountLevelError extends BridgeError {
-  constructor(message: string = "Bridge requires at least a Basic account (Level 1+)") {
+  constructor(message: string = "Bridge requires at least a Personal account (Level 1+)") {
     super(message)
   }
 }

--- a/src/services/bridge/errors.ts
+++ b/src/services/bridge/errors.ts
@@ -58,7 +58,7 @@ export class BridgeInsufficientFundsError extends BridgeError {
 }
 
 export class BridgeAccountLevelError extends BridgeError {
-  constructor(message: string = "Bridge requires Pro account (Level 2+)") {
+  constructor(message: string = "Bridge requires at least a Basic account (Level 1+)") {
     super(message)
   }
 }


### PR DESCRIPTION
## Summary

- Relaxes the bridge account level gate from `level < 2` (Pro) to `level <= 0` (any non-zero level) across all bridge operations
- Updates the `BridgeAccountLevelError` message to reflect the new requirement (Level 1+)

## Files changed

- `bridge-add-external-account.ts` — mutation level check
- `bridge-create-virtual-account.ts` — mutation level check
- `bridge-initiate-kyc.ts` — mutation level check
- `bridge-initiate-withdrawal.ts` — mutation level check
- `bridge-virtual-account.ts` — query level check
- `src/services/bridge/errors.ts` — updated error message

## Test plan

- [ ] Verify a Level 1 account can now access bridge operations
- [ ] Verify a Level 0 account is still blocked with `BridgeAccountLevelError`