### PR TITLE
feat(cutover): stage pipeline + milestone highlights on the operator dashboard

### DIFF
--- a/src/app/cash-wallet-cutover/operator-dashboard.ts
+++ b/src/app/cash-wallet-cutover/operator-dashboard.ts
@@ -948,3 +948,200 @@ export const buildCashWalletCutoverOperatorSnapshot = async ({
     reconciliation,
   }
 }
+
+// ── Stage pipeline + milestone highlights (operator monitoring) ─────────────
+//
+// Groups the 14-state migration machine into operator-facing stages and
+// derives milestone events by diffing consecutive stage summaries — so the
+// dashboard can show "where is the run" at a glance and a highlights feed of
+// every meaningful transition (run started, provisioning done, 25/50/75/100%
+// migrated, attention spikes, rollback progress).
+
+export type CashWalletCutoverStageKey =
+  | "pending"
+  | "provisioning"
+  | "moving"
+  | "fees"
+  | "finalizing"
+  | "complete"
+  | "skipped"
+  | "attention"
+  | "rollingBack"
+  | "rolledBack"
+
+export const CASH_WALLET_CUTOVER_STAGE_STATUSES: Record<
+  CashWalletCutoverStageKey,
+  (CashWalletMigrationStatus | "none")[]
+> = {
+  pending: ["none", "not_started"],
+  provisioning: ["started", "provisioned"],
+  moving: [
+    "balance_read",
+    "invoice_created",
+    "balance_move_sending",
+    "balance_move_sent",
+    "balance_move_verified",
+  ],
+  fees: [
+    "fee_reimbursement_invoice_created",
+    "fee_reimbursement_sending",
+    "fee_reimbursed",
+  ],
+  finalizing: ["pointer_flipped", "legacy_zero_verified"],
+  complete: ["complete"],
+  skipped: ["skipped_already_migrated"],
+  attention: ["failed", "requires_operator_review"],
+  rollingBack: ["rollback_started"],
+  rolledBack: ["rolled_back"],
+}
+
+export type CashWalletCutoverStageSummary = {
+  total: number
+  counts: Record<CashWalletCutoverStageKey, number>
+  statusCounts: Record<string, number>
+  inFlight: number
+  done: number
+  percentComplete: number
+  missingUsdtWallets: number
+  cutoverState: CashWalletCutoverState
+  runId?: string
+}
+
+export const summarizeCashWalletCutoverStages = ({
+  migrationStatuses,
+  cutoverState,
+  runId,
+  missingUsdtWallets,
+}: {
+  migrationStatuses: (CashWalletMigrationStatus | "none")[]
+  cutoverState: CashWalletCutoverState
+  runId?: string
+  missingUsdtWallets: number
+}): CashWalletCutoverStageSummary => {
+  const counts = Object.fromEntries(
+    Object.keys(CASH_WALLET_CUTOVER_STAGE_STATUSES).map((key) => [key, 0]),
+  ) as Record<CashWalletCutoverStageKey, number>
+  const statusCounts: Record<string, number> = {}
+
+  const stageByStatus = new Map<string, CashWalletCutoverStageKey>()
+  for (const [stage, statuses] of Object.entries(CASH_WALLET_CUTOVER_STAGE_STATUSES)) {
+    for (const status of statuses) {
+      stageByStatus.set(status, stage as CashWalletCutoverStageKey)
+    }
+  }
+
+  for (const status of migrationStatuses) {
+    statusCounts[status] = (statusCounts[status] ?? 0) + 1
+    const stage = stageByStatus.get(status) ?? "pending"
+    counts[stage] += 1
+  }
+
+  const inFlight = counts.provisioning + counts.moving + counts.fees + counts.finalizing
+  const done = counts.complete + counts.skipped
+  const total = migrationStatuses.length
+
+  return {
+    total,
+    counts,
+    statusCounts,
+    inFlight,
+    done,
+    percentComplete: total > 0 ? Math.floor((done / total) * 100) : 0,
+    missingUsdtWallets,
+    cutoverState,
+    runId,
+  }
+}
+
+export type CashWalletCutoverMilestoneKind = "ok" | "info" | "warn" | "bad"
+
+export type CashWalletCutoverMilestone = {
+  at: string
+  kind: CashWalletCutoverMilestoneKind
+  text: string
+}
+
+const PERCENT_THRESHOLDS = [25, 50, 75] as const
+
+export const deriveCashWalletCutoverMilestones = ({
+  previous,
+  current,
+  at,
+}: {
+  previous?: CashWalletCutoverStageSummary
+  current: CashWalletCutoverStageSummary
+  at: string
+}): CashWalletCutoverMilestone[] => {
+  const milestones: CashWalletCutoverMilestone[] = []
+  const push = (kind: CashWalletCutoverMilestoneKind, text: string) =>
+    milestones.push({ at, kind, text })
+
+  if (!previous) return milestones
+
+  if (previous.cutoverState !== current.cutoverState) {
+    if (current.cutoverState === "in_progress") {
+      push("info", `Cutover run started${current.runId ? ` (${current.runId})` : ""}`)
+    } else if (current.cutoverState === "complete") {
+      push("ok", "Cutover config marked COMPLETE")
+    } else if (current.cutoverState === "rolled_back") {
+      push("warn", "Cutover config marked ROLLED BACK")
+    } else {
+      push("info", `Cutover state: ${previous.cutoverState} -> ${current.cutoverState}`)
+    }
+  }
+
+  if (previous.missingUsdtWallets > 0 && current.missingUsdtWallets === 0) {
+    push("ok", `Provisioning complete: every account has a USDT wallet`)
+  }
+
+  if (previous.inFlight === 0 && current.inFlight > 0) {
+    push("info", `Migration batch running (${current.inFlight} in flight)`)
+  }
+
+  if (previous.counts.complete === 0 && current.counts.complete > 0) {
+    push("ok", "First account fully migrated")
+  }
+
+  for (const threshold of PERCENT_THRESHOLDS) {
+    if (previous.percentComplete < threshold && current.percentComplete >= threshold) {
+      push("info", `${threshold}% migrated (${current.done}/${current.total})`)
+    }
+  }
+
+  const fullyDone =
+    current.total > 0 && current.done === current.total && current.counts.attention === 0
+  const previouslyDone =
+    previous.total > 0 &&
+    previous.done === previous.total &&
+    previous.counts.attention === 0
+  if (fullyDone && !previouslyDone) {
+    push(
+      "ok",
+      `100% migrated (${current.done}/${current.total}) — run reconciliation and hold per runbook`,
+    )
+  }
+
+  if (current.counts.attention > previous.counts.attention) {
+    const delta = current.counts.attention - previous.counts.attention
+    push(
+      "bad",
+      `+${delta} account(s) need attention (failed / operator review) — total ${current.counts.attention}`,
+    )
+  }
+  if (previous.counts.attention > 0 && current.counts.attention === 0) {
+    push("ok", "Attention queue cleared")
+  }
+
+  if (previous.counts.rollingBack === 0 && current.counts.rollingBack > 0) {
+    push("warn", `Rollback in progress (${current.counts.rollingBack} account(s))`)
+  }
+  if (
+    previous.counts.rollingBack > 0 &&
+    current.counts.rollingBack === 0 &&
+    current.counts.rolledBack > previous.counts.rolledBack
+  ) {
+    push("ok", `Rollback drained — ${current.counts.rolledBack} account(s) rolled back`)
+  }
+
+  return milestones
+}

