### PR TITLE
feat(graphql): expose cashoutEnabled and bridgeEnabled in globals

### DIFF
--- a/dev/apollo-federation/supergraph.graphql
+++ b/dev/apollo-federation/supergraph.graphql
@@ -797,7 +797,18 @@ Provides global settings for the application which might have an impact for the 
 type Globals
   @join__type(graph: PUBLIC)
 {
+  """
+  Whether Bridge (international bank transfer) entry points
+  should be shown to the user. Controlled by the instance-wide bridge feature flag.
+  """
+  bridgeEnabled: Boolean!
   buildInformation: BuildInformation!
+
+  """
+  Whether cashout (settle to local bank account) entry points
+  should be shown to the user. Controlled by the instance-wide cashout feature flag.
+  """
+  cashoutEnabled: Boolean!
   feesInformation: FeesInformation!
 
   """

--- a/src/graphql/public/root/query/globals.ts
+++ b/src/graphql/public/root/query/globals.ts
@@ -1,4 +1,6 @@
 import {
+  BridgeConfig,
+  Cashout,
   NETWORK,
   Topup,
   getFeesConfig,
@@ -35,6 +37,8 @@ const GlobalsQuery = GT.Field({
         },
       },
       topupEnabled: Topup.Enabled,
+      cashoutEnabled: Cashout.Enabled,
+      bridgeEnabled: BridgeConfig.enabled,
     }
   },
 })

--- a/src/graphql/public/schema.graphql
+++ b/src/graphql/public/schema.graphql
@@ -620,7 +620,18 @@ scalar FractionalCentAmount
 Provides global settings for the application which might have an impact for the user.
 """
 type Globals {
+  """
+  Whether Bridge (international bank transfer) entry points
+  should be shown to the user. Controlled by the instance-wide bridge feature flag.
+  """
+  bridgeEnabled: Boolean!
   buildInformation: BuildInformation!
+
+  """
+  Whether cashout (settle to local bank account) entry points
+  should be shown to the user. Controlled by the instance-wide cashout feature flag.
+  """
+  cashoutEnabled: Boolean!
   feesInformation: FeesInformation!
 
   """

--- a/src/graphql/public/types/object/globals.ts
+++ b/src/graphql/public/types/object/globals.ts
@@ -42,6 +42,16 @@ const Globals = GT.Object({
         bank-transfer-to-support) should be shown to the user. Controlled by the
         instance-wide topup feature flag.`,
     },
+    cashoutEnabled: {
+      type: GT.NonNull(GT.Boolean),
+      description: dedent`Whether cashout (settle to local bank account) entry points
+        should be shown to the user. Controlled by the instance-wide cashout feature flag.`,
+    },
+    bridgeEnabled: {
+      type: GT.NonNull(GT.Boolean),
+      description: dedent`Whether Bridge (international bank transfer) entry points
+        should be shown to the user. Controlled by the instance-wide bridge feature flag.`,
+    },
   }),
 })
 


### PR DESCRIPTION
## Summary
- Adds `cashoutEnabled` and `bridgeEnabled` to the public `Globals` GraphQL type, alongside the existing `topupEnabled`.
- Values come from `Cashout.Enabled` (`cashout.enabled` yaml) and `BridgeConfig.enabled` (`bridge.enabled` yaml) — same config the server already enforces via `checkBridgeEnabled` / cashout guards.
- Regenerated `schema.graphql` and `supergraph.graphql` via `yarn write-sdl`.

## Why
The mobile app needs to hide/disable the Transfer entry points (home-screen button, top-up/settle options) when the topup/cashout/bridge flags are off on an instance (e.g. TEST cluster with all flags defaulted off per #425). Today only `topupEnabled` is queryable; cashout and bridge state are invisible to clients, so buttons show and then fail server-side.

Companion flash-mobile PR consumes these fields (link to follow).

## Test plan
- `yarn write-sdl` (includes full `yarn build`) passes; SDL/supergraph diffs are additive only.
- Query `{ globals { topupEnabled cashoutEnabled bridgeEnabled } }` on TEST after deploy and confirm values track the instance yaml flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)