### PR TITLE
feat(ibex): validate Ibex webhook sender IP against an allowlist (ISL-112)

### DIFF
--- a/dev/config/base-config.yaml
+++ b/dev/config/base-config.yaml
@@ -11,6 +11,9 @@ ibex:
     uri: "" # external uri defined in overrides
     port: 4008
     secret: "not-so-secret"
+    # Ibex's published source IPs / CIDRs for webhook delivery. Populate in
+    # production overrides to enforce the allowlist; empty disables it (ISL-112).
+    allowedIps: []
 
 # See Foreign Exchange Rates: https://www.firstglobal-bank.com/
 exchangeRates:

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -638,6 +638,13 @@ export const configSchema = {
             port: { type: "integer" },
             uri: { type: "string" },
             secret: { type: "string" },
+            // Ibex's published source IPs / CIDRs for webhook delivery. Empty
+            // disables the allowlist check (see ISL-112).
+            allowedIps: {
+              type: "array",
+              items: { type: "string" },
+              default: [],
+            },
           },
         },
       },

--- a/src/config/schema.types.d.ts
+++ b/src/config/schema.types.d.ts
@@ -20,6 +20,7 @@ type WebhookServer = {
   uri: string
   port: number
   secret: string
+  allowedIps?: string[]
 }
 
 type IbexConfig = {

--- a/src/services/ibex/webhook-server/middleware/index.ts
+++ b/src/services/ibex/webhook-server/middleware/index.ts
@@ -1,2 +1,3 @@
 export * from "./authenticate"
 export * from "./logRequest"
+export * from "./validate-ibex-ip"

--- a/src/services/ibex/webhook-server/middleware/validate-ibex-ip.ts
+++ b/src/services/ibex/webhook-server/middleware/validate-ibex-ip.ts
@@ -1,0 +1,75 @@
+import { Request, Response, NextFunction } from "express"
+import requestIp from "request-ip"
+import ipaddr from "ipaddr.js"
+
+import { IbexConfig } from "@config"
+import { baseLogger as logger } from "@services/logger"
+
+type ParsedRange = [ipaddr.IPv4 | ipaddr.IPv6, number]
+
+const parseAllowlistEntry = (entry: string): ParsedRange | null => {
+  const trimmed = entry.trim()
+  if (!trimmed) return null
+  try {
+    // Accept both single IPs ("1.2.3.4") and CIDR ranges ("1.2.3.0/24").
+    if (trimmed.includes("/")) return ipaddr.parseCIDR(trimmed)
+    const addr = ipaddr.parse(trimmed)
+    return [addr, addr.kind() === "ipv6" ? 128 : 32]
+  } catch {
+    logger.error({ entry }, "Ignoring invalid Ibex webhook IP allowlist entry")
+    return null
+  }
+}
+
+export const parseAllowlist = (entries: readonly string[]): ParsedRange[] =>
+  entries.map(parseAllowlistEntry).filter((r): r is ParsedRange => r !== null)
+
+// Parsed once at module load from config.
+const allowlist: ParsedRange[] = parseAllowlist(IbexConfig.webhook.allowedIps ?? [])
+
+export const ibexWebhookIpAllowlistEnabled = allowlist.length > 0
+
+export const isIpInAllowlist = (
+  clientIp: string | null | undefined,
+  ranges: ParsedRange[] = allowlist,
+): boolean => {
+  if (!clientIp || !ipaddr.isValid(clientIp)) return false
+  // `process` normalizes IPv4-mapped IPv6 (e.g. "::ffff:1.2.3.4") back to IPv4.
+  const addr = ipaddr.process(clientIp)
+  return ranges.some(([rangeAddr, prefix]) => {
+    if (addr.kind() === "ipv4" && rangeAddr.kind() === "ipv4") {
+      return (addr as ipaddr.IPv4).match(rangeAddr as ipaddr.IPv4, prefix)
+    }
+    if (addr.kind() === "ipv6" && rangeAddr.kind() === "ipv6") {
+      return (addr as ipaddr.IPv6).match(rangeAddr as ipaddr.IPv6, prefix)
+    }
+    return false
+  })
+}
+
+/**
+ * Reject Ibex webhook requests whose source IP is not on the configured
+ * allowlist (Ibex publishes the IPs its webhooks originate from). This is
+ * defense-in-depth alongside the shared `webhookSecret` check.
+ *
+ * Fails open when no allowlist is configured (`ibex.webhook.allowedIps` empty),
+ * so payment webhooks are never blocked before an operator populates Ibex's
+ * published IPs. See ISL-112.
+ *
+ * Apply only to authenticated Ibex-webhook routes — never to the public
+ * `GET /pay/lnurl/:username` LNURL-pay endpoint, which legitimately receives
+ * traffic from arbitrary payers.
+ */
+export const validateIbexIp = (req: Request, resp: Response, next: NextFunction) => {
+  if (!ibexWebhookIpAllowlistEnabled) return next()
+
+  const clientIp = requestIp.getClientIp(req)
+  if (!isIpInAllowlist(clientIp)) {
+    logger.warn(
+      { clientIp, path: req.path },
+      "Rejected Ibex webhook request from non-allowlisted IP",
+    )
+    return resp.status(403).end("Forbidden")
+  }
+  next()
+}

--- a/src/services/ibex/webhook-server/routes/on-pay.ts
+++ b/src/services/ibex/webhook-server/routes/on-pay.ts
@@ -1,5 +1,5 @@
 import express, { Request, Response } from "express"
-import { authenticate, logRequest } from "../middleware"
+import { authenticate, logRequest, validateIbexIp } from "../middleware"
 import { WalletsRepository } from "@services/mongoose/wallets"
 import { ZapRequestModel } from "@services/mongoose/zap-request"
 import axios from "axios"
@@ -106,12 +106,21 @@ router.get(
   },
 )
 
