### PR TITLE
fix(bridge): resolve type errors in bridge-sandbox-e2e suite

### DIFF
--- a/test/flash/bridge-sandbox-e2e/cutover-state.spec.ts
+++ b/test/flash/bridge-sandbox-e2e/cutover-state.spec.ts
@@ -53,7 +53,10 @@ const CUTOVER_TESTS = process.env.CUTOVER_TESTS === "true"
         }
       `
 
-      const response = await execQuery(source, dummyAccountId)
+      const response = await execQuery<{
+        cashWalletCutover: { state: string; cutoverVersion: number; updatedAt: string }
+      }>(source, dummyAccountId)
+      if ("errors" in response) throw new Error(JSON.stringify(response.errors))
 
       expect(response.cashWalletCutover).toBeDefined()
       expect(typeof response.cashWalletCutover.state).toBe("string")
@@ -94,7 +97,10 @@ const CUTOVER_TESTS = process.env.CUTOVER_TESTS === "true"
         }
       `
 
-      const response = await execQuery(source, dummyAccountId)
+      const response = await execQuery<{
+        cashWalletCutover: { state: string }
+      }>(source, dummyAccountId)
+      if ("errors" in response) throw new Error(JSON.stringify(response.errors))
 
       expect(VALID_STATES.has(response.cashWalletCutover?.state)).toBe(true)
     })

--- a/test/flash/bridge-sandbox-e2e/helpers.ts
+++ b/test/flash/bridge-sandbox-e2e/helpers.ts
@@ -68,7 +68,7 @@ type WithdrawalResult = GraphQlErrorResponse & {
 
 type HandlerResponse = {
   status: number
-  body?: unknown
+  body: Record<string, unknown>
 }
 
 // ============ Schema Execution ============
@@ -80,11 +80,11 @@ function buildContext(accountId: string): GraphQLPublicContextAuth {
   } as GraphQLPublicContextAuth
 }
 
-export async function execQuery(
+export async function execQuery<T = Record<string, unknown>>(
   source: string,
   accountId: string,
   variableValues?: Record<string, unknown>,
-): Promise<Record<string, unknown> | GraphQlErrorResponse> {
+): Promise<T | GraphQlErrorResponse> {
   const result = await graphql({
     schema: gqlMainSchema,
     source: new Source(source),
@@ -94,7 +94,7 @@ export async function execQuery(
   if (result.errors) {
     return { errors: result.errors.map((error) => ({ message: error.message })) }
   }
-  return result.data ?? {}
+  return (result.data ?? {}) as T
 }
 
 // ============ User Creation ============
@@ -266,10 +266,10 @@ export async function injectKycWebhook(payload: {
 }): Promise<HandlerResponse> {
   const { req, res } = createReqRes({ body: payload })
   await kycHandler(
-    req as Parameters<typeof kycHandler>[0],
-    res as Parameters<typeof kycHandler>[1],
+    req as unknown as Parameters<typeof kycHandler>[0],
+    res as unknown as Parameters<typeof kycHandler>[1],
   )
-  return { status: res.statusCode, body: res._body }
+  return { status: res.statusCode, body: (res._body ?? {}) as Record<string, unknown> }
 }
 
 /**
@@ -288,10 +288,10 @@ export async function injectExternalAccountWebhook(payload: {
 }): Promise<HandlerResponse> {
   const { req, res } = createReqRes({ body: payload })
   await externalAccountHandler(
-    req as Parameters<typeof externalAccountHandler>[0],
-    res as Parameters<typeof externalAccountHandler>[1],
+    req as unknown as Parameters<typeof externalAccountHandler>[0],
+    res as unknown as Parameters<typeof externalAccountHandler>[1],
   )
-  return { status: res.statusCode, body: res._body }
+  return { status: res.statusCode, body: (res._body ?? {}) as Record<string, unknown> }
 }
 
 /**
@@ -317,10 +317,10 @@ export async function injectDepositWebhook(payload: {
 }): Promise<HandlerResponse> {
   const { req, res } = createReqRes({ body: payload })
   await depositHandler(
-    req as Parameters<typeof depositHandler>[0],
-    res as Parameters<typeof depositHandler>[1],
+    req as unknown as Parameters<typeof depositHandler>[0],
+    res as unknown as Parameters<typeof depositHandler>[1],
   )
-  return { status: res.statusCode, body: res._body }
+  return { status: res.statusCode, body: (res._body ?? {}) as Record<string, unknown> }
 }
 
 // ============ ERPNext Verification ============


### PR DESCRIPTION
Resolves the `Check Code` (`tsc`) failures surfaced once CI began running on the integration branch. The `test/flash/bridge-sandbox-e2e/` suite was never type-checked while Actions was disabled, so type errors accumulated. **Test-only changes — no production code touched.** Fixes ENG-423.

## Changes
- **`helpers.ts` — mock req/res casts (TS2352):** the inject helpers cast `createReqRes()`'s generic objects straight to the Express handler param types. Route them through `as unknown as …` (TS's own suggestion).
- **`helpers.ts` — `execQuery` (TS2339):** made generic (`<T = Record<string, unknown>>`, backward-compatible default) so call sites can type the GraphQL payload.
- **`helpers.ts` — `HandlerResponse.body` (TS18046):** typed as `Record<string, unknown>` instead of `unknown` (defaulting to `{}` in the inject returns), which fixes `.body` access in `deposit-withdrawal.spec` and `external-account.spec` without per-site casts.
- **`cutover-state.spec.ts`:** type the `execQuery` result and narrow the error union (`if ("errors" in response) throw …`) before asserting.

## Validation caveat
- I could **not run `tsc` locally** (no install in my environment), so this is analysis-validated against the exact errors tsc reported. **CI is the real check.**
- This PR **won't show checks until #408 merges** — the integration-branch CI trigger isn't active yet, so PRs into `tmp/bridge-rebase-pr-ready` don't run workflows. Either merge #408 first, or validate this alongside it.
- Scoped strictly to Check Code / the e2e suite. The other red checks (Redis service, integration config, vendir, bats) are separate infra issues tracked in ENG-422.

🤖 Generated with [Claude Code](https://claude.com/claude-code)