### PR TITLE
fix(deps): resolve websocket-driver to 0.7.5 (critical advisory 1123483)

### DIFF
--- a/package.json
+++ b/package.json
@@ -223,6 +223,7 @@
     "**/follow-redirects": "1.16.0",
     "**/js-yaml": "4.1.1",
     "**/mongoose": "7.8.9",
+    "**/websocket-driver": "0.7.5",
     "**/axios": "1.16.0",
     "**/body-parser": "1.20.3",
     "**/ws": "8.20.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14163,10 +14163,10 @@ webidl-conversions@^7.0.0:
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-7.0.0.tgz#256b4e1882be7debbf01d05f0aa2039778ea080a"
   integrity sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==
 
-websocket-driver@>=0.5.1:
-  version "0.7.4"
-  resolved "https://registry.yarnpkg.com/websocket-driver/-/websocket-driver-0.7.4.tgz#89ad5295bbf64b480abcba31e4953aca706f5760"
-  integrity sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==
+websocket-driver@0.7.5, websocket-driver@>=0.5.1:
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/websocket-driver/-/websocket-driver-0.7.5.tgz#569d22764ab21f2de20af0e74b411e8ae5a0fa46"
+  integrity sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==
   dependencies:
     http-parser-js ">=0.5.1"
     safe-buffer ">=5.1.0"


### PR DESCRIPTION
## Summary

Advisory [1123483](https://www.npmjs.com/advisories/1123483) (critical, `websocket-driver` <0.7.5) landed in the registry on 2026-07-17 and turned the `Audit` gate (`yarn audit --level critical`, exit ≥16) red on every branch.

The vulnerable copy is dev-only: `spectaql > grunt-contrib-watch > tiny-lr > faye-websocket > websocket-driver`. Its parent accepts `>=0.5.1`, so pinning `0.7.5` via the existing `resolutions` block (house convention: exact `**/pkg` pins) changes nothing at runtime.

## Verification

- `yarn audit --level critical` exit 14 (< 16 gate) — 0 critical remaining (was 1)
- `yarn why websocket-driver` → 0.7.5
- Unit suite 136 suites / 1082 passed; `yarn tsc-check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)