### PR TITLE
ci: run checks on the bridge integration branch

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -5,7 +5,7 @@ name: Audit
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, tmp/bridge-rebase-pr-ready]
 
 jobs:
   audit:

--- a/.github/workflows/bats.yml
+++ b/.github/workflows/bats.yml
@@ -2,7 +2,7 @@ name: "Bats test"
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, tmp/bridge-rebase-pr-ready]
 
 jobs:
   integration:

--- a/.github/workflows/check-code.yml
+++ b/.github/workflows/check-code.yml
@@ -4,8 +4,10 @@
 name: Check Code
 
 on:
+  push:
+    branches: [tmp/bridge-rebase-pr-ready]
   pull_request:
-    branches: [main]
+    branches: [main, tmp/bridge-rebase-pr-ready]
 
 jobs:
   check-code:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,8 +1,10 @@
 name: "Integration test"
 
 on:
+  push:
+    branches: [tmp/bridge-rebase-pr-ready]
   pull_request:
-    branches: [main]
+    branches: [main, tmp/bridge-rebase-pr-ready]
 
 jobs:
   integration:

--- a/.github/workflows/mobile-schema-compatibility.yml
+++ b/.github/workflows/mobile-schema-compatibility.yml
@@ -2,7 +2,7 @@ name: "Mobile Schema Compatibility"
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, tmp/bridge-rebase-pr-ready]
 
 jobs:
   check-secret:

--- a/.github/workflows/mongodb-migrate.yml
+++ b/.github/workflows/mongodb-migrate.yml
@@ -2,7 +2,7 @@ name: "Migrate Mongodb"
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, tmp/bridge-rebase-pr-ready]
 
 jobs:
   migrate_mongodb:

--- a/.github/workflows/quickstart.yml
+++ b/.github/workflows/quickstart.yml
@@ -2,7 +2,7 @@ name: "Quickstart"
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, tmp/bridge-rebase-pr-ready]
 
 jobs:
   integration:

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -5,7 +5,7 @@ name: Spelling
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [ main, tmp/bridge-rebase-pr-ready ]
 
 jobs:
   spelling:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,8 +1,10 @@
 name: "Unit test"
 
 on:
+  push:
+    branches: [tmp/bridge-rebase-pr-ready]
   pull_request:
-    branches: [main]
+    branches: [main, tmp/bridge-rebase-pr-ready]
 
 jobs:
   unit-test:


### PR DESCRIPTION
## Why

Stacked cleanup PRs against `tmp/bridge-rebase-pr-ready` need the same CI signal as PRs against `main`. The existing workflows only matched `pull_request` events where the base branch is `main`, so PRs like #415 do not get Quickstart/Integration/Check Code unless this branch filter is present on the integration branch.

## What

- Add `tmp/bridge-rebase-pr-ready` to the `pull_request` branch filter for the gating workflows:
  - Check Code
  - Unit test
  - Integration test
  - Audit
  - Bats test
  - Mobile Schema Compatibility
  - Migrate MongoDB
  - Quickstart
  - Spelling
- Add `push` triggers for `tmp/bridge-rebase-pr-ready` on Check Code, Unit test, and Integration test so the integration branch tip keeps a baseline signal as fixes land.

## Verification

- Rebased cleanly onto current `origin/tmp/bridge-rebase-pr-ready` (`d5498c12`).
- Parsed every edited workflow with Ruby YAML loading.
- Confirmed the diff is limited to 9 workflow files.

## Notes

This PR intentionally targets `tmp/bridge-rebase-pr-ready`, not `main`. Once the bridge integration branch is no longer needed, these temporary branch filters should be removed.

The workflows exposed by this PR may report current integration-branch failures; that is expected and is the reason we need this CI plumbing before landing the smaller cleanup PRs.