### PR TITLE
fix(wallets): resolve drained IBEX accounts as zero balance (admin API broken for migrated accounts)

### DIFF
--- a/src/app/wallets/get-balance-for-wallet.ts
+++ b/src/app/wallets/get-balance-for-wallet.ts
@@ -1,7 +1,7 @@
 import { UnknownLedgerError } from "@domain/ledger"
 import { USDAmount, USDTAmount, WalletCurrency } from "@domain/shared"
 import Ibex from "@services/ibex/client"
-import { IbexError, UnexpectedIbexResponse } from "@services/ibex/errors"
+import { IbexError } from "@services/ibex/errors"
 
 export const getBalanceForWallet = async ({
   walletId,
@@ -18,7 +18,15 @@ export const getBalanceForWallet = async ({
       }
       return resp
     }
-    if (resp.balance === undefined) return new UnexpectedIbexResponse("Balance not found")
+    if (resp.balance === undefined) {
+      // IBEX omits `balance` for drained / never-funded accounts (per-account and
+      // bulk endpoints alike: absent means zero — verified in prod during the USDT
+      // cutover). Post-cutover, every migrated account's legacy USD wallet reads
+      // this way; returning an error here broke the admin API's wallets[].balance
+      // for all migrated accounts (the cash-wallet compat redirect only runs when
+      // client capabilities are in ctx, i.e. for app users — never for admin).
+      return currency === WalletCurrency.Usdt ? USDTAmount.ZERO : USDAmount.ZERO
+    }
     return resp.balance
   } catch (err) {
     return new UnknownLedgerError(err)

--- a/test/flash/unit/app/wallets/get-balance-for-wallet.spec.ts
+++ b/test/flash/unit/app/wallets/get-balance-for-wallet.spec.ts
@@ -1,5 +1,5 @@
 import { getBalanceForWallet } from "@app/wallets/get-balance-for-wallet"
-import { USDTAmount, WalletCurrency } from "@domain/shared"
+import { USDAmount, USDTAmount, WalletCurrency } from "@domain/shared"
 import Ibex from "@services/ibex/client"
 
 jest.mock("@services/ibex/client", () => ({
@@ -34,5 +34,36 @@ describe("getBalanceForWallet", () => {
     )
     expect(Ibex.getCryptoReceiveBalance).not.toHaveBeenCalled()
     expect(result).toBe(balance)
+  })
+
+  // IBEX omits `balance` on drained / never-funded accounts (absent means zero —
+  // verified in prod during the USDT cutover). Post-cutover every migrated
+  // account's legacy USD wallet reads this way; it must resolve to zero, not an
+  // error (an error here broke admin-API wallets[].balance for all migrated
+  // accounts, since the compat redirect never runs in admin ctx).
+  it("treats a missing balance field as zero for USD (drained legacy wallet)", async () => {
+    jest.mocked(Ibex.getAccountDetails).mockResolvedValue({
+      id: "drained-usd-ibex-id",
+    } as never)
+
+    const result = await getBalanceForWallet({
+      walletId: "drained-usd-ibex-id" as WalletId,
+      currency: WalletCurrency.Usd,
+    })
+
+    expect(result).toBe(USDAmount.ZERO)
+  })
+
+  it("treats a missing balance field as zero for USDT", async () => {
+    jest.mocked(Ibex.getAccountDetails).mockResolvedValue({
+      id: "drained-usdt-ibex-id",
+    } as never)
+
+    const result = await getBalanceForWallet({
+      walletId: "drained-usdt-ibex-id" as WalletId,
+      currency: WalletCurrency.Usdt,
+    })
+
+    expect(result).toBe(USDTAmount.ZERO)
   })
 })


### PR DESCRIPTION
## Bug
Since the USDT cutover completed (2026-07-10), the **admin GraphQL API fails for every migrated account**: `accountDetailsByUsername/ByAccountId` → `wallets[].balance` on the legacy (drained) USD wallet throws `IBEX_ERROR`, poisoning the whole response. Any admin-API consumer (Frappe Account Hub) breaks on ~all customer lookups.

**Why admin only:** the cash-wallet compat redirect in the USD wallet resolver only runs when `cashWalletClientCapabilities`/`domainAccount` are in ctx — true for app users on the public API (compat verified during cutover), never for admin ctx → raw read of the drained wallet.

**Root cause:** IBEX omits the `balance` field for drained/never-funded accounts (absent = zero; verified in prod during the cutover). `getBalanceForWallet` has a ZERO arm for `httpCode 404` but treated the missing-field case as `UnexpectedIbexResponse("Balance not found")` → resolver throws.

## Evidence
Direct prod admin-API query (`patoo`, migrated, $20):
```json
{"errors":[{"path":["accountDetailsByUsername","wallets",0,"balance"],"code":"IBEX_ERROR"}],
 "data":{"accountDetailsByUsername":{"wallets":[
   {"walletCurrency":"USD","balance":null},
   {"walletCurrency":"BTC","balance":null},
   {"walletCurrency":"USDT","balance":2000}]}}}
```
Same signature on TEST for every migrated account (`ben4`, `baa`).

## Fix
Missing `balance` on an otherwise-valid account-details response resolves to the currency's `ZERO` — consistent with the 404 arm and the cutover verifier's drained-reads-as-zero semantics. Applies to all consumers; no resolver/ctx changes.

## Tests
`TEST=get-balance-for-wallet yarn test:unit` → 3 passed (existing + drained-USD + drained-USDT). tsc clean.

## Deploy note
Wants to ride the next chart release — Account Hub (Frappe) stays broken for migrated accounts until this lands in prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)