### PR TITLE
fix(cron): gate LND maintenance tasks behind cronConfig.lndTasksEnabled

### DIFF
--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -579,12 +579,17 @@ export const configSchema = {
       properties: {
         rebalanceEnabled: { type: "boolean" },
         swapEnabled: { type: "boolean" },
+        // Gates the upstream-galoy LND/bitcoin maintenance tasks in the cron
+        // server. Flash runs IBEX-custodial with no LND, so deployments set
+        // this false; defaults true for upstream parity.
+        lndTasksEnabled: { type: "boolean", default: true },
       },
       required: ["rebalanceEnabled", "swapEnabled"],
       additionalProperties: false,
       default: {
         rebalanceEnabled: true,
         swapEnabled: true,
+        lndTasksEnabled: true,
       },
     },
     captcha: {

--- a/src/config/schema.types.d.ts
+++ b/src/config/schema.types.d.ts
@@ -203,6 +203,7 @@ type YamlSchema = {
   cronConfig: {
     rebalanceEnabled: boolean
     swapEnabled: boolean
+    lndTasksEnabled: boolean
   }
   captcha: {
     mandatory: boolean

--- a/src/config/types.d.ts
+++ b/src/config/types.d.ts
@@ -8,6 +8,7 @@ type Levels = number[]
 type CronConfig = {
   rebalanceEnabled: boolean
   swapEnabled: boolean
+  lndTasksEnabled: boolean
 }
 
 type CaptchaConfig = {

--- a/src/servers/cron.ts
+++ b/src/servers/cron.ts
@@ -91,29 +91,45 @@ const reconcileBridgeWithdrawalsJob = async () => {
 const main = async () => {
   console.log("cronjob started")
   const start = new Date()
-  await checkAllLndHealth()
 
   const cronConfig = getCronConfig()
+
+  // Flash runs IBEX-custodial with no LND nodes, so the upstream-galoy
+  // LND/bitcoin maintenance tasks have nothing to operate on — worse, the
+  // ones that require a reachable node throw OffChainServiceUnavailableError,
+  // failing the whole run (exit 99 → CrashLoopBackOff on the k8s Job).
+  // lndTasksEnabled (default true, for upstream parity) lets deployments
+  // without LND run only the tasks that apply: mongo expiry cleanup and
+  // Bridge↔IBEX reconciliation.
+  if (cronConfig.lndTasksEnabled) {
+    await checkAllLndHealth()
+  }
+
   const results: Array<boolean> = []
   const mongoose = await setupMongoConnection()
 
   const tasks = [
-    // bitcoin related tasks
-    rebalancingInternalChannels,
-    updateEscrows,
-    updatePendingLightningInvoices,
-    updatePendingLightningPayments,
-    updateLnPaymentsCollection,
-    updateRoutingRevenues,
-    updateLegacyOnChainReceipt,
+    // bitcoin/LND tasks — upstream galoy; require LND to do anything useful
+    ...(cronConfig.lndTasksEnabled
+      ? [
+          rebalancingInternalChannels,
+          updateEscrows,
+          updatePendingLightningInvoices,
+          updatePendingLightningPayments,
+          updateLnPaymentsCollection,
+          updateRoutingRevenues,
+          updateLegacyOnChainReceipt,
+        ]
+      : []),
     ...(cronConfig.rebalanceEnabled ? [rebalance] : []),
     ...(cronConfig.swapEnabled ? [swapOutJob] : []),
     reconcileBridgeDepositsJob,
     reconcileBridgeWithdrawalsJob,
     deleteExpiredPaymentFlows,
     deleteExpiredInvoices,
-    deleteLndPaymentsBefore2Months,
-    deleteFailedPaymentsAttemptAllLnds,
+    ...(cronConfig.lndTasksEnabled
+      ? [deleteLndPaymentsBefore2Months, deleteFailedPaymentsAttemptAllLnds]
+      : []),
   ]
 
   const PROCESS_KILL_EVENTS = ["SIGTERM", "SIGINT"]
@@ -198,7 +214,9 @@ const main = async () => {
 }
 
 try {
-  activateLndHealthCheck()
+  if (getCronConfig().lndTasksEnabled) {
+    activateLndHealthCheck()
+  }
   main()
 } catch (err) {
   logger.warn({ err }, "error in the cron job")


### PR DESCRIPTION
## Problem
The daily `flash-cronjob` k8s Job crash-loops: `deleteLndPaymentsBefore2Months` throws `OffChainServiceUnavailableError` (no LND exists in Flash's IBEX-custodial architecture — it tries `lnd1.galoy-dev-bitcoin.svc.cluster.local`, upstream galoy's dev default), one failed task → `exit 99` → Job retry loop. This was masked until charts 3.2.15 fixed the missing `-c` configPath; with the config finally loading, the task-level failure surfaced.

## Task audit (what runs on Flash and what shouldn't)
| Task | Verdict |
|---|---|
| `rebalancingInternalChannels`, `updateEscrows`, `updateRoutingRevenues` | LND-only → **gated** |
| `updatePendingLightningInvoices`, `updatePendingLightningPayments`, `updateLnPaymentsCollection`, `updateLegacyOnChainReceipt` | LND machinery → **gated** |
| `deleteLndPaymentsBefore2Months` (the thrower), `deleteFailedPaymentsAttemptAllLnds` | LND-only → **gated** |
| `checkAllLndHealth()` preamble + `activateLndHealthCheck()` bootstrap | LND probes → **gated** |
| `rebalance` / `swapOutJob` | keep existing `rebalanceEnabled`/`swapEnabled` gates |
| `reconcileBridgeDepositsJob` / `reconcileBridgeWithdrawalsJob` | already self-gated on `BridgeConfig.enabled` → unchanged |
| `deleteExpiredPaymentFlows`, `deleteExpiredInvoices` | pure mongo cleanup — Flash's real cron work → unconditional |

## Change
New `cronConfig.lndTasksEnabled` (schema default **true** — upstream parity). Verified through the real config loader:
- config without `cronConfig` → `{rebalanceEnabled:true, swapEnabled:true, lndTasksEnabled:true}` (unchanged behavior)
- legacy `cronConfig` without the key → `lndTasksEnabled:true` injected (backward compatible)
- explicit `false` → gated task list: expiry cleanup + bridge reconciliation only

`tsc --noEmit` clean; eslint clean.

## Rollout
After this image ships via the pipeline, set `cronConfig.lndTasksEnabled: false` in the chart's `galoy.config` (charts repo — will ride the auto image-bump PR). **Ordering matters:** the values change must not land before this image (old schema has `additionalProperties: false` and would reject the unknown key).

🤖 Generated with [Claude Code](https://claude.com/claude-code)