### PR TITLE
fix(cashout): decimal-safe JMD rate on the ACTUAL JMDAmount used by cashout

### DIFF
--- a/src/domain/shared/money/JMDAmount.ts
+++ b/src/domain/shared/money/JMDAmount.ts
@@ -1,6 +1,6 @@
 import { getCurrencyMajorExponent } from "@domain/fiat/display-currency"
 
-import Money from "../bigint-money"
+import Money, { Round } from "../bigint-money"
 
 import { BigIntConversionError } from "../errors"
 import { WalletCurrency } from "../primitives"
@@ -26,7 +26,13 @@ export class JMDAmount extends MoneyAmount {
 
   static dollars(d: number): JMDAmount | BigIntConversionError {
     try {
-      return new JMDAmount(BigInt(d) * 100n)
+      // Mirror USDAmount.dollars: use the Money lib for a decimal-safe conversion.
+      // BigInt(d) throws on any fractional rate (e.g. an NCB rate of 155.5), which
+      // is what the exchange-rate value virtually always is.
+      const dollarAmt = new Money(d.toString(), "JMDollars", Round.HALF_TO_EVEN)
+      const cents = JMDAmount.cents("100")
+      if (cents instanceof BigIntConversionError) return cents // should never happen
+      return new JMDAmount(cents.money.multiply(dollarAmt).toFixed(2))
     } catch (error) {
       return new BigIntConversionError(
         error instanceof Error ? error.message : String(error),

--- a/test/flash/unit/domain/shared/Money.spec.ts
+++ b/test/flash/unit/domain/shared/Money.spec.ts
@@ -32,6 +32,19 @@ describe("Money Amount", () => {
       const jmdprice = usdAmount.convertAtRate(rate)
       expect(jmdprice.asDollars()).toBe("16000.00")
     })
+
+    // Regression: the live NCB cashout rate is virtually always fractional
+    // (e.g. 155.5, 152.7). The old JMDAmount.dollars did `BigInt(d) * 100n`,
+    // which threw on any non-integer, breaking every JMD cashout offer.
+    // This imports JMDAmount from @domain/shared — the exact barrel-resolved
+    // class the cashout path uses (see ErpNext.getCashoutExchangeRate).
+    it("accepts fractional JMD rates (regression: NCB rate 155.5)", () => {
+      const amt = JMDAmount.dollars(155.5)
+      if (amt instanceof Error) throw amt
+      expect(amt.asDollars()).toBe("155.50")
+      expect(JMDAmount.dollars(152.7)).not.toBeInstanceOf(Error)
+      expect(JMDAmount.dollars(0.5)).not.toBeInstanceOf(Error)
+    })
   })
 
   describe("USD Amount", () => {


### PR DESCRIPTION
## Problem

After #449 deployed to TEST, JMD cashout **still** failed on fractional rates. Debugging the running image found two `JMDAmount` classes:

- `src/domain/shared/MoneyAmount.ts` — fixed in #449
- `src/domain/shared/money/JMDAmount.ts` — **untouched, still `BigInt(d) * 100n`**

The barrel `src/domain/shared/index.ts` does `export * from "./money"` and only re-exports `USDTAmount` from `MoneyAmount.ts`, so `getCashoutExchangeRate` (importing `JMDAmount` via `@domain/shared`) uses the **`money/JMDAmount.ts`** copy. #449 fixed the wrong twin — its error-map change worked (message changed) but the conversion bug remained. Proof from the deployed image: barrel `JMDAmount.dollars(155.5)` → `BigIntConversionError`; direct-file → `155.50`; `same class? false`.

## Fix

Apply the decimal-safe conversion (mirror the adjacent `money/USDAmount.dollars`, Money-lib + `HALF_TO_EVEN`) to `money/JMDAmount.ts`, and add the `Round` import.

## Test (this is the part #449 was missing)

Added a fractional-rate regression case to `test/flash/unit/domain/shared/Money.spec.ts`, which imports `JMDAmount` from `@domain/shared` — the **exact barrel-resolved class production uses**. The only pre-existing `JMDAmount.dollars` test used an integer (160), which is why the suite stayed green through the entire incident.

Ran for real (not just runtime-debugged):
- **Without the fix:** the new test fails — `BigIntConversionError: 155.5 cannot be converted to a BigInt`.
- **With the fix:** full suite **22/22 pass**; `tsc -p tsconfig.json --noEmit` clean.

## The dead twin — tracked, not hand-waved

After this PR, `MoneyAmount.ts`'s `JMDAmount` (the one #449 patched) is dead code shadowed by the barrel — a trap that will drift again. It can't be trivially deleted (the base `MoneyAmount.from()` references it), so the cleanup is its own change: **ENG-518** — *Collapse duplicate JMDAmount/MoneyAmount implementations*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)