--- a/src/app/cash-wallet-cutover/operator-dashboard.ts
+++ b/src/app/cash-wallet-cutover/operator-dashboard.ts
@@ -96,6 +96,7 @@ export type CashWalletCutoverOperatorSnapshot = {
     state: CashWalletCutoverState
     cutoverVersion: number
     runId?: string
+    startedAt?: string
     updatedAt?: string
   }
   preflight?: CashWalletCutoverPreflightReport
@@ -912,6 +913,7 @@ export const buildCashWalletCutoverOperatorSnapshot = async ({
       state: config.state,
       cutoverVersion: config.cutoverVersion,
       runId: config.runId,
+      startedAt: config.startedAt?.toISOString(),
       updatedAt: config.updatedAt?.toISOString(),
     },
     preflight: preflightReport,
@@ -997,6 +999,14 @@ export const CASH_WALLET_CUTOVER_STAGE_STATUSES: Record<
 
 export type CashWalletCutoverStageSummary = {
   total: number
+  /**
+   * Denominator for progress: once a run has started, accounts stuck at
+   * "none" (already_usdt / residual / missing_* discoveries) never get
+   * migration records and can never complete — counting them caps
+   * percentComplete below 100 forever (TEST: 315 manifest vs 297 migrations
+   * ⇒ ceiling of 94%). Before the run starts, everything counts.
+   */
+  eligibleTotal: number
   counts: Record<CashWalletCutoverStageKey, number>
   statusCounts: Record<string, number>
   inFlight: number
@@ -1039,14 +1049,17 @@ export const summarizeCashWalletCutoverStages = ({
   const inFlight = counts.provisioning + counts.moving + counts.fees + counts.finalizing
   const done = counts.complete + counts.skipped
   const total = migrationStatuses.length
+  const eligibleTotal =
+    cutoverState === "pre" ? total : total - (statusCounts["none"] ?? 0)
 
   return {
     total,
+    eligibleTotal,
     counts,
     statusCounts,
     inFlight,
     done,
-    percentComplete: total > 0 ? Math.floor((done / total) * 100) : 0,
+    percentComplete: eligibleTotal > 0 ? Math.floor((done / eligibleTotal) * 100) : 0,
     missingUsdtWallets,
     cutoverState,
     runId,
@@ -1104,20 +1117,25 @@ export const deriveCashWalletCutoverMilestones = ({
 
   for (const threshold of PERCENT_THRESHOLDS) {
     if (previous.percentComplete < threshold && current.percentComplete >= threshold) {
-      push("info", `${threshold}% migrated (${current.done}/${current.total})`)
+      push("info", `${threshold}% migrated (${current.done}/${current.eligibleTotal})`)
     }
   }
 
+  // Against eligibleTotal, not total: permanently-"none" accounts never get
+  // migration records, so done === total could never hold on real data and
+  // the reconciliation cue would never fire.
   const fullyDone =
-    current.total > 0 && current.done === current.total && current.counts.attention === 0
+    current.eligibleTotal > 0 &&
+    current.done === current.eligibleTotal &&
+    current.counts.attention === 0
   const previouslyDone =
-    previous.total > 0 &&
-    previous.done === previous.total &&
+    previous.eligibleTotal > 0 &&
+    previous.done === previous.eligibleTotal &&
     previous.counts.attention === 0
   if (fullyDone && !previouslyDone) {
     push(
       "ok",
-      `100% migrated (${current.done}/${current.total}) — run reconciliation and hold per runbook`,
+      `100% migrated (${current.done}/${current.eligibleTotal}) — run reconciliation and hold per runbook`,
     )
   }
 

--- a/src/scripts/cash-wallet-cutover-dashboard.ts
+++ b/src/scripts/cash-wallet-cutover-dashboard.ts
@@ -11,6 +11,7 @@ import { discoverCashWalletCutoverAccounts } from "@app/cash-wallet-cutover/disc
 import {
   buildCashWalletCutoverOperatorSnapshot,
   CashWalletCutoverMilestone,
+  CASH_WALLET_CUTOVER_STAGE_STATUSES,
   CashWalletCutoverOperatorManifestAccount,
   CashWalletCutoverOperatorSnapshot,
   CashWalletCutoverStageSummary,
@@ -420,19 +421,23 @@ const html = `<!doctype html>
     let snapshot = null
     let stageFilter = ""
 
+    // Status lists interpolated from CASH_WALLET_CUTOVER_STAGE_STATUSES so a
+    // new state-machine status can't silently diverge between server counts
+    // and this client-side chip filter.
+    const STAGE_STATUSES = ${JSON.stringify(CASH_WALLET_CUTOVER_STAGE_STATUSES)}
     const STAGES = [
-      ["pending", "Pending", "#98a2b3", ["none", "not_started"]],
-      ["provisioning", "Provisioning", "#7a5af8", ["started", "provisioned"]],
-      ["moving", "Moving funds", "#1f5eff", ["balance_read", "invoice_created", "balance_move_sending", "balance_move_sent", "balance_move_verified"]],
-      ["fees", "Fees", "#0ba5ec", ["fee_reimbursement_invoice_created", "fee_reimbursement_sending", "fee_reimbursed"]],
-      ["finalizing", "Finalizing", "#12b76a", ["pointer_flipped", "legacy_zero_verified"]],
-      ["complete", "Complete", "#16794c", ["complete"]],
-      ["skipped", "Skipped (USDT)", "#66c61c", ["skipped_already_migrated"]],
-      ["attention", "Attention", "#b42318", ["failed", "requires_operator_review"]],
-      ["rollingBack", "Rolling back", "#946200", ["rollback_started"]],
-      ["rolledBack", "Rolled back", "#667085", ["rolled_back"]],
-    ]
-    const stageStatuses = (key) => (STAGES.find((s) => s[0] === key) || [null, null, null, []])[3]
+      ["pending", "Pending", "#98a2b3"],
+      ["provisioning", "Provisioning", "#7a5af8"],
+      ["moving", "Moving funds", "#1f5eff"],
+      ["fees", "Fees", "#0ba5ec"],
+      ["finalizing", "Finalizing", "#12b76a"],
+      ["complete", "Complete", "#16794c"],
+      ["skipped", "Skipped (USDT)", "#66c61c"],
+      ["attention", "Attention", "#b42318"],
+      ["rollingBack", "Rolling back", "#946200"],
+      ["rolledBack", "Rolled back", "#667085"],
+    ].map(([key, label, color]) => [key, label, color, STAGE_STATUSES[key] || []])
+    const stageStatuses = (key) => STAGE_STATUSES[key] || []
 
     const $ = (id) => document.getElementById(id)
     const money = (cents) => "$" + (cents / 100).toFixed(2)
@@ -586,7 +591,10 @@ const html = `<!doctype html>
       if (f.missingUsdt && account.usdtWallets.length > 0) return false
       if (f.nonzeroUsd && !usd) return false
       if (f.nonzeroUsdt && !usdt) return false
-      if (f.migration && account.migrationStatus !== f.migration) return false
+      // An explicit status pick overrides a stale stage chip (chip clicks
+      // clear the dropdown, but not vice versa — ANDing them can render an
+      // empty table while the chip still shows a nonzero count).
+      if (f.migration) return account.migrationStatus === f.migration
       if (stageFilter && stageStatuses(stageFilter).indexOf(account.migrationStatus) === -1) return false
       return true
     }
@@ -662,9 +670,13 @@ const html = `<!doctype html>
       const feed = $("highlights")
       const items = (snapshot.milestones || []).slice().reverse()
       $("highlights-note").textContent = items.length + " event(s)"
+      // Milestone text embeds the free-form --run-id; escape it — this is the
+      // one innerHTML sink fed by operator input.
+      const esc = (s) => String(s).replace(/[&<>"']/g, (c) =>
+        ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]))
       feed.innerHTML = items.map((m) =>
-        '<li><span class="dot ' + m.kind + '"></span><span class="t">' +
-        new Date(m.at).toLocaleTimeString() + '</span><span>' + m.text + '</span></li>'
+        '<li><span class="dot ' + esc(m.kind) + '"></span><span class="t">' +
+        new Date(m.at).toLocaleTimeString() + '</span><span>' + esc(m.text) + '</span></li>'
       ).join("") || '<li><span class="muted">no events yet</span></li>'
     }
 
@@ -709,14 +721,28 @@ const html = `<!doctype html>
     // stalled every balance at zero. 60 ids/request keeps URLs ~2KB.
     const BALANCE_BATCH = 60
     let balancePollTimer = null
-    async function hydrateBalances(force) {
+    let hydrateGeneration = 0
+    function loadingWalletIds() {
+      const ids = []
+      const collect = (account) => account.usdWallets.concat(account.usdtWallets)
+        .forEach((w) => { if (!w.balance.status || w.balance.status === "loading") ids.push(w.id) })
+      snapshot.accounts.forEach(collect)
+      if (snapshot.treasury) snapshot.treasury.accounts.forEach(collect)
+      return ids
+    }
+    async function hydrateBalances(force, onlyLoading) {
       if (!snapshot) return
-      const walletIds = allWalletIds()
+      // Generation guard: the 15s active-run reload starts a new pass while a
+      // previous multi-batch pass (and its 2s poll chain) may still be
+      // running — without this they stack and interleave renders.
+      const generation = ++hydrateGeneration
+      const walletIds = onlyLoading ? loadingWalletIds() : allWalletIds()
       if (walletIds.length === 0) return
 
       let fresh = 0, errors = 0, loading = 0, pending = 0, active = false
 
       for (let i = 0; i < walletIds.length; i += BALANCE_BATCH) {
+        if (generation !== hydrateGeneration) return // superseded by a newer pass
         const batch = walletIds.slice(i, i + BALANCE_BATCH)
         const url = "/api/balances?walletIds=" + encodeURIComponent(batch.join(",")) +
           (force ? "&refresh=1" : "")
@@ -749,7 +775,9 @@ const html = `<!doctype html>
       if ((loading > 0 || pending > 0 || active) && !balancePollTimer) {
         balancePollTimer = setTimeout(() => {
           balancePollTimer = null
-          hydrateBalances(false).catch((error) => {
+          // Poll passes only re-request wallets still loading — not the full
+          // 600-wallet list every 2s while the server queue drains.
+          hydrateBalances(false, true).catch((error) => {
             $("status").textContent = error.message
           })
         }, 2000)
@@ -759,11 +787,14 @@ const html = `<!doctype html>
     async function load(force) {
       $("status").textContent = force ? "Refreshing..." : "Loading..."
       const response = await fetch("/api/snapshot" + (force ? "?refresh=1" : ""))
-      snapshot = await response.json()
-      if (!response.ok) throw new Error(snapshot.error || "Snapshot failed")
+      // Parse before assigning: a transient 500 must not replace the live
+      // snapshot with {error} and break every subsequent render.
+      const body = await response.json()
+      if (!response.ok) throw new Error(body.error || "Snapshot failed")
+      snapshot = body
       $("status").textContent = "Updated " + new Date(snapshot.generatedAt).toLocaleTimeString()
       render()
-      hydrateBalances(force).catch((error) => {
+      hydrateBalances(force, false).catch((error) => {
         $("status").textContent = error.message
       })
     }
@@ -790,9 +821,13 @@ const html = `<!doctype html>
     function scheduleReload() {
       if (reloadTimer) clearTimeout(reloadTimer)
       reloadTimer = setTimeout(() => {
+        // Watchdog: re-arm even if load() never settles — the server can hang
+        // behind a stuck snapshot build with no timeout, and a dead chain
+        // otherwise never recovers (the old setInterval did by construction).
+        const watchdog = setTimeout(scheduleReload, 60000)
         load(false)
           .catch((error) => { $("status").textContent = error.message })
-          .finally(scheduleReload)
+          .finally(() => { clearTimeout(watchdog); scheduleReload() })
       }, isActiveRun() ? 15000 : 120000)
     }
 
@@ -1053,11 +1088,30 @@ const start = async () => {
   }
 
   // Keep stage/milestone tracking alive even with no browser tab open.
-  setInterval(() => {
-    snapshot(false).catch((error) =>
-      baseLogger.warn({ error }, "cutover dashboard background poll failed"),
-    )
-  }, 30_000)
+  // Tight cadence only while a run/rollback is live; idle polls back off —
+  // each rebuild is a discovery scan over every unlocked account plus
+  // several mongo queries per dashboard account, and pre-PR it only ran
+  // while a browser was actually polling.
+  const BACKGROUND_POLL_ACTIVE_MS = 30_000
+  const BACKGROUND_POLL_IDLE_MS = 5 * 60_000
+  const backgroundPoll = () => {
+    snapshot(false)
+      .catch((error) =>
+        baseLogger.warn({ error }, "cutover dashboard background poll failed"),
+      )
+      .finally(() => {
+        const active =
+          lastStageSummary !== undefined &&
+          (lastStageSummary.cutoverState === "in_progress" ||
+            lastStageSummary.inFlight > 0 ||
+            lastStageSummary.counts.rollingBack > 0)
+        setTimeout(
+          backgroundPoll,
+          active ? BACKGROUND_POLL_ACTIVE_MS : BACKGROUND_POLL_IDLE_MS,
+        )
+      })
+  }
+  setTimeout(backgroundPoll, BACKGROUND_POLL_ACTIVE_MS)
 
   const app = express()
   app.get("/", (_req, res) => res.type("html").send(html))

--- a/src/scripts/cash-wallet-cutover-dashboard.ts
+++ b/src/scripts/cash-wallet-cutover-dashboard.ts
@@ -677,12 +677,16 @@ const html = `<!doctype html>
       renderRows()
     }
 
+    // USD wallets first (the funded legacy balances operators care about
+    // most), then USDT, then treasury — so the meaningful numbers fill in
+    // before the long tail.
     function allWalletIds() {
-      return snapshot.accounts.flatMap((account) =>
-        account.usdWallets.concat(account.usdtWallets).map((wallet) => wallet.id)
-      ).concat((snapshot.treasury ? snapshot.treasury.accounts : []).flatMap((account) =>
-        account.usdWallets.concat(account.usdtWallets).map((wallet) => wallet.id)
-      ))
+      const usd = snapshot.accounts.flatMap((a) => a.usdWallets.map((w) => w.id))
+      const usdt = snapshot.accounts.flatMap((a) => a.usdtWallets.map((w) => w.id))
+      const treasury = (snapshot.treasury ? snapshot.treasury.accounts : []).flatMap(
+        (a) => a.usdWallets.concat(a.usdtWallets).map((w) => w.id),
+      )
+      return usd.concat(usdt).concat(treasury)
     }
 
     function mergeBalances(balances) {
@@ -700,30 +704,49 @@ const html = `<!doctype html>
       }
     }
 
+    // Wallet IDs are batched into small GETs: one URL with the whole fleet
+    // (600+ UUIDs ≈ 22KB) exceeds Node's 16KB header limit and 431s, which
+    // stalled every balance at zero. 60 ids/request keeps URLs ~2KB.
+    const BALANCE_BATCH = 60
     let balancePollTimer = null
     async function hydrateBalances(force) {
       if (!snapshot) return
       const walletIds = allWalletIds()
       if (walletIds.length === 0) return
 
-      const url = "/api/balances?walletIds=" + encodeURIComponent(walletIds.join(",")) + (force ? "&refresh=1" : "")
-      const response = await fetch(url)
-      const result = await response.json()
-      if (!response.ok) throw new Error(result.error || "Balance refresh failed")
+      let fresh = 0, errors = 0, loading = 0, pending = 0, active = false
 
-      mergeBalances(result.balances)
-      renderSummary()
-      renderRows()
+      for (let i = 0; i < walletIds.length; i += BALANCE_BATCH) {
+        const batch = walletIds.slice(i, i + BALANCE_BATCH)
+        const url = "/api/balances?walletIds=" + encodeURIComponent(batch.join(",")) +
+          (force ? "&refresh=1" : "")
+        const response = await fetch(url)
+        if (!response.ok) {
+          throw new Error("Balance refresh failed (" + response.status + ")")
+        }
+        const result = await response.json()
 
-      const total = walletIds.length
-      const fresh = Object.values(result.balances).filter((balance) => balance.status === "fresh").length
-      const errors = Object.values(result.balances).filter((balance) => balance.status === "error").length
-      const loading = Object.values(result.balances).filter((balance) => balance.status === "loading").length
+        mergeBalances(result.balances)
+        for (const balance of Object.values(result.balances)) {
+          if (balance.status === "fresh") fresh++
+          else if (balance.status === "error") errors++
+          else if (balance.status === "loading") loading++
+        }
+        pending = result.queue.pending
+        active = !!result.queue.active
+
+        // Paint incrementally so funded USD balances appear as batches land.
+        renderSummary()
+        renderRows()
+        $("status").textContent = "Loading balances " + Math.min(i + BALANCE_BATCH, walletIds.length) +
+          "/" + walletIds.length + "…"
+      }
+
       $("status").textContent = "Updated " + new Date(snapshot.generatedAt).toLocaleTimeString() +
-        " | balances " + (fresh + errors) + "/" + total +
-        (result.queue.pending || result.queue.active ? " (" + result.queue.pending + " queued)" : "")
+        " | balances " + (fresh + errors) + "/" + walletIds.length +
+        (pending || active ? " (" + pending + " queued)" : "")
 
-      if ((loading > 0 || result.queue.pending > 0 || result.queue.active) && !balancePollTimer) {
+      if ((loading > 0 || pending > 0 || active) && !balancePollTimer) {
         balancePollTimer = setTimeout(() => {
           balancePollTimer = null
           hydrateBalances(false).catch((error) => {

--- a/src/scripts/cash-wallet-cutover-dashboard.ts
+++ b/src/scripts/cash-wallet-cutover-dashboard.ts
@@ -10,13 +10,17 @@ import { hideBin } from "yargs/helpers"
 import { discoverCashWalletCutoverAccounts } from "@app/cash-wallet-cutover/discovery"
 import {
   buildCashWalletCutoverOperatorSnapshot,
+  CashWalletCutoverMilestone,
   CashWalletCutoverOperatorManifestAccount,
   CashWalletCutoverOperatorSnapshot,
+  CashWalletCutoverStageSummary,
+  deriveCashWalletCutoverMilestones,
   formatCashWalletCutoverOperatorSnapshotCsv,
   formatOperatorBalance,
   OperatorBalance,
   parseCashWalletCutoverOperatorManifest,
   refreshOperatorAccountCutoverBalanceAudit,
+  summarizeCashWalletCutoverStages,
 } from "@app/cash-wallet-cutover/operator-dashboard"
 import { buildCashWalletCutoverPreflightReport } from "@app/cash-wallet-cutover/preflight"
 import { getBalanceForWallet } from "@app/wallets"
@@ -329,7 +333,26 @@ const html = `<!doctype html>
     .info { color: var(--blue); background: var(--blue-bg); }
     .right { text-align: right; }
 
+    .stagegrid { display: grid; grid-template-columns: 1.6fr 1fr; gap: 10px; margin-bottom: 14px; }
+    .panel { background: var(--panel); border: 1px solid var(--line); border-radius: 8px; padding: 12px; }
+    .panel-title { font-weight: 650; margin-bottom: 10px; display: flex; justify-content: space-between; gap: 8px; align-items: baseline; }
+    .bar { display: flex; height: 22px; border-radius: 6px; overflow: hidden; border: 1px solid var(--line); background: #eef1f6; }
+    .bar div { height: 100%; transition: width .4s ease; min-width: 0; }
+    .chips { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 10px; }
+    .chip { display: inline-flex; align-items: center; gap: 6px; border: 1px solid var(--line); border-radius: 999px; padding: 3px 10px; cursor: pointer; font-size: 12px; font-weight: 600; background: #fff; }
+    .chip .dot { width: 9px; height: 9px; border-radius: 50%; }
+    .chip.active { border-color: var(--blue); box-shadow: 0 0 0 2px var(--blue-bg); }
+    .chip .n { color: var(--muted); font-weight: 700; }
+    .chip.zero { opacity: .45; }
+    .feed { list-style: none; margin: 0; padding: 0; max-height: 200px; overflow: auto; font-size: 13px; }
+    .feed li { display: flex; gap: 8px; align-items: baseline; padding: 4px 0; border-bottom: 1px dashed var(--line); }
+    .feed .t { color: var(--muted); font-size: 11px; white-space: nowrap; font-family: ui-monospace, Menlo, monospace; }
+    .feed .dot { width: 8px; height: 8px; border-radius: 50%; flex: none; align-self: center; }
+    .feed .dot.ok { background: var(--green); } .feed .dot.info { background: var(--blue); }
+    .feed .dot.warn { background: var(--yellow); } .feed .dot.bad { background: var(--red); }
+
     @media (max-width: 1100px) {
+      .stagegrid { grid-template-columns: 1fr; }
       .summary { grid-template-columns: repeat(auto-fit, minmax(120px, 1fr)); }
       header { align-items: flex-start; flex-direction: column; }
       .table-wrap { max-height: none; }
@@ -350,6 +373,17 @@ const html = `<!doctype html>
     </div>
   </header>
   <main>
+    <section class="stagegrid">
+      <div class="panel">
+        <div class="panel-title">Pipeline <span class="muted" id="pipeline-note"></span></div>
+        <div class="bar" id="stage-bar"></div>
+        <div class="chips" id="stage-chips"></div>
+      </div>
+      <div class="panel">
+        <div class="panel-title">Highlights <span class="muted" id="highlights-note"></span></div>
+        <ol class="feed" id="highlights"></ol>
+      </div>
+    </section>
     <section class="summary" id="summary"></section>
     <section class="controls">
       <label class="filter"><input type="checkbox" id="filter-anomalies">Anomalies</label>
@@ -384,6 +418,21 @@ const html = `<!doctype html>
   </main>
   <script>
     let snapshot = null
+    let stageFilter = ""
+
+    const STAGES = [
+      ["pending", "Pending", "#98a2b3", ["none", "not_started"]],
+      ["provisioning", "Provisioning", "#7a5af8", ["started", "provisioned"]],
+      ["moving", "Moving funds", "#1f5eff", ["balance_read", "invoice_created", "balance_move_sending", "balance_move_sent", "balance_move_verified"]],
+      ["fees", "Fees", "#0ba5ec", ["fee_reimbursement_invoice_created", "fee_reimbursement_sending", "fee_reimbursed"]],
+      ["finalizing", "Finalizing", "#12b76a", ["pointer_flipped", "legacy_zero_verified"]],
+      ["complete", "Complete", "#16794c", ["complete"]],
+      ["skipped", "Skipped (USDT)", "#66c61c", ["skipped_already_migrated"]],
+      ["attention", "Attention", "#b42318", ["failed", "requires_operator_review"]],
+      ["rollingBack", "Rolling back", "#946200", ["rollback_started"]],
+      ["rolledBack", "Rolled back", "#667085", ["rolled_back"]],
+    ]
+    const stageStatuses = (key) => (STAGES.find((s) => s[0] === key) || [null, null, null, []])[3]
 
     const $ = (id) => document.getElementById(id)
     const money = (cents) => "$" + (cents / 100).toFixed(2)
@@ -538,6 +587,7 @@ const html = `<!doctype html>
       if (f.nonzeroUsd && !usd) return false
       if (f.nonzeroUsdt && !usdt) return false
       if (f.migration && account.migrationStatus !== f.migration) return false
+      if (stageFilter && stageStatuses(stageFilter).indexOf(account.migrationStatus) === -1) return false
       return true
     }
 
@@ -571,9 +621,58 @@ const html = `<!doctype html>
       }).join("")
     }
 
+    function elapsedText(startedAt) {
+      if (!startedAt) return ""
+      const ms = Date.now() - new Date(startedAt).getTime()
+      if (ms < 0) return ""
+      const m = Math.floor(ms / 60000), sec = Math.floor((ms % 60000) / 1000)
+      return (m >= 60 ? Math.floor(m / 60) + "h " + (m % 60) + "m" : m + "m " + sec + "s")
+    }
+
+    function renderPipeline() {
+      const st = snapshot.stages
+      const bar = $("stage-bar"), chips = $("stage-chips"), note = $("pipeline-note")
+      if (!st) { bar.innerHTML = ""; chips.innerHTML = '<span class="muted">waiting for first snapshot…</span>'; return }
+      note.textContent = st.cutoverState + (st.runId ? " · " + st.runId : "") +
+        (snapshot.cutover && snapshot.cutover.state === "in_progress" && snapshot.cutover.startedAt
+          ? " · elapsed " + elapsedText(snapshot.cutover.startedAt) : "") +
+        " · " + st.percentComplete + "% done"
+      bar.innerHTML = STAGES.map(([key, label, color]) => {
+        const n = st.counts[key] || 0
+        if (!n) return ""
+        const pct = (n / st.total) * 100
+        return '<div title="' + label + ': ' + n + '" style="width:' + pct + '%;background:' + color + '"></div>'
+      }).join("")
+      chips.innerHTML = STAGES.map(([key, label, color]) => {
+        const n = st.counts[key] || 0
+        return '<span class="chip' + (stageFilter === key ? " active" : "") + (n ? "" : " zero") + '" data-stage="' + key + '">' +
+          '<span class="dot" style="background:' + color + '"></span>' + label + ' <span class="n">' + n + '</span></span>'
+      }).join("")
+      chips.querySelectorAll(".chip").forEach((chip) => {
+        chip.addEventListener("click", () => {
+          stageFilter = stageFilter === chip.dataset.stage ? "" : chip.dataset.stage
+          $("filter-migration").value = ""
+          renderPipeline()
+          renderRows()
+        })
+      })
+    }
+
+    function renderHighlights() {
+      const feed = $("highlights")
+      const items = (snapshot.milestones || []).slice().reverse()
+      $("highlights-note").textContent = items.length + " event(s)"
+      feed.innerHTML = items.map((m) =>
+        '<li><span class="dot ' + m.kind + '"></span><span class="t">' +
+        new Date(m.at).toLocaleTimeString() + '</span><span>' + m.text + '</span></li>'
+      ).join("") || '<li><span class="muted">no events yet</span></li>'
+    }
+
     function render() {
       renderReadiness()
       renderSummary()
+      renderPipeline()
+      renderHighlights()
       renderMigrationFilter()
       renderRows()
     }
@@ -656,12 +755,27 @@ const html = `<!doctype html>
       window.location.href = "/api/export.csv"
     })
 
+    // Adaptive refresh: tight loop while a run (or rollback) is active,
+    // relaxed when idle.
+    function isActiveRun() {
+      if (!snapshot) return false
+      if (snapshot.cutover && snapshot.cutover.state === "in_progress") return true
+      const st = snapshot.stages
+      return !!st && (st.inFlight > 0 || (st.counts && st.counts.rollingBack > 0))
+    }
+    let reloadTimer = null
+    function scheduleReload() {
+      if (reloadTimer) clearTimeout(reloadTimer)
+      reloadTimer = setTimeout(() => {
+        load(false)
+          .catch((error) => { $("status").textContent = error.message })
+          .finally(scheduleReload)
+      }, isActiveRun() ? 15000 : 120000)
+    }
+
     load(false).catch((error) => {
       $("status").textContent = error.message
-    })
-    setInterval(() => load(false).catch((error) => {
-      $("status").textContent = error.message
-    }), 120000)
+    }).finally(scheduleReload)
   </script>
 </body>
 </html>`
@@ -696,6 +810,41 @@ const start = async () => {
       }
     | undefined
   let pending: Promise<CashWalletCutoverOperatorSnapshot> | undefined
+
+  // Stage pipeline + milestone highlights: diff consecutive snapshots and
+  // keep a bounded feed. Also logged, so `kubectl logs` retains the history
+  // across browser sessions.
+  let lastStageSummary: CashWalletCutoverStageSummary | undefined
+  const MILESTONE_LIMIT = 300
+  const milestones: CashWalletCutoverMilestone[] = [
+    {
+      at: new Date().toISOString(),
+      kind: "info",
+      text: `Dashboard online — watching ${manifestAccounts.length} accounts`,
+    },
+  ]
+
+  const observeStageProgress = (result: CashWalletCutoverOperatorSnapshot) => {
+    const current = summarizeCashWalletCutoverStages({
+      migrationStatuses: result.accounts.map((account) => account.migrationStatus),
+      cutoverState: result.cutover.state,
+      runId: result.cutover.runId,
+      missingUsdtWallets: result.summary.wallets.missingUsdt,
+    })
+    const fresh = deriveCashWalletCutoverMilestones({
+      previous: lastStageSummary,
+      current,
+      at: new Date().toISOString(),
+    })
+    for (const milestone of fresh) {
+      milestones.push(milestone)
+      baseLogger.info({ milestone }, "cutover milestone")
+    }
+    if (milestones.length > MILESTONE_LIMIT) {
+      milestones.splice(0, milestones.length - MILESTONE_LIMIT)
+    }
+    lastStageSummary = current
+  }
   const walletCurrencies = new Map<WalletId, WalletCurrency>()
   const balanceCache = new Map<WalletId, CachedBalance>()
   const balanceQueue: Array<{ walletId: WalletId; currency: WalletCurrency }> = []
@@ -858,6 +1007,7 @@ const start = async () => {
         }),
     })
     registerSnapshotWallets(result)
+    observeStageProgress(result)
     return result
   }
 
@@ -879,11 +1029,19 @@ const start = async () => {
     return pending
   }
 
+  // Keep stage/milestone tracking alive even with no browser tab open.
+  setInterval(() => {
+    snapshot(false).catch((error) =>
+      baseLogger.warn({ error }, "cutover dashboard background poll failed"),
+    )
+  }, 30_000)
+
   const app = express()
   app.get("/", (_req, res) => res.type("html").send(html))
   app.get("/api/snapshot", async (req, res) => {
     try {
-      res.json(await snapshot(req.query.refresh === "1"))
+      const result = await snapshot(req.query.refresh === "1")
+      res.json({ ...result, stages: lastStageSummary, milestones })
     } catch (error) {
       baseLogger.error({ error }, "Cash wallet cutover dashboard snapshot failed")
       res.status(500).json({
@@ -945,6 +1103,9 @@ const start = async () => {
         active: activeBalanceId,
       },
     })
+  })
+  app.get("/api/milestones", (_req, res) => {
+    res.json({ stages: lastStageSummary, milestones })
   })
   app.get("/api/export.csv", async (_req, res) => {
     try {

--- a/test/flash/unit/app/cash-wallet-cutover/operator-dashboard-stages.spec.ts
+++ b/test/flash/unit/app/cash-wallet-cutover/operator-dashboard-stages.spec.ts
@@ -1,0 +1,172 @@
+import {
+  deriveCashWalletCutoverMilestones,
+  summarizeCashWalletCutoverStages,
+} from "@app/cash-wallet-cutover/operator-dashboard"
+
+const AT = "2026-07-05T12:00:00.000Z"
+
+const summary = (
+  statuses: (CashWalletMigrationStatus | "none")[],
+  {
+    state = "in_progress" as CashWalletCutoverState,
+    missingUsdt = 0,
+    runId = "run-1",
+  } = {},
+) =>
+  summarizeCashWalletCutoverStages({
+    migrationStatuses: statuses,
+    cutoverState: state,
+    runId,
+    missingUsdtWallets: missingUsdt,
+  })
+
+describe("summarizeCashWalletCutoverStages", () => {
+  it("groups every migration status into a stage", () => {
+    const s = summary([
+      "none",
+      "not_started",
+      "started",
+      "balance_move_sending",
+      "fee_reimbursed",
+      "pointer_flipped",
+      "complete",
+      "skipped_already_migrated",
+      "failed",
+      "requires_operator_review",
+      "rollback_started",
+      "rolled_back",
+    ])
+
+    expect(s.counts).toMatchObject({
+      pending: 2,
+      provisioning: 1,
+      moving: 1,
+      fees: 1,
+      finalizing: 1,
+      complete: 1,
+      skipped: 1,
+      attention: 2,
+      rollingBack: 1,
+      rolledBack: 1,
+    })
+    expect(s.inFlight).toBe(4)
+    expect(s.done).toBe(2)
+    expect(s.total).toBe(12)
+  })
+
+  it("computes percentComplete from complete+skipped", () => {
+    const s = summary(["complete", "skipped_already_migrated", "none", "none"])
+    expect(s.percentComplete).toBe(50)
+  })
+})
+
+describe("deriveCashWalletCutoverMilestones", () => {
+  it("emits nothing on the first observation", () => {
+    expect(
+      deriveCashWalletCutoverMilestones({ current: summary(["none"]), at: AT }),
+    ).toEqual([])
+  })
+
+  it("announces run start, completion, and rollback state changes", () => {
+    const pre = summary(["none"], { state: "pre" })
+    const started = deriveCashWalletCutoverMilestones({
+      previous: pre,
+      current: summary(["none"]),
+      at: AT,
+    })
+    expect(started).toEqual([
+      { at: AT, kind: "info", text: "Cutover run started (run-1)" },
+    ])
+
+    const done = deriveCashWalletCutoverMilestones({
+      previous: summary(["complete"]),
+      current: summary(["complete"], { state: "complete" }),
+      at: AT,
+    })
+    expect(done.some((m) => m.kind === "ok" && /COMPLETE/.test(m.text))).toBe(true)
+
+    const rolled = deriveCashWalletCutoverMilestones({
+      previous: summary(["rolled_back"]),
+      current: summary(["rolled_back"], { state: "rolled_back" }),
+      at: AT,
+    })
+    expect(rolled.some((m) => m.kind === "warn" && /ROLLED BACK/.test(m.text))).toBe(true)
+  })
+
+  it("announces provisioning completion when missing USDT wallets reach zero", () => {
+    const out = deriveCashWalletCutoverMilestones({
+      previous: summary(["none"], { missingUsdt: 5 }),
+      current: summary(["none"], { missingUsdt: 0 }),
+      at: AT,
+    })
+    expect(out.some((m) => /Provisioning complete/.test(m.text))).toBe(true)
+  })
+
+  it("announces first in-flight, first complete, and percent thresholds", () => {
+    const quiet = summary(["none", "none", "none", "none"])
+    const moving = deriveCashWalletCutoverMilestones({
+      previous: quiet,
+      current: summary(["balance_move_sending", "none", "none", "none"]),
+      at: AT,
+    })
+    expect(moving.some((m) => /Migration batch running/.test(m.text))).toBe(true)
+
+    const firstDone = deriveCashWalletCutoverMilestones({
+      previous: summary(["balance_move_sending", "none", "none", "none"]),
+      current: summary(["complete", "none", "none", "none"]),
+      at: AT,
+    })
+    expect(firstDone.some((m) => /First account fully migrated/.test(m.text))).toBe(true)
+    expect(firstDone.some((m) => /25% migrated/.test(m.text))).toBe(true)
+
+    const allDone = deriveCashWalletCutoverMilestones({
+      previous: summary(["complete", "complete", "complete", "none"]),
+      current: summary(["complete", "complete", "complete", "complete"]),
+      at: AT,
+    })
+    expect(allDone.some((m) => /100% migrated/.test(m.text))).toBe(true)
+  })
+
+  it("announces attention spikes and the queue clearing", () => {
+    const spike = deriveCashWalletCutoverMilestones({
+      previous: summary(["none", "none"]),
+      current: summary(["failed", "requires_operator_review"]),
+      at: AT,
+    })
+    expect(
+      spike.some(
+        (m) => m.kind === "bad" && /\+2 account\(s\) need attention/.test(m.text),
+      ),
+    ).toBe(true)
+
+    const cleared = deriveCashWalletCutoverMilestones({
+      previous: summary(["failed", "none"]),
+      current: summary(["complete", "none"]),
+      at: AT,
+    })
+    expect(cleared.some((m) => /Attention queue cleared/.test(m.text))).toBe(true)
+  })
+
+  it("announces rollback start and drain", () => {
+    const started = deriveCashWalletCutoverMilestones({
+      previous: summary(["complete"]),
+      current: summary(["rollback_started"]),
+      at: AT,
+    })
+    expect(started.some((m) => /Rollback in progress/.test(m.text))).toBe(true)
+
+    const drained = deriveCashWalletCutoverMilestones({
+      previous: summary(["rollback_started", "rolled_back"]),
+      current: summary(["rolled_back", "rolled_back"]),
+      at: AT,
+    })
+    expect(drained.some((m) => /Rollback drained — 2/.test(m.text))).toBe(true)
+  })
+
+  it("does not repeat milestones when nothing changes", () => {
+    const same = summary(["complete", "none"])
+    expect(
+      deriveCashWalletCutoverMilestones({ previous: same, current: same, at: AT }),
+    ).toEqual([])
+  })
+})

--- a/test/flash/unit/app/cash-wallet-cutover/operator-dashboard-stages.spec.ts
+++ b/test/flash/unit/app/cash-wallet-cutover/operator-dashboard-stages.spec.ts
@@ -54,8 +54,21 @@ describe("summarizeCashWalletCutoverStages", () => {
     expect(s.total).toBe(12)
   })
 
-  it("computes percentComplete from complete+skipped", () => {
+  it("excludes permanently-none accounts from the denominator once the run started", () => {
+    // "none" accounts (already_usdt / residual / missing_*) never get
+    // migration records — counting them caps percentComplete below 100
+    // forever (TEST: 315 manifest vs 297 migrations ⇒ 94% ceiling).
     const s = summary(["complete", "skipped_already_migrated", "none", "none"])
+    expect(s.total).toBe(4)
+    expect(s.eligibleTotal).toBe(2)
+    expect(s.percentComplete).toBe(100)
+  })
+
+  it("keeps none accounts in the denominator before the run starts", () => {
+    const s = summary(["complete", "skipped_already_migrated", "none", "none"], {
+      state: "pre" as CashWalletCutoverState,
+    })
+    expect(s.eligibleTotal).toBe(4)
     expect(s.percentComplete).toBe(50)
   })
 })
@@ -120,11 +133,22 @@ describe("deriveCashWalletCutoverMilestones", () => {
     expect(firstDone.some((m) => /25% migrated/.test(m.text))).toBe(true)
 
     const allDone = deriveCashWalletCutoverMilestones({
-      previous: summary(["complete", "complete", "complete", "none"]),
+      previous: summary(["complete", "complete", "complete", "pointer_flipped"]),
       current: summary(["complete", "complete", "complete", "complete"]),
       at: AT,
     })
     expect(allDone.some((m) => /100% migrated/.test(m.text))).toBe(true)
+  })
+
+  it("fires the 100% milestone even when permanently-none accounts exist", () => {
+    // The reconciliation cue must fire on real data, where the manifest
+    // always contains accounts that never get migration records.
+    const out = deriveCashWalletCutoverMilestones({
+      previous: summary(["complete", "pointer_flipped", "none", "none"]),
+      current: summary(["complete", "complete", "none", "none"]),
+      at: AT,
+    })
+    expect(out.some((m) => /100% migrated \(2\/2\)/.test(m.text))).toBe(true)
   })
 
   it("announces attention spikes and the queue clearing", () => {


### PR DESCRIPTION
Operator monitoring upgrades for the USDT cutover rehearsal (ENG-461) and cutover day.

## What's new
- **Pipeline view**: stacked progress bar + clickable stage chips grouping the 14-status migration machine into 10 operator stages; chips filter the account table. Run context line shows state · runId · elapsed · % done.
- **Highlights feed**: server-derived milestone events — run started/COMPLETE/ROLLED BACK, provisioning complete, first account in flight, first fully migrated, 25/50/75/100% (with reconcile reminder), attention spikes/cleared, rollback started/drained. Bounded feed, every event also pino-logged so `kubectl logs` keeps history; a 30s background poll keeps milestones flowing with no browser open.
- **Adaptive refresh**: 15s while a run/rollback is active, 120s idle.
- New `/api/milestones`; `/api/snapshot` now carries `stages` + `milestones`.

## Design
Stage grouping + milestone derivation are pure functions in `operator-dashboard.ts` (9 new unit tests). The script only wires and renders — already validated live on TEST via the ad-hoc dashboard pod (config-map override): 315 accounts, `{pending: 315, pct 0, state pre, missingUsdt 315}`, milestones flowing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)