### PR TITLE
fix(bank-account): regenerate federation supergraph for pendingUpdate [ENG-509]

### DIFF
--- a/dev/apollo-federation/supergraph.graphql
+++ b/dev/apollo-federation/supergraph.graphql
@@ -384,6 +384,11 @@ type BankAccount
   """ERPNext bank account identifier"""
   id: ID
   isDefault: Boolean!
+
+  """
+  The account's in-flight update request when it needs the user's attention — Pending (awaiting review) or Rejected (declined). Null once approved/closed, or when none exists.
+  """
+  pendingUpdate: BankAccountUpdateRequest
 }
 
 input BankAccountInput
@@ -394,6 +399,58 @@ input BankAccountInput
   bankBranch: String!
   bankName: String!
   currency: String!
+}
+
+"""
+A pending request to change the details of an approved bank account, awaiting admin review.
+"""
+type BankAccountUpdateRequest
+  @join__type(graph: PUBLIC)
+{
+  """Proposed new account number"""
+  accountNumber: String!
+
+  """Proposed new account type"""
+  accountType: String!
+
+  """Proposed new bank branch"""
+  bankBranch: String!
+
+  """Proposed new bank name"""
+  bankName: String!
+
+  """Account currency (unchanged from the current account)"""
+  currency: String!
+
+  """Reviewer note, set when status is Rejected"""
+  rejectionReason: String
+
+  """Pending | Approved | Rejected | Closed"""
+  status: String!
+}
+
+input BankAccountUpdateRequestInput
+  @join__type(graph: PUBLIC)
+{
+  accountNumber: AccountNumber!
+  accountType: String!
+
+  """ERPNext identifier of the account to update"""
+  bankAccountId: ID!
+  bankBranch: String!
+  bankName: String!
+
+  """Must match the account's current currency (currency is locked)"""
+  currency: String!
+}
+
+type BankAccountUpdateRequestPayload
+  @join__type(graph: PUBLIC)
+{
+  errors: [Error]
+
+  """Status of the created request (Pending on success)"""
+  status: String
 }
 
 type BridgeAddExternalAccountPayload
@@ -1486,6 +1543,7 @@ type Mutation
   Rotate an API key: a replacement with a new secret (and keyId) is created with the same name, scopes, and expiry, and the old key is revoked. The new raw key is only shown once.
   """
   apiKeyRotate(input: ApiKeyRotateInput!): ApiKeyRotatePayload!
+  bankAccountUpdateRequest(input: BankAccountUpdateRequestInput!): BankAccountUpdateRequestPayload!
   bridgeAddExternalAccount: BridgeAddExternalAccountPayload!
   bridgeCancelWithdrawalRequest(input: BridgeCancelWithdrawalRequestInput!): BridgeCancelWithdrawalRequestPayload!
   bridgeCreateExternalAccount(input: BridgeCreateExternalAccountInput!): BridgeCreateExternalAccountPayload!


### PR DESCRIPTION
## Problem

PR #444 (ENG-509) added `pendingUpdate` to the **public subgraph** schema (`src/graphql/public/schema.graphql`) but the composed **Apollo Router supergraph** (`dev/apollo-federation/supergraph.graphql`) was never regenerated. `check:sdl` only guards the subgraph SDL, not the supergraph, so the stale supergraph passed CI.

`api.*.flashapp.me` is served by the Apollo Router, which validates queries against that baked-in supergraph. Result: the mobile app's `BankAccounts` query (`bankAccounts { ... pendingUpdate { ... } }`) is rejected with:

```
Cannot query field "pendingUpdate" on type "BankAccount"  (GRAPHQL_VALIDATION_FAILED) → HTTP 400
```

even on backend images built from #444. On TEST this surfaces as **"No bank account found."** on the cashout screen — the 400 drops the whole response, so `bankAccounts` reads empty.

## Fix

Ran `make codegen` to recompose the supergraph. The subgraph schema was already current, so the **only** change is the generated `supergraph.graphql` (**58 insertions, 0 deletions**): the `pendingUpdate: BankAccountUpdateRequest` field plus the `BankAccountUpdateRequest` type/input.

## Deploy note

This is a chart-baked artifact — merging bumps the flash image/chart; TEST/prod pick it up on the next `make flash ENV=<env>`. Verify post-deploy: the `flash-supergraph` configmap and the served `__type(name:"BankAccount")` both include `pendingUpdate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)