### PR TITLE
feat(cashout): price JMD payout at live NCB rate from ERPNext

### DIFF
--- a/src/app/offers/CashoutManager.ts
+++ b/src/app/offers/CashoutManager.ts
@@ -1,5 +1,5 @@
 import { resolveCashoutWalletSelection } from "@app/cash-wallet-cutover/cashout-routing"
-import { Cashout, ExchangeRates } from "@config"
+import { Cashout } from "@config"
 import { decodeInvoice } from "@domain/bitcoin/lightning"
 import { CacheServiceError } from "@domain/cache"
 import { USDAmount, USDTAmount, ValidationError } from "@domain/shared"
@@ -10,16 +10,16 @@ import { getBankOwnerIbexAccount } from "@services/ledger/caching"
 import { RepositoryError } from "@domain/errors"
 import { EmailService } from "@services/email"
 import ErpNext from "@services/frappe/ErpNext"
-import { BankAccountQueryError } from "@services/frappe/errors"
+import { BankAccountQueryError, ExchangeRateQueryError } from "@services/frappe/errors"
 import { AccountsRepository, WalletsRepository } from "@services/mongoose"
 
 import PersistedOffer from "./storage/PersistedOffer"
 import Storage from "./storage/Redis"
+import { CashoutDetails } from "./types"
 import ValidOffer, { InitiatedCashout } from "./ValidOffer"
 
 const config = {
   ...Cashout.OfferConfig,
-  ...ExchangeRates,
 }
 
 const CashoutManager = {
@@ -68,8 +68,6 @@ const CashoutManager = {
 
     const serviceFee = userPayment.multiplyBips(config.fee)
     const usdPayout = userPayment.subtract(serviceFee)
-    const exchangeRate = config.jmd.sell // todo: get from price server
-    const jmdPayout = usdPayout.convertAtRate(exchangeRate)
 
     const bankAccounts = await ErpNext.getBankAccountsByCustomer(account.erpParty!)
     if (bankAccounts instanceof BankAccountQueryError) return bankAccounts
@@ -78,9 +76,22 @@ const CashoutManager = {
       return new ValidationError(`Bank account not found: ${bankAccountId}`)
 
     const isJmdPayout = bankAccount.currency === "JMD"
-    const payout = isJmdPayout
-      ? { bankAccountId, amount: jmdPayout, serviceFee, exchangeRate }
-      : { bankAccountId, amount: usdPayout, serviceFee }
+
+    // JMD cashout settles at NCB's buy rate, scraped weekly into ERPNext. Fail
+    // closed: never build a JMD offer at a guessed rate if the live rate is missing.
+    let payout: CashoutDetails["payout"]
+    if (isJmdPayout) {
+      const exchangeRate = await ErpNext.getCashoutExchangeRate()
+      if (exchangeRate instanceof ExchangeRateQueryError) return exchangeRate
+      payout = {
+        bankAccountId,
+        amount: usdPayout.convertAtRate(exchangeRate),
+        serviceFee,
+        exchangeRate,
+      }
+    } else {
+      payout = { bankAccountId, amount: usdPayout, serviceFee }
+    }
 
     const validated = await ValidOffer.from({
       payment: {

--- a/src/services/frappe/ErpNext.ts
+++ b/src/services/frappe/ErpNext.ts
@@ -1,6 +1,6 @@
 import ValidOffer from "@app/offers/ValidOffer"
 import { FrappeConfig } from "@config"
-import { USDTAmount, Validated } from "@domain/shared"
+import { JMDAmount, USDTAmount, Validated } from "@domain/shared"
 import { baseLogger } from "@services/logger"
 import { recordExceptionInCurrentSpan } from "@services/tracing"
 import axios, { isAxiosError } from "axios"
@@ -13,6 +13,7 @@ import {
   BridgeTransferRequestUpsertError,
   CashoutDraftError,
   CashoutSubmitError,
+  ExchangeRateQueryError,
   JournalEntryDeleteError,
   SetDocTypeValueError,
   UpgradeRequestCreateError,
@@ -288,6 +289,40 @@ export class ErpNext {
         attributes: { "erpnext.exception": responseData?.exception },
       })
       return new BankAccountQueryError(err)
+    }
+  }
+
+  async getCashoutExchangeRate(): Promise<JMDAmount | ExchangeRateQueryError> {
+    try {
+      // Cashout is money-out, so it settles at the bank's *buy* side (for_buying).
+      // The weekly NCB scrape upserts Currency Exchange records; the newest one is
+      // the live rate (ERPNext serves the most recent rate <= posting date).
+      const filters = `[["from_currency","=","USD"],["to_currency","=","JMD"],["for_buying","=",1]]`
+      const fields = `["exchange_rate","date"]`
+      const resp = await axios.get(
+        `${this.url}/api/resource/Currency%20Exchange?filters=${filters}&fields=${fields}&order_by=date%20desc&limit_page_length=1`,
+        { headers: this.headers },
+      )
+
+      const rate = resp.data?.data?.[0]?.exchange_rate
+      if (typeof rate !== "number" || !(rate > 0)) {
+        return new ExchangeRateQueryError("No USD->JMD for_buying rate found in ERPNext")
+      }
+
+      const jmdRate = JMDAmount.dollars(rate)
+      if (jmdRate instanceof Error) return new ExchangeRateQueryError(jmdRate)
+      return jmdRate
+    } catch (err) {
+      const responseData = isAxiosError(err) ? err.response?.data : undefined
+      baseLogger.error(
+        { err, responseData },
+        "Error querying Currency Exchange from ERPNext",
+      )
+      recordExceptionInCurrentSpan({
+        error: err,
+        attributes: { "erpnext.exception": responseData?.exception },
+      })
+      return new ExchangeRateQueryError(err)
     }
   }
 

--- a/src/services/frappe/errors.ts
+++ b/src/services/frappe/errors.ts
@@ -11,4 +11,5 @@ export class BanksQueryError extends ErpNextError {}
 export class BankAccountQueryError extends ErpNextError {}
 export class BankAccountUpdateRequestCreateError extends ErpNextError {}
 export class BankAccountUpdateRequestQueryError extends ErpNextError {}
+export class ExchangeRateQueryError extends ErpNextError {}
 export class BridgeTransferRequestUpsertError extends ErpNextError {}

--- a/test/flash/integration/offers/execute-offer.spec.ts
+++ b/test/flash/integration/offers/execute-offer.spec.ts
@@ -1,6 +1,6 @@
 import CashoutManager from "@app/offers/CashoutManager"
 
-import { USDAmount } from "@domain/shared"
+import { JMDAmount, USDAmount } from "@domain/shared"
 import ErpNext, { CashoutId } from "@services/frappe/ErpNext"
 import Ibex from "@services/ibex/client"
 
@@ -53,6 +53,7 @@ jest.mock("@services/frappe/ErpNext", () => ({
   __esModule: true,
   default: {
     getBankAccountsByCustomer: jest.fn(),
+    getCashoutExchangeRate: jest.fn(),
     draftCashout: jest.fn(),
     submitCashout: jest.fn(),
   },
@@ -77,6 +78,9 @@ beforeEach(async () => {
   })
   mockedIbex.payInvoice.mockResolvedValue(Mocks.payInvoiceV2.response)
   mockedErpNext.getBankAccountsByCustomer.mockResolvedValue([bankAccount])
+  mockedErpNext.getCashoutExchangeRate.mockResolvedValue(
+    JMDAmount.dollars(160) as JMDAmount,
+  )
   mockedErpNext.draftCashout.mockResolvedValue("cashout-test-id" as CashoutId)
   mockedErpNext.submitCashout.mockResolvedValue(true)
 })

--- a/test/flash/integration/offers/make-cashout-offer.spec.ts
+++ b/test/flash/integration/offers/make-cashout-offer.spec.ts
@@ -2,7 +2,7 @@ import CashoutManager from "@app/offers/CashoutManager"
 
 import ErpNext from "@services/frappe/ErpNext"
 import Ibex from "@services/ibex/client"
-import { USDAmount } from "@domain/shared"
+import { JMDAmount, USDAmount } from "@domain/shared"
 
 import { alice } from "../jest.setup"
 
@@ -57,6 +57,7 @@ jest.mock("@services/frappe/ErpNext", () => ({
   __esModule: true,
   default: {
     getBankAccountsByCustomer: jest.fn(),
+    getCashoutExchangeRate: jest.fn(),
   },
 }))
 let mockedIbex: jest.Mocked<typeof Ibex>
@@ -73,6 +74,9 @@ beforeEach(async () => {
       "lnurl1dp68gurn8ghj7um9dej8xct5w3skccne9e3k7mf0d3h82unvwqhkxun0wa5kgct5v93kzmmfd3skjmn0wvhxcmmv9u",
   })
   mockedErpNext.getBankAccountsByCustomer.mockResolvedValue([bankAccount])
+  mockedErpNext.getCashoutExchangeRate.mockResolvedValue(
+    JMDAmount.dollars(160) as JMDAmount,
+  )
 })
 
 afterEach(async () => {


### PR DESCRIPTION
## What
JMD cashout offers now price at the **live NCB buy rate** read from ERPNext, instead of the hardcoded `exchangeRates.USD.JMD.ask` (160).

## Why
The offer rate was static config with a standing `// todo: get from price server` (`CashoutManager.ts`). A weekly CronJob scrapes NCB's board into ERPNext `Currency Exchange` records; for money-out, the correct side is `for_buying` (USD→JMD ≈ 152.7). Users were quoted 160 while the real bank buy rate was ~152.7.

## Change
- **`ErpNext.getCashoutExchangeRate()`** — reads the latest `for_buying` USD→JMD `Currency Exchange` record (same REST pattern as `getBankAccountsByCustomer`).
- **`CashoutManager.createOffer`** — uses that rate for JMD payouts; **fails closed** if the live rate can't be read (never builds a JMD offer at a guessed rate). USD payouts unchanged.
- Retires the static `ExchangeRates` config wiring in the cashout path.

## Behaviour change
JMD payouts settle at the real bank buy rate (~152.7) rather than 160 — users receive ~4.5% less JMD, matching what Flash actually realizes on the FX. The rate + `receiveJmd` on the settle screen and the ERP payable JE all use the same value.

## Validation
- `tsc --noEmit` + eslint clean.
- Ran the exact query as the flash API user (`flash_sa@getflash.io`, permissions enforced) against **prod ERP** → `Currency Exchange` returns `152.7 (2026-07-13)`, confirming the query *and* read permission.
- No unit tests added — these ERPNext service methods (`getBankAccountsByCustomer`, `listBanks`, …) aren't unit-tested in this repo; validated against live ERP instead.

## Notes
- Fail-closed = a JMD cashout errors if ERPNext is unreachable at offer time (deliberate; chosen over transacting at a stale rate). ERPNext serves the most-recent rate ≤ today, so a missed weekly scrape does **not** trigger this.
- Topup intentionally left as-is (prices differently; no analogous backend rate step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
