### PR TITLE
fix(bridge): add external account webhook config

### DIFF
--- a/dev/apollo-federation/supergraph.graphql
+++ b/dev/apollo-federation/supergraph.graphql
@@ -268,7 +268,7 @@ type BridgeAddExternalAccountPayload
   @join__type(graph: PUBLIC)
 {
   errors: [Error!]!
-  externalAccount: BridgeExternalAccount
+  externalAccount: BridgeExternalAccountLink
 }
 
 type BridgeCreateVirtualAccountPayload
@@ -285,6 +285,13 @@ type BridgeExternalAccount
   bankName: String!
   id: ID!
   status: String!
+}
+
+type BridgeExternalAccountLink
+  @join__type(graph: PUBLIC)
+{
+  expiresAt: String!
+  linkUrl: String!
 }
 
 input BridgeInitiateKycInput

--- a/dev/config/base-config.yaml
+++ b/dev/config/base-config.yaml
@@ -43,6 +43,7 @@ bridge:
         dwIDAQAB
         -----END PUBLIC KEY-----
       transfer: "<replace>"
+      external_account: "<replace>"
     timestampSkewMs: 300000
 
 # See Foreign Exchange Rates: https://www.firstglobal-bank.com/

--- a/src/graphql/public/schema.graphql
+++ b/src/graphql/public/schema.graphql
@@ -243,7 +243,7 @@ input BankAccountInput {
 
 type BridgeAddExternalAccountPayload {
   errors: [Error!]!
-  externalAccount: BridgeExternalAccount
+  externalAccount: BridgeExternalAccountLink
 }
 
 type BridgeCreateVirtualAccountPayload {
@@ -256,6 +256,11 @@ type BridgeExternalAccount {
   bankName: String!
   id: ID!
   status: String!
+}
+
+type BridgeExternalAccountLink {
+  expiresAt: String!
+  linkUrl: String!
 }
 
 input BridgeInitiateKycInput {


### PR DESCRIPTION
## Summary
- Adds the missing Bridge `external_account` webhook public-key placeholder to `dev/config/base-config.yaml`.
- Regenerates public schema and supergraph so the external-account link payload matches the current GraphQL code.

## Test Plan
- [x] `npx prettier --check dev/config/base-config.yaml`
- [x] `yarn check:sdl`

## Notes
- This is intentionally separate from ENG-406 and ENG-274.
- Without this, latest `tmp/bridge-rebase-pr-ready` fails config validation because `bridge.webhook.publicKeys.external_account` is required by the schema but absent from the base config.
