### PR TITLE
ci: auto-bump flash chart version on image bump (1/3 one-step deploy)

### DIFF
--- a/ci/tasks/bump-image-digest.sh
+++ b/ci/tasks/bump-image-digest.sh
@@ -19,6 +19,16 @@ yq -i e '.galoy.images.mongodbMigrate.digest = strenv(migrate_digest)' ./charts/
 yq -i e '.galoy.images.websocket.digest = strenv(websocket_digest)' ./charts/flash/values.yaml
 yq -i e '.appVersion = strenv(app_version)' ./charts/flash/Chart.yaml
 
+# Bump the chart's own semver patch on every image bump. This is load-bearing
+# for the deploy: package-releases.sh publishes with `helm push ... | grep -v
+# "already exists"`, so if `version` is unchanged the push silently no-ops and
+# the OCI registry keeps the stale chart — a terraform apply then re-pulls the
+# old image. A fresh patch version means every image bump is a distinct,
+# publishable, deployable chart. Was previously a manual edit.
+export chart_version=$(yq e '.version' ./charts/flash/Chart.yaml)
+export new_chart_version=$(echo "${chart_version}" | awk -F. '{ printf "%d.%d.%d", $1, $2, $3 + 1 }')
+yq -i e '.version = strenv(new_chart_version)' ./charts/flash/Chart.yaml
+
 if [[ -z $(git config --global user.email) ]]; then
   git config --global user.email "bot@flash.io"
 fi
@@ -31,5 +41,5 @@ fi
   git merge --no-edit ${BRANCH}
   git add -A
   git status
-  git commit -m "chore(deps): bump flash image to '${digest}'"
+  git commit -m "chore(deps): bump flash image to '${digest}' (chart ${new_chart_version})"
 )


### PR DESCRIPTION
## Summary
Automates the manual `Chart.yaml` version bump (`3.2.11 → 3.2.12`) that gates every deploy.

`ci/tasks/bump-image-digest.sh` (which generates the `bump-flash-image` PR to the charts repo) already sets the image digests and `appVersion`, but left the chart `version` alone. That was a manual edit — and a load-bearing one:

- `package-releases.sh` publishes with `helm push … | grep -v "already exists"`, so an **unchanged version makes the push silently no-op** and the OCI registry keeps the stale chart.
- `make flash ENV=test` (terraform `helm_release` pinned to `oci://ghcr.io/brh28` version `3.2.11`) then re-pulls the **old** image.

Confirmed on the jumpbox: TEST runs chart `flash-3.2.11` from `repository = oci://ghcr.io/brh28`, so OCI-semver is the live deploy path.

This increments the chart's semver **patch** alongside the digest/appVersion bump, so every image bump is a distinct publishable/deployable version. Verified the awk logic (`3.2.11→3.2.12`, multi-digit rollover `99→100`) and `bash -n`.

## Part of a 3-piece one-step-deploy change
1. **(this PR)** auto-bump the chart version here.
2. charts repo: publish the new version to OCI on merge (so `package-releases` runs automatically).
3. charts/deployments: sync the terraform `version` pin in `tf-modules/flash/main.tf` to the published version.

After all three, a deploy is just `make flash ENV=test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)