### PR TITLE
fix(bridge): pad withdrawal notification amount to 2 decimals

### DIFF
--- a/src/app/bridge/send-withdrawal-notification.ts
+++ b/src/app/bridge/send-withdrawal-notification.ts
@@ -17,8 +17,11 @@ import {
 
 const i18n = getI18nInstance()
 
-const formatWithdrawalAmount = (amount: string, currency: string): string =>
-  `${amount} ${currency.toUpperCase()}`
+const formatWithdrawalAmount = (amount: string, currency: string): string => {
+  const numeric = Number(amount)
+  const display = Number.isFinite(numeric) ? numeric.toFixed(2) : amount
+  return `${display} ${currency.toUpperCase()}`
+}
 
 export type BridgeWithdrawalNotificationOutcome =
   | "submitted"


### PR DESCRIPTION
## Problem

Bridge (International) cashout push notifications render the amount with inconsistent decimals — e.g. **\`\$5.0\`** instead of **\`\$5.00\`**. Confirmed on a live prod cashout (bridge withdrawal record stored \`amount: 5.0\`).

## Root cause

`src/app/bridge/send-withdrawal-notification.ts` — `formatWithdrawalAmount` interpolated the amount **verbatim** as a string:

```ts
const formatWithdrawalAmount = (amount, currency) => `${amount} ${currency.toUpperCase()}`
```

The `amount` originates directly from the Bridge webhook payload (`services/bridge/webhook-server/routes/transfer.ts`), which emits decimal strings like `"5.0"` or `"5"`. With no `.toFixed(2)` / `minimumFractionDigits`, the value passed straight through to the i18n body and the client rendered `$5.0`.

This path also bypasses the money formatting the in-app notifications already use (`Intl.NumberFormat` with `minimumFractionDigits` in `services/notifications/create-push-notification-content.ts`).

## Fix

Format the value to 2 decimal places, with a fallback to the raw string for any non-numeric input so a malformed payload can never render `NaN`:

```ts
const formatWithdrawalAmount = (amount, currency) => {
  const numeric = Number(amount)
  const display = Number.isFinite(numeric) ? numeric.toFixed(2) : amount
  return `${display} ${currency.toUpperCase()}`
}
```

`"5.0"` → `"5.00"` → notification shows `$5.00`.

## Scope / notes

- Display-only; no change to amounts, fees, or the withdrawal record.
- Minimal, targeted fix. A broader follow-up could route this through the shared `CurrencyFormatter` (`@domain/fiat`) to match the in-app notification path, but that's out of scope here.
- USD/USDT bridge withdrawals are 2-dp; `.toFixed(2)` is correct for this notification path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)