-// Keep other routes as stubs
-router.post(paths.invoice, authenticate, logRequest, async (_: Request, resp: Response) =>
-  resp.status(200).end(),
+// Keep other routes as stubs. These are Ibex webhooks (authenticated), so they
+// are IP-restricted; the public GET /pay/lnurl/:username above is not.
+router.post(
+  paths.invoice,
+  validateIbexIp,
+  authenticate,
+  logRequest,
+  async (_: Request, resp: Response) => resp.status(200).end(),
 )
-router.post(paths.onchain, authenticate, logRequest, async (_: Request, resp: Response) =>
-  resp.status(200).end(),
+router.post(
+  paths.onchain,
+  validateIbexIp,
+  authenticate,
+  logRequest,
+  async (_: Request, resp: Response) => resp.status(200).end(),
 )
 
 export { paths, router }

--- a/src/services/ibex/webhook-server/routes/on-receive.ts
+++ b/src/services/ibex/webhook-server/routes/on-receive.ts
@@ -1,7 +1,7 @@
 import express, { Request, Response, NextFunction } from "express"
 import { baseLogger, baseLogger as logger } from "@services/logger"
 import { NotificationsService } from "@services/notifications"
-import { authenticate, logRequest } from "../middleware"
+import { authenticate, logRequest, validateIbexIp } from "../middleware"
 import {
   AccountsRepository,
   UsersRepository,
@@ -174,6 +174,7 @@ const router = express.Router()
 
 router.post(
   paths.invoice,
+  validateIbexIp,
   authenticate,
   logRequest,
   fetchPaymentContext,
@@ -184,6 +185,7 @@ router.post(
 
 router.post(
   paths.lnurl,
+  validateIbexIp,
   authenticate,
   logRequest,
   fetchPaymentContext,
@@ -194,6 +196,7 @@ router.post(
 
 router.post(
   paths.zap,
+  validateIbexIp,
   authenticate,
   logRequest,
   fetchPaymentContext,
@@ -201,12 +204,12 @@ router.post(
   (_req, resp) => resp.status(200).end(),
 )
 
-router.post(paths.cashout, authenticate, logRequest, (_req, resp) => {
+router.post(paths.cashout, validateIbexIp, authenticate, logRequest, (_req, resp) => {
   baseLogger.info("Received payment for cashout.")
   resp.status(200).end()
 })
 
-router.post(paths.onchain, authenticate, logRequest, fetchPaymentContext, sendOnchainNotification, (_req, resp) => {
+router.post(paths.onchain, validateIbexIp, authenticate, logRequest, fetchPaymentContext, sendOnchainNotification, (_req, resp) => {
   baseLogger.info("Received onchain payment.")
   resp.status(200).end()
 })

--- a/test/flash/unit/services/ibex/webhook-server/validate-ibex-ip.spec.ts
+++ b/test/flash/unit/services/ibex/webhook-server/validate-ibex-ip.spec.ts
@@ -1,0 +1,66 @@
+import {
+  parseAllowlist,
+  isIpInAllowlist,
+} from "@services/ibex/webhook-server/middleware/validate-ibex-ip"
+
+describe("Ibex webhook IP allowlist (ISL-112)", () => {
+  describe("parseAllowlist", () => {
+    it("parses single IPs and CIDR ranges, ignoring blanks and invalid entries", () => {
+      const ranges = parseAllowlist([
+        "203.0.113.4",
+        "198.51.100.0/24",
+        "  ",
+        "not-an-ip",
+        "2001:db8::/32",
+      ])
+      // 203.0.113.4, 198.51.100.0/24, 2001:db8::/32 — the blank and "not-an-ip" dropped
+      expect(ranges).toHaveLength(3)
+    })
+  })
+
+  describe("isIpInAllowlist", () => {
+    const ranges = parseAllowlist([
+      "203.0.113.4",
+      "198.51.100.0/24",
+      "2001:db8::/32",
+    ])
+
+    it("matches an exact IPv4 address", () => {
+      expect(isIpInAllowlist("203.0.113.4", ranges)).toBe(true)
+    })
+
+    it("rejects an IPv4 address that is not listed", () => {
+      expect(isIpInAllowlist("203.0.113.5", ranges)).toBe(false)
+    })
+
+    it("matches an IPv4 address inside a CIDR range", () => {
+      expect(isIpInAllowlist("198.51.100.200", ranges)).toBe(true)
+    })
+
+    it("rejects an IPv4 address outside the CIDR range", () => {
+      expect(isIpInAllowlist("198.51.101.1", ranges)).toBe(false)
+    })
+
+    it("normalizes IPv4-mapped IPv6 and matches the IPv4 range", () => {
+      expect(isIpInAllowlist("::ffff:203.0.113.4", ranges)).toBe(true)
+    })
+
+    it("matches an IPv6 address inside a CIDR range", () => {
+      expect(isIpInAllowlist("2001:db8::1", ranges)).toBe(true)
+    })
+
+    it("rejects an IPv6 address outside the range", () => {
+      expect(isIpInAllowlist("2001:dead::1", ranges)).toBe(false)
+    })
+
+    it("returns false for missing or invalid client IPs", () => {
+      expect(isIpInAllowlist(null, ranges)).toBe(false)
+      expect(isIpInAllowlist(undefined, ranges)).toBe(false)
+      expect(isIpInAllowlist("garbage", ranges)).toBe(false)
+    })
+
+    it("returns false when the allowlist is empty", () => {
+      expect(isIpInAllowlist("203.0.113.4", [])).toBe(false)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Ibex recommends confirming that webhook requests originate from its **published source IPs**. This adds an IP-allowlist middleware as **defense-in-depth** alongside the existing shared `webhookSecret` check on the Ibex webhook server.

## Changes

- **New `validateIbexIp` middleware** (`webhook-server/middleware/validate-ibex-ip.ts`):
  - Extracts the client IP via `request-ip` (consistent with `graphql-admin-server.ts`).
  - Matches it against a configured allowlist of **IPs and CIDR ranges** using `ipaddr.js`, via a pure, unit-tested `isIpInAllowlist`. IPv4-mapped IPv6 (`::ffff:1.2.3.4`) is normalized to IPv4 before matching.
  - Returns `403` for non-allowlisted IPs.
- **Fail-open when unconfigured:** if `ibex.webhook.allowedIps` is empty the check is skipped, so payment webhooks are **never blocked before** an operator populates Ibex's IPs (no risk of a self-inflicted webhook outage).
- **Scoped to authenticated webhook routes only.** Applied (before `authenticate`) to the `onReceive` routes (invoice/lnurlp/zap/cashout/onchain) and the authenticated `onPay` POSTs (invoice/onchain). The **public `GET /pay/lnurl/:username`** LNURL-pay endpoint — which legitimately receives traffic from arbitrary payers — is **deliberately left unrestricted**. `/health` is also unaffected.
- **Config:** adds `ibex.webhook.allowedIps` to the JSON schema + TS type and the dev base config (empty default, documented).

## Activation (operator action)

This ships the mechanism; the allowlist is **off by default**. To enforce it, populate `ibex.webhook.allowedIps` with Ibex's published webhook source IPs/CIDRs in the production config overrides. I did not hardcode IPs — they're deployment config and must come from Ibex's docs.

## Validation

- New unit tests: **10/10 pass** — exact IPv4, CIDR in/out, IPv6 range, IPv4-mapped-IPv6, invalid/missing IP, and empty-allowlist cases.
- Full unit suite: **53 suites / 400 tests** green.
- `tsc --noEmit`: zero errors in the touched files.

## Notes
- Client-IP extraction uses `request-ip` (matching the admin server). If this server sits behind a proxy/CDN that can be bypassed, `X-Forwarded-For` spoofing is a theoretical concern — the `webhookSecret` check remains the primary auth, with the IP allowlist as an additional layer. Worth confirming the deployment topology (ingress / trusted proxy) when the IPs are configured.
- No CI on `lnflash/flash` PRs yet, so checks above are local (unit + typecheck).

Closes ISL-112.

🤖 Generated with [Claude Code](https://claude.com/claude-code)