### PR TITLE
chore: upgrade Node.js 20 (EOL) → 24 LTS

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 24
           cache: "yarn"
       - run: yarn install --frozen-lockfile
       - name: Run audit

--- a/.github/workflows/bats.yml
+++ b/.github/workflows/bats.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 24
           cache: "yarn"
       - run: yarn install --frozen-lockfile
       - name: Run bats tests

--- a/.github/workflows/check-code.yml
+++ b/.github/workflows/check-code.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 24
           cache: "yarn"
       - run: yarn install --frozen-lockfile
       - name: Run check code

--- a/.github/workflows/generate-graphql-docs.yml
+++ b/.github/workflows/generate-graphql-docs.yml
@@ -20,7 +20,7 @@ jobs:
           path: docs
       - uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 24
       - run: yarn install --frozen-lockfile
         working-directory: main
       - uses: vmware-tanzu/carvel-setup-action@v1

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 24
           cache: "yarn"
       - run: yarn install --frozen-lockfile
       - name: Run integration tests

--- a/.github/workflows/mongodb-migrate.yml
+++ b/.github/workflows/mongodb-migrate.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 24
           cache: "yarn"
       - run: yarn install --frozen-lockfile
       - name: Run clean mongodb migration

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 24
           cache: "yarn"
       - run: yarn install --frozen-lockfile
       - name: Run unit tests

--- a/.github/workflows/vendor/nodejs-audit.yml
+++ b/.github/workflows/vendor/nodejs-audit.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 24
           cache: "yarn"
       - run: yarn install --frozen-lockfile
       - name: Run audit

--- a/.github/workflows/vendor/nodejs-check-code.yml
+++ b/.github/workflows/vendor/nodejs-check-code.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 24
           cache: "yarn"
       - run: yarn install --frozen-lockfile
       - name: Run check code

--- a/DEV.md
+++ b/DEV.md
@@ -29,12 +29,12 @@ If you prefer to set things up yourself, or if the setup script fails:
 
 | Tool | Required Version | Install |
 |------|-----------------|---------|
