### PR TITLE
fix(cashout): make JMD exchange-rate conversion decimal-safe [ENG-509]

### DIFF
--- a/src/domain/shared/MoneyAmount.ts
+++ b/src/domain/shared/MoneyAmount.ts
@@ -146,7 +146,13 @@ export class JMDAmount extends MoneyAmount {
 
   static dollars(d: number): JMDAmount | BigIntConversionError {
     try {
-      return new JMDAmount(BigInt(d) * 100n)
+      // Mirror USDAmount.dollars: use the Money lib for a decimal-safe conversion.
+      // BigInt(d) throws on any fractional rate (e.g. an NCB rate of 155.5), which
+      // is what the exchange-rate value virtually always is.
+      const dollarAmt = new Money(d.toString(), "JMDollars", Round.HALF_TO_EVEN)
+      const cents = JMDAmount.cents("100")
+      if (cents instanceof BigIntConversionError) return cents // should never happen
+      return new JMDAmount(cents.money.multiply(dollarAmt).toFixed(2))
     } catch (error) {
       return new BigIntConversionError(
         error instanceof Error ? error.message : String(error),

--- a/src/graphql/error-map.ts
+++ b/src/graphql/error-map.ts
@@ -921,6 +921,11 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
       message = "No upgrade request found for this account"
       return new NotFoundError({ message, logger: baseLogger })
 
+    case "ExchangeRateQueryError":
+      message =
+        "Cashout is temporarily unavailable while we refresh the exchange rate. Please try again shortly."
+      return new UnexpectedClientError({ message, logger: baseLogger })
+
     case "InvalidLnurlError":
       return new InvalidLnurlError({ message: error.message, logger: baseLogger })
 


### PR DESCRIPTION
## Problem

JMD cashout (`requestCashout`) silently fails on TEST — the "Next" button spins and the screen never advances, with **no error shown**. Two bugs stacked:

1. **`JMDAmount.dollars(d)`** (`src/domain/shared/MoneyAmount.ts`) did `new JMDAmount(BigInt(d) * 100n)`. `BigInt(155.5)` **throws** (non-integer) → `BigIntConversionError`. The cashout offer wraps the live NCB rate via this method (`getCashoutExchangeRate`), and NCB rates are ~always fractional (152.7, 155.5…), so it returned `ExchangeRateQueryError` for every real rate.

2. **`error-map.ts`** had no `ExchangeRateQueryError` case → the error fell through to the exhaustiveness fallback and was returned as a `data: null` **top-level GraphQL error**. The mobile app reads `res.data?.requestCashout.errors[0]?.message`; with `data` null it gets nothing → **no visible error**, just a spinner.

Reproduced with a real session token: `{"errors":[{"message":"This should never compile with ExchangeRateQueryError"}],"data":null}`. Setting the ERPNext rate to a whole number made `requestCashout` return a valid offer — confirming the cause.

## Fix

- Rewrote `JMDAmount.dollars` to mirror the already-correct `USDAmount.dollars` (uses the `Money` lib with `HALF_TO_EVEN`, string-based, no `BigInt` of a fractional). Fractional rates now convert correctly.
- Added an `ExchangeRateQueryError` case to `error-map.ts` returning a clear `UnexpectedClientError` message, so a rate failure surfaces to the user instead of a blank `data: null`.

## Impact / urgency

Only reachable on builds with the live-NCB-rate cashout (#444/#445). Those are **not yet on prod**, which is why prod JMD cashout works today — but a prod deploy of that code would break JMD cashout in every environment until this merges. Effectively a release blocker for #445.

Follow-up worth a ticket: a unit test asserting `JMDAmount.dollars(155.5)` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)