### PR TITLE
feat(bridge): push notification on deposit settlement [ENG-275]

### DIFF
--- a/src/app/bridge/send-deposit-notification.ts
+++ b/src/app/bridge/send-deposit-notification.ts
@@ -1,0 +1,98 @@
+import { getI18nInstance } from "@config"
+import { checkedToAccountId } from "@domain/accounts"
+import { getLanguageOrDefault } from "@domain/locale"
+import {
+  DeviceTokensNotRegisteredNotificationsServiceError,
+  FlashNotificationCategories,
+  NotificationsServiceError,
+} from "@domain/notifications"
+import { removeDeviceTokens } from "@app/users/remove-device-tokens"
+import { baseLogger } from "@services/logger"
+import { AccountsRepository } from "@services/mongoose/accounts"
+import { UsersRepository } from "@services/mongoose/users"
+import {
+  PushNotificationsService,
+  SendFilteredPushNotificationStatus,
+} from "@services/notifications/push-notifications"
+
+const i18n = getI18nInstance()
+
+const formatDepositAmount = (amount: string, currency: string): string =>
+  `${amount} ${currency.toUpperCase()}`
+
+export const sendBridgeDepositNotification = async ({
+  accountId: accountIdRaw,
+  amount,
+  currency,
+}: {
+  accountId: string
+  amount: string
+  currency: string
+}): Promise<true | ApplicationError> => {
+  const accountId = checkedToAccountId(accountIdRaw)
+  if (accountId instanceof Error) return accountId
+
+  const account = await AccountsRepository().findById(accountId)
+  if (account instanceof Error) return account
+
+  const user = await UsersRepository().findById(account.kratosUserId)
+  if (user instanceof Error) return user
+
+  const locale = getLanguageOrDefault(user.language)
+  const formattedAmount = formatDepositAmount(amount, currency)
+  const phraseBase = "notification.bridgeDeposit"
+
+  const title = i18n.__({ phrase: `${phraseBase}.title`, locale })
+  const body = i18n.__(
+    { phrase: `${phraseBase}.body`, locale },
+    { amount: formattedAmount },
+  )
+
+  const result = await PushNotificationsService().sendFilteredNotification({
+    deviceTokens: user.deviceTokens,
+    title,
+    body,
+    notificationCategory: FlashNotificationCategories.Payments,
+    notificationSettings: account.notificationSettings,
+    data: {
+      type: "bridge_deposit_completed",
+      amount,
+      currency: currency == "usdt" ? "USD" : currency.toUpperCase(),
+    },
+  })
+
+  if (result instanceof NotificationsServiceError) return result
+
+  if (result.status === SendFilteredPushNotificationStatus.Filtered) {
+    return true
+  }
+
+  return true
+}
+
+export const sendBridgeDepositNotificationBestEffort = async (
+  args: Parameters<typeof sendBridgeDepositNotification>[0],
+): Promise<void> => {
+  const result = await sendBridgeDepositNotification(args)
+
+  if (result instanceof DeviceTokensNotRegisteredNotificationsServiceError) {
+    const accountId = checkedToAccountId(args.accountId)
+    if (accountId instanceof Error) return
+
+    const account = await AccountsRepository().findById(accountId)
+    if (account instanceof Error) return
+
+    await removeDeviceTokens({
+      userId: account.kratosUserId,
+      deviceTokens: result.tokens,
+    })
+    return
+  }
+
+  if (result instanceof Error) {
+    baseLogger.warn(
+      { accountId: args.accountId, error: result },
+      "Failed to send Bridge deposit push notification",
+    )
+  }
+}

--- a/src/config/locales/en.json
+++ b/src/config/locales/en.json
@@ -41,6 +41,10 @@
       "body": "Your cashout of {{amount}} has been deposited to your bank account.",
       "title": "Cashout"
     },
+    "bridgeDeposit": {
+      "body": "Your deposit of {{amount}} has been added to your account.",
+      "title": "Deposit received"
+    },
     "bridgeWithdrawal": {
       "completed": {
         "body": "Your withdrawal of {{amount}} has been sent to your bank account.",

--- a/src/config/locales/es.json
+++ b/src/config/locales/es.json
@@ -37,6 +37,10 @@
         "title": "Transacción {{walletCurrency}}"
       }
     },
+    "bridgeDeposit": {
+      "body": "Su depósito de {{amount}} se agregó a su cuenta.",
+      "title": "Depósito recibido"
+    },
     "bridgeWithdrawal": {
       "completed": {
         "body": "Su retiro de {{amount}} se envió a su cuenta bancaria.",

--- a/src/services/ibex/webhook-server/routes/crypto-receive.ts
+++ b/src/services/ibex/webhook-server/routes/crypto-receive.ts
@@ -2,6 +2,7 @@ import express, { Request, Response } from "express"
 import { AccountsRepository } from "@services/mongoose/accounts"
 import { createIbexCryptoReceive } from "@services/mongoose/ibex-crypto-receive-log"
 import { listWalletsByAccountId } from "@app/wallets"
+import { sendBridgeDepositNotificationBestEffort } from "@app/bridge/send-deposit-notification"
 import { WalletCurrency, USDTAmount } from "@domain/shared"
 import { baseLogger } from "@services/logger"
 import { LockService } from "@services/lock"
@@ -124,6 +125,12 @@ const cryptoReceiveHandler = async (req: Request, res: Response) => {
           )
           return { status: "error", code: "erpnext_audit_failed" } as CryptoReceiveResult
         }
+
+        await sendBridgeDepositNotificationBestEffort({
+          accountId: account.id,
+          amount: String(usdtAmount.asNumber()),
+          currency: normalizedCurrency,
+        })
 
         return { status: "success" } as CryptoReceiveResult
       } catch (error) {


### PR DESCRIPTION
## ENG-275 — Push notification on /deposit and /transfer

Completes the **deposit** side of ENG-275. The **withdrawal-completion push already exists** (`transfer.ts` → `sendBridgeWithdrawalNotificationBestEffort` on `transfer.completed`/failure), so this PR adds the missing **deposit settlement push** (the must-have launch gate).

### Where it fires
A Bridge USDT deposit settles when IBEX sends its `crypto.received` webhook. The push is fired at the success point of `services/ibex/webhook-server/routes/crypto-receive.ts`, where:
- the account is resolved (`findByBridgeEthereumAddress` — so it's Bridge-specific),
- the USDT amount is validated,
- and it's inside the per-`txHash` `LockService` block → **idempotent, fires once** per deposit.

### What's added
- `src/app/bridge/send-deposit-notification.ts` — `sendBridgeDepositNotification(BestEffort)`, mirroring the existing withdrawal-notification function (resolve account→user→deviceTokens, `PushNotificationsService().sendFilteredNotification`, best-effort token-cleanup + warn).
- `notification.bridgeDeposit.{title,body}` i18n phrases in `en.json` + `es.json`.
- One call wired into the crypto-receive settlement handler.

### Notes
- Server-side trigger only (per ticket); mobile display/config is the separate Nick ticket.
- No new env/config — reuses the existing push-notification infrastructure (FCM).
- Currency display mirrors the withdrawal notif (USDT → "USD" in the payload).
- Diff is purely additive (+113 / -0). New file lint-clean; touched files type-check. (Pre-existing base lint/test debt in surrounding files is not touched.)

### Acceptance
- A successful Bridge deposit (`crypto.received` settles) triggers a push; a successful withdrawal (`transfer.completed`) already does. Mobile receives + displays (Nick's client work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)