### PR TITLE
fix(bridge): remove leaked sandbox API key from base config

### DIFF
--- a/dev/config/base-config.yaml
+++ b/dev/config/base-config.yaml
@@ -14,7 +14,7 @@ ibex:
 
 bridge:
   enabled: true
-  apiKey: "sk-test-3bd6463c9cd77c3d8858c60b9997d0c6"
+  apiKey: "" # real key injected via config overrides; never commit a real key
   baseUrl: "https://api.sandbox.bridge.xyz/v0"
   minWithdrawalAmount: 2
   timeoutMs: 15000


### PR DESCRIPTION
## Summary

Removes the committed Bridge **sandbox** API key from `dev/config/base-config.yaml` on the integration branch, replacing it with an empty placeholder (real key injected via config overrides, consistent with the `ibex` credentials in the same file).

## Context

- The key was flagged in the #403 review (islandbitcoin) and is live in `dev/config/base-config.yaml` on `tmp/bridge-rebase-pr-ready` (it is **not** present on `main`).
- The key has already been **rotated/revoked at Bridge**, so the value is now inert.
- This is split out as a small, standalone change so it can land immediately, independent of the larger #403 fee-estimate PR (which also replaces the line, with `<replace>`). Trivial conflict on that one line if both merge; either placeholder is fine.

## History note

The rotated key still exists in older commit history. Because it is revoked it is **no longer a live secret**, so a history rewrite of the shared branch is optional and, if desired, should be coordinated separately (force-pushing a shared integration branch with an open fork PR against it is disruptive).

## Verification
- `git grep` confirms the key value is gone from the working tree.
- `base-config.yaml` still parses; `bridge.apiKey` is `""` (valid for the required `string` config field).

🤖 Generated with [Claude Code](https://claude.com/claude-code)