-| Node.js | 20.x (20.18.1+ recommended) | [nvm](https://github.com/nvm-sh/nvm): `nvm install 20` |
+| Node.js | 24.x (24.0.0+ required) | [nvm](https://github.com/nvm-sh/nvm): `nvm install 24` |
 | yarn | 1.x | `corepack enable && corepack prepare yarn@1 --activate` |
 | Docker | 20+ with compose v2 | [Docker Desktop](https://www.docker.com/products/docker-desktop) |
 | direnv | any (optional) | [direnv.net](https://direnv.net) |
 
-> **Note:** The project specifies `"node": "20"` in `package.json`. Node 22+ will fail on `yarn install` due to transitive dependency engine checks. Use `--ignore-engines` if you need to override, but Node 20.x is recommended.
+> **Note:** The project specifies `"node": ">=24.0.0 <25"` in `package.json`. The repo's `.yarnrc` sets `ignore-engines true`, so transitive dependency engine checks are bypassed and `yarn install` succeeds on Node 24. Node 24.x (LTS) is required.
 
 ### 1. Environment Variables
 
@@ -221,7 +221,7 @@ You're hitting the GraphQL server directly (port 4012). Use the oathkeeper proxy
 
 ### `The engine "node" is incompatible`
 
-Flash requires Node 20.x. Switch with `nvm use 20` or run `yarn install --ignore-engines`.
+Flash requires Node 24.x. Switch with `nvm use 24` or run `yarn install --ignore-engines`.
 
 ### Docker warnings about unset variables
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine AS BUILD_IMAGE
+FROM node:24-alpine AS BUILD_IMAGE
 
 WORKDIR /app
 
@@ -16,7 +16,7 @@ RUN yarn install --frozen-lockfile --production
 
 RUN touch .env
 
-FROM gcr.io/distroless/nodejs20-debian11
+FROM gcr.io/distroless/nodejs24-debian12
 COPY --from=BUILD_IMAGE /app/.env /app/.env
 COPY --from=BUILD_IMAGE /app/lib /app/lib
 COPY --from=BUILD_IMAGE /app/src/config/locales /app/lib/config/locales

--- a/Dockerfile-debug
+++ b/Dockerfile-debug
@@ -1,4 +1,4 @@
-FROM node:20-alpine AS BUILD_IMAGE
+FROM node:24-alpine AS BUILD_IMAGE
 
 WORKDIR /app
 
@@ -15,7 +15,7 @@ RUN yarn build
 
 RUN touch .env
 
-FROM gcr.io/distroless/nodejs20-debian11:debug
+FROM gcr.io/distroless/nodejs24-debian12:debug
 COPY --from=BUILD_IMAGE /app/.env /app/.env
 COPY --from=BUILD_IMAGE /app/lib /app/lib
 COPY --from=BUILD_IMAGE /app/src/config/locales /app/lib/config/locales

--- a/Dockerfile-migrate
+++ b/Dockerfile-migrate
@@ -1,4 +1,4 @@
-FROM node:20-alpine AS BUILD_IMAGE
+FROM node:24-alpine AS BUILD_IMAGE
 
 WORKDIR /app
 
@@ -15,7 +15,7 @@ RUN yarn build
 
 COPY ./scripts ./scripts
 
-FROM node:20-alpine
+FROM node:24-alpine
 COPY --from=BUILD_IMAGE /app/lib /app/lib
 COPY --from=BUILD_IMAGE /app/src/config/locales /app/lib/config/locales
 COPY --from=BUILD_IMAGE /app/node_modules /app/node_modules

--- a/Dockerfile-websocket
+++ b/Dockerfile-websocket
@@ -1,4 +1,4 @@
-FROM node:20-alpine AS BUILD_IMAGE
+FROM node:24-alpine AS BUILD_IMAGE
 
 WORKDIR /app
 
@@ -16,7 +16,7 @@ RUN yarn install --frozen-lockfile --production
 
 RUN touch .env
 
-FROM gcr.io/distroless/nodejs20-debian11
+FROM gcr.io/distroless/nodejs24-debian12
 COPY --from=BUILD_IMAGE /app/.env /app/.env
 COPY --from=BUILD_IMAGE /app/lib /app/lib
 COPY --from=BUILD_IMAGE /app/src/config/locales /app/lib/config/locales

--- a/dev/setup.sh
+++ b/dev/setup.sh
@@ -31,16 +31,16 @@ if [[ "$NODE_VERSION" == "none" ]]; then
 fi
 
 NODE_MAJOR=$(echo "$NODE_VERSION" | sed 's/v//' | cut -d. -f1)
-if [[ "$NODE_MAJOR" != "20" ]]; then
-  warn "Node.js $NODE_VERSION detected — Flash requires Node 20.x"
+if [[ "$NODE_MAJOR" != "24" ]]; then
+  warn "Node.js $NODE_VERSION detected — Flash requires Node 24.x"
   if command -v nvm &>/dev/null || [ -f "$HOME/.nvm/nvm.sh" ]; then
-    echo "  Attempting: nvm use 20..."
+    echo "  Attempting: nvm use 24..."
     export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
     [ -s "$NVM_DIR/nvm.sh" ] && source "$NVM_DIR/nvm.sh"
-    nvm use 20 2>/dev/null || nvm install 20
+    nvm use 24 2>/dev/null || nvm install 24
     info "Now using $(node --version)"
   else
-    fail "Please install Node 20.x. Recommended: use nvm (https://github.com/nvm-sh/nvm)"
+    fail "Please install Node 24.x. Recommended: use nvm (https://github.com/nvm-sh/nvm)"
   fi
 else
   info "Node.js $NODE_VERSION"

--- a/flake.nix
+++ b/flake.nix
@@ -14,9 +14,9 @@
     flake-utils.lib.eachDefaultSystem (system: let
       overlays = [
         (self: super: {
-          nodejs = super.nodejs_20;
+          nodejs = super.nodejs_24;
           yarn = super.yarn.override {
-            nodejs = super.nodejs_20;
+            nodejs = super.nodejs_24;
           };
         })
       ];

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "gen-test-jwt": "ts-node ./dev/bin/gen-test-jwt.ts"
   },
   "engines": {
-    "node": ">=20.18.1 <21"
+    "node": ">=24.0.0 <25"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.968.0",
@@ -161,7 +161,7 @@
     "@types/lodash.sortby": "^4.7.6",
     "@types/lodash.sumby": "^4.6.6",
     "@types/migrate-mongo": "^10.0.0",
-    "@types/node": "^20.6.2",
+    "@types/node": "^24",
     "@types/node-jose": "^1.1.10",
     "@types/nodemon": "^1.19.2",
     "@types/react": "^18.2.21",

--- a/src/utils/grpc-stream-client/stream.ts
+++ b/src/utils/grpc-stream-client/stream.ts
@@ -87,7 +87,7 @@ export class Stream<T extends GrpcData, R extends GrpcData> {
     const onceListeners = [] as GrpcStreamEventsListener<T, R, K>[]
     listeners.forEach((l) => {
       l.listener(this, ev)
-      if (l.options !== undefined && (l.options as AddEventListenerOptions).once)
+      if (l.options !== undefined && (l.options as { once?: boolean }).once)
         onceListeners.push(l)
     })
     onceListeners.forEach((l) => this.removeEventListener(type, l.listener, l.options))

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "sourceMap": true,
     "strict": true,
     "target": "es2020",
+    "lib": ["es2022"],
     "noImplicitAny": false,
     "esModuleInterop": true,
     "baseUrl": "./",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4380,12 +4380,12 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.60.tgz#35f3d6213daed95da7f0f73e75bcc6980e90597b"
   integrity sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==
 
-"@types/node@^20.6.2":
-  version "20.19.23"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.19.23.tgz#7de99389c814071cca78656a3243f224fed7453d"
-  integrity sha512-yIdlVVVHXpmqRhtyovZAcSy0MiPcYWGkoO4CGe/+jpP0hmNuihm4XhHbADpK++MsiLHP5MVlv+bcgdF99kSiFQ==
+"@types/node@^24":
+  version "24.13.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-24.13.2.tgz#3b9b280a7055128359f125eb1067d9a190f39854"
+  integrity sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==
   dependencies:
-    undici-types "~6.21.0"
+    undici-types "~7.18.0"
 
 "@types/node@^8.0.0":
   version "8.10.66"
@@ -13962,15 +13962,15 @@ underscore@1.13.6, underscore@1.13.8, underscore@~1.13.2:
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.8.tgz#a93a21186c049dbf0e847496dba72b7bd8c1e92b"
   integrity sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==
 
-undici-types@~6.21.0:
-  version "6.21.0"
-  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.21.0.tgz#691d00af3909be93a7faa13be61b3a5b50ef12cb"
-  integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
-
 undici-types@~7.16.0:
   version "7.16.0"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.16.0.tgz#ffccdff36aea4884cbfce9a750a0580224f58a46"
   integrity sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==
+
+undici-types@~7.18.0:
+  version "7.18.2"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.18.2.tgz#29357a89e7b7ca4aef3bf0fd3fd0cd73884229e9"
+  integrity sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==
 
 undici@6.24.0, undici@^5.22.1, undici@^7.12.0:
   version "6.24.0"


### PR DESCRIPTION
## Summary

Node.js 20 reached end-of-life in April 2026. This bumps the project to Node 24 (LTS, supported through ~April 2028).

### Changes by category

- **`package.json` engines** — `>=20.18.1 <21` → `>=24.0.0 <25`
- **`@types/node`** — `^20.6.2` → `^24` (resolves to 24.13.2 in `yarn.lock`)
- **4 Dockerfiles** — `Dockerfile`, `Dockerfile-debug`, `Dockerfile-migrate`, `Dockerfile-websocket`: `node:20-alpine` → `node:24-alpine`; distroless `nodejs20-debian11` → `nodejs24-debian12` (incl. `:debug` tag)
- **9 GitHub Actions workflows** — `node-version: 20` → `24` (bats, check-code, integration-test, audit, mongodb-migrate, generate-graphql-docs, unit-test, vendor/nodejs-audit, vendor/nodejs-check-code)
- **`flake.nix`** — `nodejs_20` → `nodejs_24` (overlay + yarn override)
- **`DEV.md`** — Node version references updated to 24; corrected the stale "Node 22+ breaks yarn install" warning (see below)
- **`tsconfig.json`** — added `"lib": ["es2022"]` (required after the `@types/node@24` bump; see below)
- **`src/utils/grpc-stream-client/stream.ts`** — replaced `as AddEventListenerOptions` (a DOM type no longer in scope) with an inline `{ once?: boolean }` cast

### Validation (run under Node v24.18.0)

- `yarn install` — **passed**, exit 0 (the repo's `.yarnrc` has `ignore-engines true`, so engine checks are bypassed). The old DEV.md claim that "Node 22+ will fail on yarn install" did **not** hold true under Node 24; the warning has been corrected.
- `yarn build` (`tsconfig-build.json`, the production build) — **passed**, exit 0.
- `yarn tsc-check` — the `@types/node@24` bump initially surfaced 2 new type errors (`Array.prototype.at()` needing es2022 lib, and a removed `AddEventListenerOptions` DOM type). Both are fixed by the `tsconfig.json` lib addition and the inline cast. The remaining `tsc-check` failures are **pre-existing** errors in `test/flash/integration/**` spec files (verified identical on `main` under Node 20) and are unrelated to this upgrade.

### Distroless image note

Verified `gcr.io/distroless/nodejs24-debian12` exists via `docker manifest inspect` (OK). `nodejs24-debian11` does **not** exist (MISSING), so all distroless references use `debian12`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)