### PR TITLE
fix(notifications): format USDT pushes as USD

### DIFF
--- a/src/services/ibex/webhook-server/routes/on-receive.ts
+++ b/src/services/ibex/webhook-server/routes/on-receive.ts
@@ -22,6 +22,8 @@ import { ibexWebhookPaths } from "@services/ibex/webhook-config"
 
 import { authenticate, logRequest, validateIbexIp } from "../middleware"
 
+const USDT_MICROS_PER_MAJOR_UNIT = 1_000_000
+
 interface PaymentContext {
   receiverWallet: Wallet
   recipientAccount: Account
@@ -255,6 +257,8 @@ const parsePaymentHash = (hash: unknown) =>
 const toPaymentAmount = (currency: WalletCurrency) => (dollarAmount: number) => {
   let amount: PaymentAmount<WalletCurrency>["amount"] | undefined
   if (currency === WalletCurrency.Usd) amount = BigInt(Math.round(dollarAmount * 100))
+  if (currency === WalletCurrency.Usdt)
+    amount = BigInt(Math.round(dollarAmount * USDT_MICROS_PER_MAJOR_UNIT))
   return { amount: amount as PaymentAmount<WalletCurrency>["amount"], currency }
 }
 

--- a/src/services/notifications/create-push-notification-content.ts
+++ b/src/services/notifications/create-push-notification-content.ts
@@ -5,6 +5,7 @@ import { WalletCurrency } from "@domain/shared"
 import { getLanguageOrDefault } from "@domain/locale"
 
 const i18n = getI18nInstance()
+const USDT_MICROS_PER_MAJOR_UNIT = 1_000_000
 
 const customToLocaleString = (
   number: number,
@@ -36,20 +37,38 @@ export const createPushNotificationContent = <T extends DisplayCurrency>({
 } => {
   const locale = getLanguageOrDefault(userLanguage)
   const baseCurrency = amount.currency
+  const walletCurrencyLabel = baseCurrency === WalletCurrency.Usdt ? "USD" : baseCurrency
   const notificationType = type === "balance" ? type : `transaction.${type}`
   const title = i18n.__(
     { phrase: `notification.${notificationType}.title`, locale },
-    { walletCurrency: baseCurrency },
+    { walletCurrency: walletCurrencyLabel },
   )
-  const baseCurrencyName = baseCurrency === WalletCurrency.Btc ? "sats" : ""
-  const displayedBaseAmount =
-    baseCurrency === WalletCurrency.Usd ? Number(amount.amount) / 100 : amount.amount
+  let baseCurrencyName = ""
+  let displayedBaseAmount: number | bigint = amount.amount
+  let numberFormatOptions: Intl.NumberFormatOptions = { style: "decimal" }
+
+  if (baseCurrency === WalletCurrency.Btc) {
+    baseCurrencyName = "sats"
+  }
+
+  if (baseCurrency === WalletCurrency.Usd) {
+    displayedBaseAmount = Number(amount.amount) / 100
+    numberFormatOptions = {
+      currency: baseCurrency,
+      style: "currency",
+      currencyDisplay: "narrowSymbol",
+    }
+  }
+
+  if (baseCurrency === WalletCurrency.Usdt) {
+    baseCurrencyName = "USD"
+    displayedBaseAmount = Number(amount.amount) / USDT_MICROS_PER_MAJOR_UNIT
+  }
+
   const baseCurrencyAmount = customToLocaleString(Number(displayedBaseAmount), locale, {
     minimumFractionDigits: 0,
     maximumFractionDigits: MajorExponent.STANDARD,
-    currency: baseCurrency,
-    style: baseCurrency === WalletCurrency.Btc ? "decimal" : "currency",
-    currencyDisplay: "narrowSymbol",
+    ...numberFormatOptions,
   })
 
   let body = i18n.__(

--- a/test/flash/unit/services/notifications/create-push-notification-content.spec.ts
+++ b/test/flash/unit/services/notifications/create-push-notification-content.spec.ts
@@ -1,0 +1,21 @@
+import { NotificationType } from "@domain/notifications"
+import { WalletCurrency } from "@domain/shared"
+import { createPushNotificationContent } from "@services/notifications/create-push-notification-content"
+
+describe("createPushNotificationContent", () => {
+  it("formats USDT invoice-paid notifications with USD-facing copy", () => {
+    const content = createPushNotificationContent({
+      type: NotificationType.LnInvoicePaid,
+      userLanguage: "en" as UserLanguageOrEmpty,
+      amount: {
+        amount: 20_000n,
+        currency: WalletCurrency.Usdt,
+      } as PaymentAmount<typeof WalletCurrency.Usdt>,
+    })
+
+    expect(content).toEqual({
+      title: "USD Transaction",
+      body: "+0.02 USD",
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- convert IBEX USDT webhook amounts into USDT micro-units before notification handling
- render USDT push notification titles/bodies with user-facing USD labels
- add unit coverage for invoice-paid USDT push content

## UAT Context
- fixes the notification issue found during integrated UAT (`NOTIF-02` / `BUG-007`)
- local retest confirmed payment-received pushes arrive once device tokens are registered

## Test Plan
- `TEST=test/flash/unit/services/notifications/create-push-notification-content.spec.ts yarn test:unit`
- `yarn tsc-check`
- `git diff --check`

Draft until the parent Bridge/UAT branch is ready for final review.