### PR TITLE
chore(config): default all feature flags off in base-config

### DIFF
--- a/dev/config/base-config.yaml
+++ b/dev/config/base-config.yaml
@@ -16,7 +16,7 @@ ibex:
     allowedIps: []
 
 bridge:
-  enabled: true
+  enabled: false # flags-off baseline; enable per environment via config overrides
   apiKey: "" # real key injected via config overrides; never commit a real key
   baseUrl: "https://api.sandbox.bridge.xyz/v0"
   minWithdrawalAmount: 2


### PR DESCRIPTION
## Summary
- set `bridge.enabled: false` in `dev/config/base-config.yaml` — with `cashout.enabled` and `topup.enabled` already false, the base config now ships with every feature flag off
- environments must opt in explicitly via their overrides

## Context
Flags-off baseline for the v0.6.0 launch posture: anything reading the base config (local dev, unit/integration jest setups, write-sdl) sees bridge/cashout/topup disabled unless explicitly enabled.

Note for TEST/prod: the deployed server loads only `/var/yaml/custom.yaml` rendered from `galoy.config` in the deployments repo values — the TEST flags are controlled there (companion PR in lnflash/deployments flips `cashout.enabled: false` and pins `bridge`/`topup` off explicitly for the TEST environment).

## Test Plan
- `yarn test:unit` — 105 suites / 788 passed with the flag off (bridge specs mock `@config`)
- CI integration suite on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)