### PR TITLE
fix(wallets): never emit unresolvable via types from IBEX transaction mapping

### DIFF
--- a/src/app/wallets/get-transactions-for-wallet.ts
+++ b/src/app/wallets/get-transactions-for-wallet.ts
@@ -44,33 +44,18 @@ const currencyFromIbexCurrencyId = (
 }
 
 export const toWalletTransactions = (ibexResp: GResponse200): IbexTransaction[] => {
-  return ibexResp.map((trx) => {
+  return ibexResp.flatMap((trx) => {
     const currency = currencyFromIbexCurrencyId(trx.currencyId)
 
     if (!currency) {
       baseLogger.error(
-        `Failed to parse Ibex transaction currency. { WalletId: ${trx.accountId}, TransactionId: ${trx.id}, currencyId: ${trx.currencyId} }`,
+        `Failed to parse Ibex transaction currency. Excluding transaction from list. { WalletId: ${trx.accountId}, TransactionId: ${trx.id}, currencyId: ${trx.currencyId} }`,
       )
-      return {
-        walletId: (trx.accountId || "") as WalletId,
-        settlementAmount: 0 as Satoshis,
-        settlementFee: 0 as Satoshis,
-        settlementCurrency: WalletCurrency.Usd,
-        settlementDisplayAmount: `${trx.amount}`,
-        settlementDisplayFee: `${trx.networkFee}`,
-        settlementDisplayPrice: {
-          base: 0n,
-          offset: 0n,
-          displayCurrency: "USD" as DisplayCurrency,
-          walletCurrency: WalletCurrency.Usd,
-        },
-        createdAt: trx.createdAt ? new Date(trx.createdAt) : new Date(),
-        id: trx.id || "null",
-        status: "success" as TxStatus,
-        memo: null,
-        initiationVia: { type: "unknown" },
-        settlementVia: { type: "unknown" },
-      } as UnknownTypeTransaction
+      // A row with an unrecognized currency cannot be represented truthfully;
+      // excluding it beats fabricating a USD row or emitting a source the
+      // NonNull initiationVia/settlementVia unions cannot resolve (which fails
+      // the whole transaction list query for the account).
+      return []
     }
 
     const settlementDisplayPrice: WalletMinorUnitDisplayPrice<
@@ -124,13 +109,25 @@ export const toWalletTransactions = (ibexResp: GResponse200): IbexTransaction[] 
         } as WalletOnChainSettledTransaction // assuming Ibex only gives us settled
       default:
         baseLogger.error(
-          `Failed to parse Ibex transaction type. { WalletId: ${baseTrx.walletId}, TransactionId: ${trx.id}, transactionTypeId: ${trx.transactionTypeId}`,
+          `Failed to parse Ibex transaction type. Rendering as intraledger. { WalletId: ${baseTrx.walletId}, TransactionId: ${trx.id}, transactionTypeId: ${trx.transactionTypeId}`,
         )
+        // Amounts and currency are valid even when the IBEX type id is not
+        // recognized; render as a generic intraledger transaction (all union
+        // fields nullable) rather than hiding money movement or emitting a
+        // source the unions cannot resolve.
         return {
           ...baseTrx,
-          initiationVia: { type: "unknown" },
-          settlementVia: { type: "unknown" },
-        } as UnknownTypeTransaction
+          initiationVia: {
+            type: "intraledger",
+            counterPartyWalletId: undefined as unknown as WalletId,
+            counterPartyUsername: undefined as unknown as Username,
+          },
+          settlementVia: {
+            type: "intraledger",
+            counterPartyWalletId: undefined as unknown as WalletId,
+            counterPartyUsername: null,
+          },
+        } as IntraLedgerTransaction
     }
   })
 }

--- a/src/app/wallets/get-transactions-for-wallet.ts
+++ b/src/app/wallets/get-transactions-for-wallet.ts
@@ -109,22 +109,25 @@ export const toWalletTransactions = (ibexResp: GResponse200): IbexTransaction[] 
         } as WalletOnChainSettledTransaction // assuming Ibex only gives us settled
       default:
         baseLogger.error(
-          `Failed to parse Ibex transaction type. Rendering as intraledger. { WalletId: ${baseTrx.walletId}, TransactionId: ${trx.id}, transactionTypeId: ${trx.transactionTypeId}`,
+          `Failed to parse Ibex transaction type. Rendering as intraledger. { WalletId: ${baseTrx.walletId}, TransactionId: ${trx.id}, transactionTypeId: ${trx.transactionTypeId} }`,
         )
         // Amounts and currency are valid even when the IBEX type id is not
         // recognized; render as a generic intraledger transaction (all union
         // fields nullable) rather than hiding money movement or emitting a
