### PR TITLE
feat(topup): add topup.enabled flag exposed via Globals

### DIFF
--- a/dev/apollo-federation/supergraph.graphql
+++ b/dev/apollo-federation/supergraph.graphql
@@ -792,6 +792,13 @@ type Globals
 
   """A list of countries and their supported auth channels"""
   supportedCountries: [Country!]!
+
+  """
+  Whether wallet top-up entry points (card webview and
+  bank-transfer-to-support) should be shown to the user. Controlled by the
+  instance-wide topup feature flag.
+  """
+  topupEnabled: Boolean!
 }
 
 type GraphQLApplicationError implements Error

--- a/dev/config/base-config.yaml
+++ b/dev/config/base-config.yaml
@@ -87,6 +87,9 @@ cashout:
     from: "notifications@getflash.io"
     subject: "New Cashout"
 
+topup:
+  enabled: false
+
 frappe:
   url: http://flashapp.me.localhost:8000
   sitename: flashapp.me.localhost # default sitename for frappe docker container

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -719,6 +719,17 @@ export const configSchema = {
       required: ["enabled", "minimum", "maximum", "accountLevel"],
       default: { enabled: true },
     },
+    topup: {
+      type: "object",
+      properties: {
+        enabled: { type: "boolean" },
+      },
+      required: ["enabled"],
+      additionalProperties: false,
+      // Default OFF: top-up entry points (card webview, bank-transfer-to-support)
+      // stay hidden unless explicitly enabled per the v0.6.0 flag ramp.
+      default: { enabled: false },
+    },
     frappe: {
       type: "object",
       properties: {

--- a/src/config/schema.types.d.ts
+++ b/src/config/schema.types.d.ts
@@ -229,6 +229,9 @@ type YamlSchema = {
     duration: number
     email: CashoutEmail
   }
+  topup: {
+    enabled: boolean
+  }
   sendgrid: SendGridConfig
   frappe: FrappeConfig
   fcmTopics: {

--- a/src/config/yaml.ts
+++ b/src/config/yaml.ts
@@ -388,6 +388,10 @@ export const Cashout = {
   },
 }
 
+export const Topup = {
+  Enabled: (yamlConfig.topup?.enabled ?? false) as boolean,
+}
+
 export const SendGridConfig = yamlConfig.sendgrid as SendGridConfig
 
 export const IbexConfig = yamlConfig.ibex as IbexConfig

--- a/src/graphql/public/root/query/globals.ts
+++ b/src/graphql/public/root/query/globals.ts
@@ -1,5 +1,6 @@
 import {
   NETWORK,
+  Topup,
   getFeesConfig,
   getGaloyBuildInformation,
   getLightningAddressDomain,
@@ -33,6 +34,7 @@ const GlobalsQuery = GT.Field({
           ratio: `${feesConfig.depositRatioAsBasisPoints}`,
         },
       },
+      topupEnabled: Topup.Enabled,
     }
   },
 })

--- a/src/graphql/public/schema.graphql
+++ b/src/graphql/public/schema.graphql
@@ -623,6 +623,13 @@ type Globals {
 
   """A list of countries and their supported auth channels"""
   supportedCountries: [Country!]!
+
+  """
+  Whether wallet top-up entry points (card webview and
+  bank-transfer-to-support) should be shown to the user. Controlled by the
+  instance-wide topup feature flag.
+  """
+  topupEnabled: Boolean!
 }
 
 type GraphQLApplicationError implements Error {

--- a/src/graphql/public/types/object/globals.ts
+++ b/src/graphql/public/types/object/globals.ts
@@ -36,6 +36,12 @@ const Globals = GT.Object({
     feesInformation: {
       type: GT.NonNull(FeesInformation),
     },
+    topupEnabled: {
+      type: GT.NonNull(GT.Boolean),
+      description: dedent`Whether wallet top-up entry points (card webview and
+        bank-transfer-to-support) should be shown to the user. Controlled by the
+        instance-wide topup feature flag.`,
+    },
   }),
 })
 


### PR DESCRIPTION
## Summary

Adds an instance-wide **`topup.enabled`** feature flag and exposes it to clients on the `Globals` query as **`topupEnabled`**, so top-up can be killed/enabled by flipping YAML + rolling restart — the same SOP as every other feature.

### Why this shape (no mutation guard)

Top-up has no money-moving GraphQL mutation in this backend to guard. Its two entry points are **client-side**:
- **Credit card** → a Fygaro **webview**
- **Bank transfer** → a **handoff to support**

So the only effective lever is a backend-owned flag the mobile reads to show/hide those entry points. `Globals.topupEnabled` is that lever.

**International bank top-up is intentionally not covered here** — it flows through Bridge and is already gated by `bridge.enabled`.

### Changes
- `topup.enabled` config block, defaulting to `false`
- `Topup.Enabled` config export
- `Globals.topupEnabled: Boolean!` public GraphQL field
- regenerated public SDL and supergraph SDL
- explicit `topup.enabled: false` in `dev/config/base-config.yaml`

### Verification
- `yarn install --frozen-lockfile`
- `yarn tsc-check`
- `yarn build`
- `yarn check:sdl`
- `eslint` on touched TS files
- `git diff --check`

### Mobile consumer
Consumed by flash-mobile PR #621, which reads `Globals.topupEnabled` and gates the card-webview + local bank-transfer support top-up entries. Bridge international top-up remains available through the existing Bridge gate.

Stacked on `tmp/bridge-rebase-pr-ready` (#413).