### PR TITLE
security(bridge): scrub committed sandbox apiKey + replaySecret (ENG-468)

### DIFF
--- a/dev/config/base-config.yaml
+++ b/dev/config/base-config.yaml
@@ -14,13 +14,13 @@ ibex:
 
 bridge:
   enabled: true
-  apiKey: "sk-test-3bd6463c9cd77c3d8858c60b9997d0c6"
+  apiKey: "" # real key injected via config overrides; never commit a real key
   baseUrl: "https://api.sandbox.bridge.xyz/v0"
   minWithdrawalAmount: 2
   timeoutMs: 15000
   webhook:
     port: 4009
-    replaySecret: "also-not-so-secret"
+    replaySecret: "" # set BRIDGE_WEBHOOK_REPLAY_SECRET or a local override to enable /internal/replay
     publicKeys:
       kyc: |
         -----BEGIN PUBLIC KEY-----


### PR DESCRIPTION
Scrubs the Bridge `apiKey` (`sk-test-…` sandbox key) and `replaySecret` committed to `dev/config/base-config.yaml` on this branch, aligning with main's placeholder convention (main already carries `apiKey: ""`).

## ⚠️ Scrubbing is not the fix — rotation is
`lnflash/flash` is **public**. The key is in git history on a pushed branch, so it's already exposed and this commit does not remove it. The sandbox key **must be rotated** in the Bridge dashboard.

**Coordinate the rotation with live TEST**: if `sk-test-3bd6463c9cd77c3d8858c60b9997d0c6` is the same key currently in `test.tfvars` as `BRIDGE_API_KEY`, rotating it breaks TEST's bridge flows until the tfvars value is updated and `make flash ENV=test` re-applied.

## Separately noted (not fixed here)
`base-config.yaml` also carries frappe `credentials.apiKey`/`apiSecret` (`2701937b…`) — these appear on **main** too, under the localhost frappe-docker block, so they look like the shared dev-container default rather than a deployed secret. Worth confirming they're not real for any deployed frappe; if they are, that's a separate rotation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)