### PR TITLE
fix(flash): cap IBEX receive invoice expiration at 60s (ENG-427)

### DIFF
--- a/src/app/wallets/add-invoice-for-wallet.ts
+++ b/src/app/wallets/add-invoice-for-wallet.ts
@@ -5,7 +5,10 @@ import { RateLimitConfig } from "@domain/rate-limit"
 import { checkedToMinutes } from "@domain/primitives"
 import { UnsupportedCurrencyError } from "@domain/errors"
 import { RateLimiterExceededError } from "@domain/rate-limit/errors"
-import { DEFAULT_EXPIRATIONS } from "@domain/bitcoin/lightning/invoice-expiration"
+import {
+  DEFAULT_EXPIRATIONS,
+  ibexReceiveDefaultExpirationMinutes,
+} from "@domain/bitcoin/lightning/invoice-expiration"
 import { WalletInvoiceBuilder } from "@domain/wallet-invoices/wallet-invoice-builder"
 
 import { LndService } from "@services/lnd"
@@ -74,7 +77,7 @@ export const addInvoiceForSelfForUsdWallet = async (
   const walletId = checkedToWalletId(args.walletId)
   if (walletId instanceof Error) return walletId
 
-  const expiresIn = checkedToMinutes(args.expiresIn || defaultUsdExpiration)
+  const expiresIn = checkedToMinutes(args.expiresIn || ibexReceiveDefaultExpirationMinutes)
   if (expiresIn instanceof Error) return expiresIn
 
   const validated = await validateIsUsdWallet(walletId)
@@ -160,7 +163,7 @@ export const addInvoiceForRecipientForUsdWallet = async (
   const recipientWalletId = checkedToWalletId(args.recipientWalletId)
   if (recipientWalletId instanceof Error) return recipientWalletId
 
-  const expiresIn = checkedToMinutes(args.expiresIn || defaultUsdExpiration)
+  const expiresIn = checkedToMinutes(args.expiresIn || ibexReceiveDefaultExpirationMinutes)
   if (expiresIn instanceof Error) return expiresIn
 
   const validated = await validateIsUsdWallet(recipientWalletId)

--- a/src/domain/bitcoin/lightning/index.ts
+++ b/src/domain/bitcoin/lightning/index.ts
@@ -6,6 +6,9 @@ export { decodeInvoice } from "./ln-invoice"
 export {
   invoiceExpirationForCurrency,
   defaultTimeToExpiryInSeconds,
+  IBEX_RECEIVE_MAX_EXPIRATION_SECONDS,
+  ibexReceiveDefaultExpirationMinutes,
+  cappedIbexReceiveExpiration,
 } from "./invoice-expiration"
 export * from "./errors"
 

--- a/src/domain/bitcoin/lightning/invoice-expiration.ts
+++ b/src/domain/bitcoin/lightning/invoice-expiration.ts
@@ -6,6 +6,33 @@ const SECS_PER_DAY = toSeconds(60 * 60 * 24)
 
 export const defaultTimeToExpiryInSeconds = SECS_PER_5_MINS
 
+// IBEX caps BOLT11 receive-invoice expiry by the account's currency type:
+//   - msat currency accounts: up to 900s
+//   - all other currency accounts (USD/USDT/JMD): up to 60s
+// Flash does not use msat currency accounts for its IBEX receive flows, so
+// every Flash IBEX receive invoice is limited to 60s. IBEX silently caps any
+// larger requested expiration down to this value, so the backend must not
+// request more than this. (Confirmed by IBEX 2026-06-18 — see ENG-427.)
+export const IBEX_RECEIVE_MAX_EXPIRATION_SECONDS = SECS_PER_MIN
+
+// Default receive-invoice expiry for Flash IBEX flows, expressed in minutes for
+// the GraphQL `expiresIn` contract. Capped at the IBEX limit above.
+export const ibexReceiveDefaultExpirationMinutes = (IBEX_RECEIVE_MAX_EXPIRATION_SECONDS /
+  SECS_PER_MIN) as Minutes
+
+// Clamp a requested IBEX receive-invoice expiration to the account-type limit.
+// `undefined` is passed through so IBEX applies its own account default.
+export const cappedIbexReceiveExpiration = (
+  expiration?: Seconds,
+): Seconds | undefined => {
+  if (expiration === undefined) return undefined
+  return (
+    expiration > IBEX_RECEIVE_MAX_EXPIRATION_SECONDS
+      ? IBEX_RECEIVE_MAX_EXPIRATION_SECONDS
+      : expiration
+  ) as Seconds
+}
+
 export const DEFAULT_EXPIRATIONS = {
   BTC: { delay: SECS_PER_DAY, delayMinutes: (SECS_PER_DAY / SECS_PER_MIN) as Minutes },
   USD: {

--- a/src/services/ibex/client.ts
+++ b/src/services/ibex/client.ts
@@ -7,6 +7,7 @@ import WebhookServer from "./webhook-server";
 import { Redis }  from "./cache"
 import { GetFeeEstimateArgs, IbexAccountDetails, IbexFeeEstimation, IbexInvoiceArgs, PayInvoiceArgs, SendOnchainArgs } from "./types";
 import { USDAmount } from "@domain/shared";
+import { cappedIbexReceiveExpiration } from "@domain/bitcoin/lightning";
 
 const Ibex = new IbexClient(
   { clientId: IbexConfig.clientId, clientSecret: IbexConfig.clientSecret, environment: IbexConfig.environment },
@@ -41,11 +42,14 @@ const getAccountTransactions = async (params: GMetadataParam): Promise<GResponse
 }
 
 const addInvoice = async (args: IbexInvoiceArgs): Promise<AddInvoiceResponse201 | IbexError> => {
-  const body = { 
-      ...args, 
-      amount: args.amount?.toIbex(), 
+  const body = {
+      ...args,
+      amount: args.amount?.toIbex(),
+      // IBEX silently caps non-msat receive invoices at 60s; never request more.
+      // See IBEX_RECEIVE_MAX_EXPIRATION_SECONDS (ENG-427).
+      expiration: cappedIbexReceiveExpiration(args.expiration),
       webhookUrl: WebhookServer.endpoints.onReceive.invoice,
-      webhookSecret: WebhookServer.secret, 
+      webhookSecret: WebhookServer.secret,
   } as AddInvoiceBodyParam
   addAttributesToCurrentSpan({ "request.params": JSON.stringify(body) })
   return Ibex.addInvoice(body).then(errorHandler)

--- a/test/flash/unit/domain/bitcoin/lightning/invoice-expiration.spec.ts
+++ b/test/flash/unit/domain/bitcoin/lightning/invoice-expiration.spec.ts
@@ -2,7 +2,12 @@ import { SECS_PER_10_MINS, SECS_PER_DAY } from "@config"
 
 import { toSeconds } from "@domain/primitives"
 import { WalletCurrency } from "@domain/shared"
-import { invoiceExpirationForCurrency } from "@domain/bitcoin/lightning"
+import {
+  invoiceExpirationForCurrency,
+  IBEX_RECEIVE_MAX_EXPIRATION_SECONDS,
+  ibexReceiveDefaultExpirationMinutes,
+  cappedIbexReceiveExpiration,
+} from "@domain/bitcoin/lightning"
 
 describe("invoiceExpirationForCurrency", () => {
   const BTC = WalletCurrency.Btc
@@ -59,5 +64,42 @@ describe("invoiceExpirationForCurrency", () => {
     const expiration = invoiceExpirationForCurrency(currency, now, delay)
     const expectedExpiration = new Date("2000-01-01T00:03:00Z")
     expect(expiration).toEqual(expectedExpiration)
+  })
+})
+
+// ENG-427: Flash uses non-msat IBEX currency accounts for receive, which IBEX
+// caps at a 60s BOLT11 expiry. These guard the backend from requesting more.
+describe("IBEX receive-invoice expiration policy", () => {
+  it("caps the receive-invoice limit at 60 seconds", () => {
+    expect(IBEX_RECEIVE_MAX_EXPIRATION_SECONDS).toEqual(60)
+  })
+
+  it("uses a default of 1 minute so the requested expiration is exactly 60s", () => {
+    // The GraphQL `expiresIn` contract is in minutes and is multiplied by 60
+    // before reaching IBEX. A 1-minute default keeps the request at 60s and
+    // prevents the previous 5-minute (300s) default from being requested again.
+    expect(ibexReceiveDefaultExpirationMinutes).toEqual(1)
+    expect(ibexReceiveDefaultExpirationMinutes * 60).toEqual(
+      IBEX_RECEIVE_MAX_EXPIRATION_SECONDS,
+    )
+  })
+
+  describe("cappedIbexReceiveExpiration", () => {
+    it("passes undefined through so IBEX applies its account default", () => {
+      expect(cappedIbexReceiveExpiration(undefined)).toBeUndefined()
+    })
+
+    it("leaves an expiration at or below the cap unchanged", () => {
+      expect(cappedIbexReceiveExpiration(toSeconds(60))).toEqual(60)
+      expect(cappedIbexReceiveExpiration(toSeconds(30))).toEqual(30)
+    })
+
+    it("clamps a 5-minute (300s) request down to 60s", () => {
+      expect(cappedIbexReceiveExpiration(toSeconds(300))).toEqual(60)
+    })
+
+    it("clamps the msat-account max (900s) down to 60s for Flash accounts", () => {
+      expect(cappedIbexReceiveExpiration(toSeconds(900))).toEqual(60)
+    })
   })
 })


### PR DESCRIPTION
## Summary

Flash uses **non-msat** IBEX currency accounts (USD/USDT/JMD) for its receive flows. IBEX caps BOLT11 receive-invoice expiry by account type — **60s** for these accounts, 900s only for msat accounts. The backend defaulted to **5 minutes (300s)** and sent `expiration: 300` to IBEX, which **silently capped it to 60s**. So the requested value was never honored, and the mobile receive screen shows a 60s countdown that looked like a bug.

This aligns the backend with the real IBEX limit so we never request an expiration IBEX will ignore.

## Changes

- **`invoice-expiration.ts`** — add a documented `IBEX_RECEIVE_MAX_EXPIRATION_SECONDS` (60s) constant recording the IBEX account-type limit, an `ibexReceiveDefaultExpirationMinutes` default, and a pure `cappedIbexReceiveExpiration()` clamp.
- **`ibex/client.ts`** — clamp `expiration` centrally in the `addInvoice` wrapper (the single choke point for every IBEX receive invoice), so no caller can request more than 60s, regardless of an explicit `expiresIn` override.
- **`add-invoice-for-wallet.ts`** — default the USD receive flows to 60s instead of 300s.
- **Tests** — extend `invoice-expiration.spec.ts` with the policy, including a regression guard that a 5-minute (300s) request can never reach IBEX.

## Notes / decisions

- **Mobile needs no change** — the receive countdown already decodes the actual BOLT11 expiry (`prToDateString` / `decodeInvoiceString(...).timeExpireDateString`), so it will correctly show 60s.
- The clamp scopes naturally to IBEX: it lives in `Ibex.addInvoice`, so the legacy no-amount / LND `WalletInvoiceBuilder` path is untouched.
- `undefined` expiration is passed through so IBEX applies its own account default.

## Acceptance criteria
- [x] Backend expiration defaults for current Flash IBEX receive flows cap at 60s
- [x] Tests cover the policy so a 5-minute default can't be reapplied to non-msat accounts
- [x] Mobile receive countdown remains based on the actual BOLT11 expiry (unchanged)
- [x] The IBEX account-type limit is documented next to the expiry policy

Closes ENG-427.

🤖 Generated with [Claude Code](https://claude.com/claude-code)