-        // source the unions cannot resolve.
+        // source the unions cannot resolve. Accepted caveat: the sign
+        // convention (send = negative) is only known for recognized type ids,
+        // so an unrecognized send type renders positive until its id is
+        // added to the switch above.
         return {
           ...baseTrx,
           initiationVia: {
             type: "intraledger",
-            counterPartyWalletId: undefined as unknown as WalletId,
-            counterPartyUsername: undefined as unknown as Username,
+            counterPartyWalletId: undefined,
+            counterPartyUsername: undefined,
           },
           settlementVia: {
             type: "intraledger",
-            counterPartyWalletId: undefined as unknown as WalletId,
+            counterPartyWalletId: undefined,
             counterPartyUsername: null,
           },
         } as IntraLedgerTransaction

--- a/src/domain/wallets/index.types.d.ts
+++ b/src/domain/wallets/index.types.d.ts
@@ -9,8 +9,8 @@ type WalletType =
 
 type InitiationViaIntraledger = {
   readonly type: "intraledger"
-  readonly counterPartyWalletId: WalletId
-  readonly counterPartyUsername: Username
+  readonly counterPartyWalletId: WalletId | undefined
+  readonly counterPartyUsername: Username | undefined
 }
 
 type InitiationViaLn = {
@@ -32,7 +32,7 @@ type InitiationViaOnChainLegacy = {
 
 type SettlementViaIntraledger = {
   readonly type: "intraledger"
-  readonly counterPartyWalletId: WalletId
+  readonly counterPartyWalletId: WalletId | undefined
   readonly counterPartyUsername: Username | null
 }
 

--- a/src/domain/wallets/index.types.d.ts
+++ b/src/domain/wallets/index.types.d.ts
@@ -130,15 +130,6 @@ type WalletLnSettledTransaction = BaseWalletTransaction & {
   readonly settlementVia: SettlementViaLn
 }
 
-type UnknownTypeTransaction = BaseWalletTransaction & {
-  readonly initiationVia: {
-    readonly type: "unknown"
-  }
-  readonly settlementVia: {
-    readonly type: "unknown"
-  }
-}
-
 type WalletOnChainTransaction =
   | WalletOnChainIntraledgerTransaction
   | WalletOnChainSettledTransaction
@@ -153,9 +144,9 @@ type WalletTransaction =
   | WalletLnTransaction
 
 type IbexTransaction =
+  | IntraLedgerTransaction
   | WalletOnChainTransaction
   | WalletLnTransaction
-  | UnknownTypeTransaction
 
 type MemoSharingConfig = {
   memoSharingCentsThreshold: UsdCents

--- a/src/graphql/shared/types/abstract/initiation-via.ts
+++ b/src/graphql/shared/types/abstract/initiation-via.ts
@@ -10,7 +10,6 @@ import PaymentHash from "../scalar/payment-hash"
 
 const InitiationViaIntraLedger = GT.Object({
   name: "InitiationViaIntraLedger",
-  isTypeOf: (source) => source.type === PaymentInitiationMethod.IntraLedger,
   fields: () => ({
     counterPartyWalletId: {
       // type: GT.NonNull(WalletId),
@@ -24,7 +23,6 @@ const InitiationViaIntraLedger = GT.Object({
 
 const InitiationViaLn = GT.Object({
   name: "InitiationViaLn",
-  isTypeOf: (source) => source.type === PaymentInitiationMethod.Lightning,
   fields: () => ({
     paymentHash: {
       type: GT.NonNull(PaymentHash),
@@ -34,7 +32,6 @@ const InitiationViaLn = GT.Object({
 
 const InitiationViaOnChain = GT.Object({
   name: "InitiationViaOnChain",
-  isTypeOf: (source) => source.type === PaymentInitiationMethod.OnChain,
   fields: () => ({
     address: {
       type: GT.NonNull(OnChainAddress),

--- a/src/graphql/shared/types/abstract/initiation-via.ts
+++ b/src/graphql/shared/types/abstract/initiation-via.ts
@@ -1,6 +1,7 @@
 import { GT } from "@graphql/index"
 
 import { PaymentInitiationMethod } from "@domain/wallets"
+import { baseLogger } from "@services/logger"
 
 import WalletId from "../scalar/wallet-id"
 import Username from "../scalar/username"
@@ -44,6 +45,25 @@ const InitiationViaOnChain = GT.Object({
 const InitiationVia = GT.Union({
   name: "InitiationVia",
   types: () => [InitiationViaIntraLedger, InitiationViaLn, InitiationViaOnChain],
+  // initiationVia is NonNull on Transaction: a source that fails to resolve
+  // fails the entire transaction list query for the account. Unrecognized
+  // sources degrade to the all-nullable IntraLedger member instead.
+  resolveType: (source) => {
+    switch (source.type) {
+      case PaymentInitiationMethod.IntraLedger:
+        return "InitiationViaIntraLedger"
+      case PaymentInitiationMethod.Lightning:
+        return "InitiationViaLn"
+      case PaymentInitiationMethod.OnChain:
+        return "InitiationViaOnChain"
+      default:
+        baseLogger.error(
+          { initiationViaType: source.type },
+          "Unrecognized initiationVia type; defaulting to InitiationViaIntraLedger",
+        )
+        return "InitiationViaIntraLedger"
+    }
+  },
 })
 
 export default InitiationVia

--- a/src/graphql/shared/types/abstract/settlement-via.ts
+++ b/src/graphql/shared/types/abstract/settlement-via.ts
@@ -3,6 +3,7 @@ import dedent from "dedent"
 import { GT } from "@graphql/index"
 
 import { SettlementMethod } from "@domain/wallets"
+import { baseLogger } from "@services/logger"
 
 import WalletId from "@graphql/shared/types/scalar/wallet-id"
 
@@ -57,6 +58,25 @@ const SettlementViaOnChain = GT.Object({
 const SettlementVia = GT.Union({
   name: "SettlementVia",
   types: () => [SettlementViaIntraLedger, SettlementViaLn, SettlementViaOnChain],
+  // settlementVia is NonNull on Transaction: a source that fails to resolve
+  // fails the entire transaction list query for the account. Unrecognized
+  // sources degrade to the all-nullable IntraLedger member instead.
+  resolveType: (source) => {
+    switch (source.type) {
+      case SettlementMethod.IntraLedger:
+        return "SettlementViaIntraLedger"
+      case SettlementMethod.Lightning:
+        return "SettlementViaLn"
+      case SettlementMethod.OnChain:
+        return "SettlementViaOnChain"
+      default:
+        baseLogger.error(
+          { settlementViaType: source.type },
+          "Unrecognized settlementVia type; defaulting to SettlementViaIntraLedger",
+        )
+        return "SettlementViaIntraLedger"
+    }
+  },
 })
 
 export default SettlementVia

--- a/src/graphql/shared/types/abstract/settlement-via.ts
+++ b/src/graphql/shared/types/abstract/settlement-via.ts
@@ -16,7 +16,6 @@ import LnPaymentSecret from "../scalar/ln-payment-secret"
 
 const SettlementViaIntraLedger = GT.Object({
   name: "SettlementViaIntraLedger",
-  isTypeOf: (source) => source.type === SettlementMethod.IntraLedger,
   fields: () => ({
     counterPartyWalletId: {
       // type: GT.NonNull(WalletId),
@@ -31,7 +30,6 @@ const SettlementViaIntraLedger = GT.Object({
 
 const SettlementViaLn = GT.Object({
   name: "SettlementViaLn",
-  isTypeOf: (source: SettlementViaLn) => source.type === SettlementMethod.Lightning,
   fields: () => ({
     paymentSecret: {
       type: LnPaymentSecret,
@@ -48,7 +46,6 @@ const SettlementViaLn = GT.Object({
 
 const SettlementViaOnChain = GT.Object({
   name: "SettlementViaOnChain",
-  isTypeOf: (source) => source.type === SettlementMethod.OnChain,
   fields: () => ({
     transactionHash: { type: OnChainTxHash },
     vout: { type: GT.Int },

--- a/test/flash/unit/app/wallets/get-transactions-for-wallet.spec.ts
+++ b/test/flash/unit/app/wallets/get-transactions-for-wallet.spec.ts
@@ -156,8 +156,10 @@ describe("toWalletTransactions", () => {
     expect(transaction.settlementFee).toBe(12)
   })
 
-  it("does not silently classify unknown IBEX currency ids as BTC", () => {
-    const [transaction] = toWalletTransactions([
+  it("excludes transactions with unknown IBEX currency ids from the list", () => {
+    const errorSpy = jest.spyOn(baseLogger, "error").mockImplementation()
+
+    const transactions = toWalletTransactions([
       {
         id: "trx-id",
         accountId: "wallet-id",
@@ -168,9 +170,62 @@ describe("toWalletTransactions", () => {
       },
     ] as GResponse200)
 
-    expect(transaction.settlementCurrency).not.toBe(WalletCurrency.Btc)
-    expect(transaction.initiationVia.type).toBe("unknown")
-    expect(transaction.settlementVia.type).toBe("unknown")
+    expect(transactions).toHaveLength(0)
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Failed to parse Ibex transaction currency"),
+    )
+
+    errorSpy.mockRestore()
+  })
+
+  it("maps unknown IBEX transaction type ids to intraledger with valid amounts", () => {
+    const errorSpy = jest.spyOn(baseLogger, "error").mockImplementation()
+
+    const [transaction] = toWalletTransactions([
+      {
+        id: "trx-id",
+        accountId: "wallet-id",
+        amount: 250,
+        networkFee: 1,
+        currencyId: 3,
+        transactionTypeId: 99,
+        createdAt: "2026-05-13T00:00:00.000Z",
+      },
+    ] as GResponse200)
+
+    expect(transaction.settlementCurrency).toBe(WalletCurrency.Usd)
+    expect(transaction.settlementAmount).toBe(250)
+    expect(transaction.settlementFee).toBe(1)
+    expect(transaction.initiationVia.type).toBe("intraledger")
+    expect(transaction.settlementVia.type).toBe("intraledger")
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Failed to parse Ibex transaction type"),
+    )
+
+    errorSpy.mockRestore()
+  })
+
+  it("never emits via types outside the GraphQL union members", () => {
+    const resolvable = ["intraledger", "lightning", "onchain"]
+
+    const transactions = toWalletTransactions(
+      [3, 29].flatMap((currencyId) =>
+        [1, 2, 3, 4, 10, 99, undefined].map((transactionTypeId, i) => ({
+          id: `trx-${currencyId}-${i}`,
+          accountId: "wallet-id",
+          amount: 10,
+          currencyId,
+          transactionTypeId,
+          createdAt: "2026-05-13T00:00:00.000Z",
+        })),
+      ) as GResponse200,
+    )
+
+    expect(transactions).toHaveLength(14)
+    for (const transaction of transactions) {
+      expect(resolvable).toContain(transaction.initiationVia.type)
+      expect(resolvable).toContain(transaction.settlementVia.type)
+    }
   })
 })
 

--- a/test/flash/unit/graphql/shared/types/abstract/via-unions.spec.ts
+++ b/test/flash/unit/graphql/shared/types/abstract/via-unions.spec.ts
@@ -1,0 +1,48 @@
+import { GraphQLResolveInfo, GraphQLUnionType } from "graphql"
+
+import InitiationVia from "@graphql/shared/types/abstract/initiation-via"
+import SettlementVia from "@graphql/shared/types/abstract/settlement-via"
+import { baseLogger } from "@services/logger"
+
+const resolve = (union: GraphQLUnionType, source: { type?: string }) =>
+  union.resolveType?.(source, {}, {} as GraphQLResolveInfo, union)
+
+describe("InitiationVia union", () => {
+  it("resolves known initiation methods to their object types", () => {
+    expect(resolve(InitiationVia, { type: "intraledger" })).toBe(
+      "InitiationViaIntraLedger",
+    )
+    expect(resolve(InitiationVia, { type: "lightning" })).toBe("InitiationViaLn")
+    expect(resolve(InitiationVia, { type: "onchain" })).toBe("InitiationViaOnChain")
+  })
+
+  it("falls back to InitiationViaIntraLedger for unrecognized sources instead of failing the query", () => {
+    const errorSpy = jest.spyOn(baseLogger, "error").mockImplementation()
+
+    expect(resolve(InitiationVia, { type: "unknown" })).toBe("InitiationViaIntraLedger")
+    expect(resolve(InitiationVia, {})).toBe("InitiationViaIntraLedger")
+    expect(errorSpy).toHaveBeenCalled()
+
+    errorSpy.mockRestore()
+  })
+})
+
+describe("SettlementVia union", () => {
+  it("resolves known settlement methods to their object types", () => {
+    expect(resolve(SettlementVia, { type: "intraledger" })).toBe(
+      "SettlementViaIntraLedger",
+    )
+    expect(resolve(SettlementVia, { type: "lightning" })).toBe("SettlementViaLn")
+    expect(resolve(SettlementVia, { type: "onchain" })).toBe("SettlementViaOnChain")
+  })
+
+  it("falls back to SettlementViaIntraLedger for unrecognized sources instead of failing the query", () => {
+    const errorSpy = jest.spyOn(baseLogger, "error").mockImplementation()
+
+    expect(resolve(SettlementVia, { type: "unknown" })).toBe("SettlementViaIntraLedger")
+    expect(resolve(SettlementVia, {})).toBe("SettlementViaIntraLedger")
+    expect(errorSpy).toHaveBeenCalled()
+
+    errorSpy.mockRestore()
+  })
+})


### PR DESCRIPTION
## Problem

Any IBEX transaction row with an unrecognized `currencyId` or `transactionTypeId` maps to `initiationVia/settlementVia: { type: "unknown" }`. The `InitiationVia`/`SettlementVia` GraphQL unions resolve members via `isTypeOf` checks that only match `intraledger`/`lightning`/`onchain`, and both fields are NonNull — so graphql-js throws:

> Abstract type 'InitiationVia' must resolve to an Object type at runtime for field 'Transaction.initiationVia'

One bad row fails the **entire transaction list query** for the account: home screen and transaction history go down in the mobile app. This is live on TEST today (dev builds default to the Test instance) and becomes a prod incident as soon as the #413 code path meets a legacy/BTC-denominated or new-swap-type IBEX row on Main, because #413 narrowed the currency mapping to USD (3) / USDT (29) only and the type switch handles only 1,2 (LN) and 3,4,10 (onchain).

## Fix

- **Unknown `currencyId`** → exclude the row from the list (error log kept). It cannot be represented truthfully; a fabricated $0 USD row or a crashed query are both worse. This keeps #413's deliberate decision not to misclassify unknown currencies as BTC.
- **Unknown `transactionTypeId`** → amounts and currency are valid, so render as a generic intraledger transaction (all union fields nullable) instead of hiding money movement (error log kept, includes the offending type id).
- **Remove `UnknownTypeTransaction`** from the domain types so no code path can emit `{ type: "unknown" }` again — the compiler now rejects it.
- **Defense in depth**: add `resolveType` with a logged intraledger fallback on both unions, so an unrecognized source degrades to a renderable member instead of failing the whole list, whatever the producer.

No schema change (`yarn check:sdl` clean — union membership is untouched).

## Tests

- `test/flash/unit/app/wallets/get-transactions-for-wallet.spec.ts`: unknown currency rows are excluded + logged; unknown type ids render as intraledger with correct amounts + logged; exhaustive sweep asserting every currencyId × transactionTypeId combination only ever emits union-resolvable via types.
- `test/flash/unit/graphql/shared/types/abstract/via-unions.spec.ts` (new): both unions resolve all known methods to the right object types and fall back with a logged error for unrecognized sources.
- Full unit suite: 137 suites / 1088 tests green. `yarn tsc-check` clean.

## Ops note

The two error-log paths (`Failed to parse Ibex transaction currency/type`) include the concrete `currencyId`/`transactionTypeId` — worth watching after deploy to add explicit mappings for whatever IBEX is actually returning (the ibex-swap A/B on TEST is a likely source).

🤖 Generated with [Claude Code](https://claude.com/claude-code)