### PR TITLE
fix: route quickstart through flash service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ RUN yarn install --frozen-lockfile
 
 COPY ./src ./src
 
+RUN chmod -R a+rX /app/src
+
 RUN yarn build
 
 RUN yarn install --frozen-lockfile --production

--- a/quickstart/bin/quickstart.sh
+++ b/quickstart/bin/quickstart.sh
@@ -7,34 +7,18 @@ COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-quickstart}"
 DIR="$(dirname "$(readlink -f "$BASH_SOURCE")")"
 source ${DIR}/helpers.sh
 
-show_galoy() {
+show_flash() {
 cat << "EOF"
-                 ('-.                                        
-                ( OO ).-.                                    
-    ,----.      / . --. / ,--.      .-'),-----.   ,--.   ,--.
-   '  .-./-')   | \-.  \  |  |.-') ( OO'  .-.  '   \  `.'  / 
-   |  |_( O- ).-'-'  |  | |  | OO )/   |  | |  | .-')     /  
-   |  | .--, \ \| |_.'  | |  |`-' |\_) |  |\|  |(OO  \   /   
-  (|  | '. (_/  |  .-.  |(|  '---.'  \ |  | |  | |   /  /\_  
-   |  '--'  |   |  | |  | |      |    `'  '-'  ' `-./  /.__) 
-    `------'    `--' `--' `------'      `-----'    `--'      
+Flash quickstart
 EOF
 }
 
 main() {
-  show_galoy
+  show_flash
   echo "------------------------------------------------------------"
   echo "------------------------------------------------------------"
   echo
-  echo "Checking that all services are up and running"
-  echo
-  ${DIR}/init-onchain.sh
-  ${DIR}/init-lightning.sh
-  echo
-  echo "------------------------------------------------------------"
-  echo "------------------------------------------------------------"
-  echo
-  echo "Hitting graphql endpoints"
+  echo "Checking Flash public GraphQL endpoint"
 
   echo "Running on network:"
   for i in {1..90}; do
@@ -48,18 +32,8 @@ main() {
     echo "$output" | jq .
     exit 1
   fi
-  echo
-  for i in {1..10}; do
-    echo "Logging in Alice"
-    login_user "alice" "+16505554328" "000000" && break
-    sleep 1
-  done
 
-  initialize_user_from_onchain "alice" "+16505554328" "000000" 
-  echo "Alice account set up, token: $(read_value "alice")"
-  
-  echo "TOKEN_ALICE=$(read_value "alice")"
-  export TOKEN_ALICE=$(read_value "alice")
+  echo "DONE"
 }
 
 main

--- a/quickstart/bin/re-render.sh
+++ b/quickstart/bin/re-render.sh
@@ -11,6 +11,37 @@ pushd ${REPO_ROOT}/quickstart
 ytt -f vendir > vendir.yml
 vendir sync
 
+rewrite_flash_quickstart_hosts() {
+  local files=(
+    dev/apollo-federation/supergraph-config.yaml
+    dev/apollo-federation/supergraph.graphql
+    dev/ory/kratos.yml
+    dev/ory/oathkeeper_rules.yaml
+  )
+
+  for file in "${files[@]}"; do
+    sed -i.bak 's#http://bats-tests:#http://flash:#g' "${file}"
+    rm -f "${file}.bak"
+  done
+
+  local app_check_files=(
+    dev/ory/oathkeeper.yml
+    dev/ory/oathkeeper_rules.yaml
+  )
+
+  for file in "${app_check_files[@]}"; do
+    sed -i.bak \
+      -e 's#- id: galoy-ws#- id: flash-ws#' \
+      -e 's#- id: galoy-backend#- id: flash-backend#' \
+      -e 's#firebaseappcheck.googleapis.com/72279297366#firebaseappcheck.googleapis.com/806646140435#' \
+      -e 's#projects/72279297366#projects/806646140435#' \
+      "${file}"
+    rm -f "${file}.bak"
+  done
+}
+
+rewrite_flash_quickstart_hosts
+
 ytt -f ./docker-compose.tmpl.yml -f ${GALOY_ROOT_DIR}/docker-compose.yml -f ${GALOY_ROOT_DIR}/docker-compose.override.yml > docker-compose.yml
 
 pushd ${GALOY_ROOT_DIR}

--- a/quickstart/config/quickstart-config.yaml
+++ b/quickstart/config/quickstart-config.yaml
@@ -1,0 +1,2 @@
+ibex:
+  mock: true

--- a/quickstart/dev/apollo-federation/supergraph-config.yaml
+++ b/quickstart/dev/apollo-federation/supergraph-config.yaml
@@ -1,6 +1,6 @@
 federation_version: =2.3.2
 subgraphs:
   public:
-    routing_url: http://bats-tests:4012/graphql
+    routing_url: http://flash:4012/graphql
     schema:
       file: ../../src/graphql/public/schema.graphql

--- a/quickstart/dev/apollo-federation/supergraph.graphql
+++ b/quickstart/dev/apollo-federation/supergraph.graphql
@@ -556,7 +556,7 @@ enum InvoicePaymentStatus
 scalar join__FieldSet
 
 enum join__Graph {
-  PUBLIC @join__graph(name: "public", url: "http://bats-tests:4012/graphql")
+  PUBLIC @join__graph(name: "public", url: "http://flash:4012/graphql")
 }
 
 scalar Language

--- a/quickstart/dev/ory/kratos.yml
+++ b/quickstart/dev/ory/kratos.yml
@@ -70,7 +70,7 @@ selfservice:
           hooks:
             - hook: web_hook
               config:
-                # url: http://bats-tests:4002/auth/after_settings_hooks
+                # url: http://flash:4002/auth/after_settings_hooks
                 url: http://invalid-because-we-dont-want-profile-to-be-updated
                 method: POST
                 body: file:///home/ory/body.jsonnet
@@ -119,7 +119,7 @@ selfservice:
             #
             # - hook: web_hook
             #   config:
-            #     url: http://bats-tests:4012/kratos/preregistration
+            #     url: http://flash:4012/kratos/preregistration
             #     method: POST
             #     response:
             #       parse: true
@@ -132,7 +132,7 @@ selfservice:
             #         in: header
             - hook: web_hook
               config:
-                url: http://bats-tests:4012/kratos/registration
+                url: http://flash:4012/kratos/registration
                 method: POST
                 response:
                   parse: false

--- a/quickstart/dev/ory/oathkeeper_rules.yaml
+++ b/quickstart/dev/ory/oathkeeper_rules.yaml
@@ -1,6 +1,6 @@
 - id: anonymous-rest-auth
   upstream:
-    url: "http://bats-tests:4012"
+    url: "http://flash:4012"
   match:
     url: "<(http|https)>://<[a-zA-Z0-9-.:]+>/auth/<(clearCookies|login|logout|email/code|email/login|totp/validate|email/login/cookie)>"
     methods: ["GET", "POST", "OPTIONS"]
@@ -13,7 +13,7 @@
 
 - id: device-login
   upstream:
-    url: "http://bats-tests:4012"
+    url: "http://flash:4012"
   match:
     url: "<(http|https)>://<[a-zA-Z0-9-.:]+>/auth/create/device-account"
     methods: ["POST"]
@@ -34,9 +34,9 @@
   mutators:
     - handler: noop
 
-- id: galoy-ws
+- id: flash-ws
   upstream:
-    url: "http://bats-tests:4000/graphql"
+    url: "http://flash:4000/graphql"
     strip_path: /graphqlws # ONLY FOR DEV, in prod should resolve to /graphql, like ws.blink.sv/graphql
   match:
     url: "<(http|https)>://<[a-zA-Z0-9-.:]+>/graphqlws" # ONLY FOR DEV, in prod should resolve to /graphql
@@ -48,7 +48,7 @@
   mutators:
     - handler: noop
 
-- id: galoy-backend
+- id: flash-backend
   upstream:
     url: "http://apollo-router:4004"
   match:
@@ -79,7 +79,7 @@
 
 - id: admin-backend
   upstream:
-    url: "http://bats-tests:4001"
+    url: "http://flash:4001"
     strip_path: /admin
   match:
     url: "<(http|https)>://<.*><[0-9]+>/admin<.*>"

--- a/quickstart/docker-compose.tmpl.yml
+++ b/quickstart/docker-compose.tmpl.yml
@@ -50,7 +50,16 @@ services:
       - "-r"
       - "/app/lib/services/tracing.js"
       - "lib/servers/graphql-main-server.js"
+      - "--configPath"
+      - "/app/dev/config/base-config.yaml"
+      - "--configPath"
+      - "/app/quickstart/config/quickstart-config.yaml"
     env_file: ${HOST_PROJECT_PATH:-.}/${GALOY_QUICKSTART_PATH:-vendor/galoy-quickstart}/.env.galoy
+    environment:
+    - FLASH_ENABLE_IBEX_MOCK=true
+    volumes:
+    - ${FLASH_PROJECT_PATH:-..}/dev/config:/app/dev/config:ro
+    - ${FLASH_PROJECT_PATH:-..}/quickstart/config:/app/quickstart/config:ro
     depends_on:
     - trigger
     - apollo-router
@@ -75,7 +84,16 @@ services:
       - "-r"
       - "/app/lib/services/tracing.js"
       - "lib/servers/trigger.js"
+      - "--configPath"
+      - "/app/dev/config/base-config.yaml"
+      - "--configPath"
+      - "/app/quickstart/config/quickstart-config.yaml"
     env_file: ${HOST_PROJECT_PATH:-.}/${GALOY_QUICKSTART_PATH:-vendor/galoy-quickstart}/.env.galoy
+    environment:
+    - FLASH_ENABLE_IBEX_MOCK=true
+    volumes:
+    - ${FLASH_PROJECT_PATH:-..}/dev/config:/app/dev/config:ro
+    - ${FLASH_PROJECT_PATH:-..}/quickstart/config:/app/quickstart/config:ro
     depends_on:
     - lnd1
     - bria

--- a/quickstart/docker-compose.tmpl.yml
+++ b/quickstart/docker-compose.tmpl.yml
@@ -12,7 +12,7 @@ services:
       - oathkeeper
       - kratos
       - kratos-pg
-      - galoy
+      - flash
       - trigger
       - redis
       - mongodb
@@ -37,7 +37,7 @@ services:
   kratos: #@ data.values.services["kratos"]
   kratos-pg: #@ data.values.services["kratos-pg"]
 
-  galoy:
+  flash:
 #@ if galoy_image_digest == "local":
     build:
       context: ../
@@ -62,10 +62,6 @@ services:
     - mongodb
     - redis
     - stablesats
-    networks:
-      default:
-        aliases:
-        - bats-tests
   trigger:
 #@ if galoy_image_digest == "local":
     build:

--- a/quickstart/docker-compose.yml
+++ b/quickstart/docker-compose.yml
@@ -74,7 +74,16 @@ services:
     - -r
     - /app/lib/services/tracing.js
     - lib/servers/graphql-main-server.js
+    - --configPath
+    - /app/dev/config/base-config.yaml
+    - --configPath
+    - /app/quickstart/config/quickstart-config.yaml
     env_file: ${HOST_PROJECT_PATH:-.}/${GALOY_QUICKSTART_PATH:-vendor/galoy-quickstart}/.env.galoy
+    environment:
+    - FLASH_ENABLE_IBEX_MOCK=true
+    volumes:
+    - ${FLASH_PROJECT_PATH:-..}/dev/config:/app/dev/config:ro
+    - ${FLASH_PROJECT_PATH:-..}/quickstart/config:/app/quickstart/config:ro
     depends_on:
     - trigger
     - apollo-router
@@ -92,7 +101,16 @@ services:
     - -r
     - /app/lib/services/tracing.js
     - lib/servers/trigger.js
+    - --configPath
+    - /app/dev/config/base-config.yaml
+    - --configPath
+    - /app/quickstart/config/quickstart-config.yaml
     env_file: ${HOST_PROJECT_PATH:-.}/${GALOY_QUICKSTART_PATH:-vendor/galoy-quickstart}/.env.galoy
+    environment:
+    - FLASH_ENABLE_IBEX_MOCK=true
+    volumes:
+    - ${FLASH_PROJECT_PATH:-..}/dev/config:/app/dev/config:ro
+    - ${FLASH_PROJECT_PATH:-..}/quickstart/config:/app/quickstart/config:ro
     depends_on:
     - lnd1
     - bria

--- a/quickstart/docker-compose.yml
+++ b/quickstart/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     - oathkeeper
     - kratos
     - kratos-pg
-    - galoy
+    - flash
     - trigger
     - redis
     - mongodb
@@ -68,7 +68,7 @@ services:
     - POSTGRES_USER=dbuser
     - POSTGRES_PASSWORD=secret
     - POSTGRES_DB=default
-  galoy:
+  flash:
     image: us.gcr.io/galoy-org/galoy-app@sha256:61eec2c0747ce8e20e1a45f1d0492e955631e6d89f25cf2364c0727b27786cfe
     command:
     - -r
@@ -86,10 +86,6 @@ services:
     - mongodb
     - redis
     - stablesats
-    networks:
-      default:
-        aliases:
-        - bats-tests
   trigger:
     image: us.gcr.io/galoy-org/galoy-app@sha256:61eec2c0747ce8e20e1a45f1d0492e955631e6d89f25cf2364c0727b27786cfe
     command:

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -629,6 +629,7 @@ export const configSchema = {
     ibex: {
       type: "object",
       properties: {
+        mock: { type: "boolean", default: false },
         clientId: { type: "string" },
         clientSecret: { type: "string" },
         environment: { type: "string", enum: ["production", "sandbox"] },

--- a/src/config/schema.types.d.ts
+++ b/src/config/schema.types.d.ts
@@ -24,6 +24,7 @@ type WebhookServer = {
 }
 
 type IbexConfig = {
+  mock?: boolean
   clientId: string
   clientSecret: string
   environment: 'production' | 'sandbox'

--- a/src/services/ibex/client.ts
+++ b/src/services/ibex/client.ts
@@ -63,11 +63,23 @@ const Ibex = new IbexClient(
 )
 
 const IbexUrlConfig = IbexUrls[IbexConfig.environment]
+const mockIbexEnabled =
+  IbexConfig.mock === true && process.env.FLASH_ENABLE_IBEX_MOCK === "true"
+const mockLnurl =
+  "lnurl1dp68gurn8ghj7um9dej8xct5w3skccne9e3k7mf0d3h82unvwqhkxun0wa5kgct5v93kzmmfd3skjmn0wvhxcmmv9u"
 
 const createAccount = async (
   name: string,
   currencyId: IbexCurrencyId,
 ): Promise<CreateAccountResponse201 | IbexError> => {
+  if (mockIbexEnabled) {
+    return {
+      id: `quickstart-${name}-${currencyId}`,
+      name,
+      currencyId,
+    } as CreateAccountResponse201
+  }
+
   return Ibex.createAccount({ name, currencyId }).then(errorHandler)
 }
 
@@ -286,6 +298,10 @@ const estimateOnchainFee = async (
 const createLnurlPay = async (
   body: CreateLnurlPayBodyParam,
 ): Promise<CreateLnurlPayResponse201 | IbexError> => {
+  if (mockIbexEnabled) {
+    return { lnurl: mockLnurl } as CreateLnurlPayResponse201
+  }
+
   const bodyWithHooks = {
     ...body,
     webhookUrl: WebhookServer.endpoints.onReceive.lnurl,

--- a/test/flash/bridge-sandbox-e2e/README.md
+++ b/test/flash/bridge-sandbox-e2e/README.md
@@ -30,7 +30,7 @@ The package scripts source `.env` from the project root, then source `.env.local
 ```bash
 # Required
 export IBEX_ENVIRONMENT=sandbox
-export MONGODB_CON=mongodb://localhost:27017/flash
+export MONGODB_CON=mongodb://localhost:27017/galoy
 
 # Bridge sandbox — fill from Bridge dashboard
 # These are the API key and webhook secret, not stored in .env directly in production:


### PR DESCRIPTION
## Summary
- Rename the quickstart app service from `galoy` to `flash` and render Apollo Router, Kratos, and Oathkeeper upstreams to `http://flash:...` instead of legacy Galoy/Bats service names.
- Pass Flash YAML config into the quickstart `flash` and `trigger` containers, including a quickstart-only overlay.
- Add a guarded quickstart IBEX mock for local bootstrap: it requires both `ibex.mock: true` in the quickstart overlay and `FLASH_ENABLE_IBEX_MOCK=true` in Compose, so normal environments still use real IBEX.
- Narrow `quickstart.sh` to a Flash public GraphQL smoke test instead of running the old Galoy BTC-wallet funding flow.
- Fix distroless image source asset permissions so the non-root runtime can read copied config/proto assets.

## Note
The previous revision used `galoy` because that was the inherited Compose service name for the local app container. Dread was right to call that out: Flash quickstart should not encode Galoy service routing, and CI quickstart should not need real IBEX sandbox credentials.

## Verification
- `GALOY_QUICKSTART_PATH=./ docker compose -f quickstart/docker-compose.yml config --quiet`
- `bash -n quickstart/bin/re-render.sh quickstart/bin/quickstart.sh`
- `git diff --check`
- `ytt -f ./docker-compose.tmpl.yml -f galoy/docker-compose.yml -f galoy/docker-compose.override.yml | rg -n "/app/quickstart/config|FLASH_ENABLE_IBEX_MOCK|http://(galoy|bats-tests):|firebaseappcheck.googleapis.com/72279297366|projects/72279297366"`
- Isolated local quickstart smoke with local Flash images and alternate host ports: `GALOY_ENDPOINT=localhost:14002 COMPOSE_PROJECT_NAME=qs415ci ./bin/quickstart.sh` → `regtest`, `DONE`