### PR TITLE
feat(notifications): Baileys wa-bridge delivery for WhatsApp invites

### DIFF
--- a/src/services/notification/index.ts
+++ b/src/services/notification/index.ts
@@ -3,6 +3,24 @@ import sgMail from "@sendgrid/mail"
 import { baseLogger } from "@services/logger"
 import { env, SendGridConfig, TWILIO_FROM, TWILIO_WHATSAPP_FROM } from "@config"
 
+// Single source of truth for whether WhatsApp delivery routes through the
+// Baileys wa-bridge (authed POST /send) instead of Twilio. Both the transport
+// (sendWhatsApp) and the invite message-body selection (sendInviteNotification)
+// read this, so the two decisions can never disagree. Returns null when the
+// bridge is not configured; warns if exactly one of the two vars is set — a
+// misconfiguration that would otherwise silently fall back to the Twilio path.
+export const waBridgeConfig = (): { url: string; secret: string } | null => {
+  const url = process.env.WA_BRIDGE_URL
+  const secret = process.env.WA_BRIDGE_SECRET
+  if (url && secret) return { url, secret }
+  if (url || secret) {
+    baseLogger.warn(
+      "WA_BRIDGE_URL and WA_BRIDGE_SECRET must both be set to route WhatsApp via the wa-bridge; falling back to Twilio",
+    )
+  }
+  return null
+}
+
 export enum NotificationMethod {
   EMAIL = "EMAIL",
   SMS = "SMS",
@@ -148,17 +166,13 @@ class NotificationServiceImpl implements NotificationService {
   }
 
   private async sendWhatsApp(to: string, body: string): Promise<boolean> {
-    // Baileys bridge delivery (TEST/dev): when WA_BRIDGE_URL + WA_BRIDGE_SECRET
-    // are configured, WhatsApp messages go out through the wa-bridge's authed
-    // POST /send instead of Twilio (no Twilio WhatsApp sender is provisioned
-    // in any env today). Unset both to use the Twilio template path.
-    if (process.env.WA_BRIDGE_URL && process.env.WA_BRIDGE_SECRET) {
-      return this.sendWhatsAppViaBridge(
-        process.env.WA_BRIDGE_URL,
-        process.env.WA_BRIDGE_SECRET,
-        to,
-        body,
-      )
+    // When the wa-bridge is configured (see waBridgeConfig), WhatsApp messages
+    // go out through its authed POST /send instead of Twilio (no Twilio
+    // WhatsApp sender is provisioned in any env today). This gate is env-based,
+    // not environment-restricted — it fires wherever both vars are set.
+    const bridge = waBridgeConfig()
+    if (bridge) {
+      return this.sendWhatsAppViaBridge(bridge.url, bridge.secret, to, body)
     }
 
     if (!this.twilioClient) {

--- a/src/services/notification/index.ts
+++ b/src/services/notification/index.ts
@@ -148,6 +148,19 @@ class NotificationServiceImpl implements NotificationService {
   }
 
   private async sendWhatsApp(to: string, body: string): Promise<boolean> {
+    // Baileys bridge delivery (TEST/dev): when WA_BRIDGE_URL + WA_BRIDGE_SECRET
+    // are configured, WhatsApp messages go out through the wa-bridge's authed
+    // POST /send instead of Twilio (no Twilio WhatsApp sender is provisioned
+    // in any env today). Unset both to use the Twilio template path.
+    if (process.env.WA_BRIDGE_URL && process.env.WA_BRIDGE_SECRET) {
+      return this.sendWhatsAppViaBridge(
+        process.env.WA_BRIDGE_URL,
+        process.env.WA_BRIDGE_SECRET,
+        to,
+        body,
+      )
+    }
+
     if (!this.twilioClient) {
       baseLogger.error("Twilio client not configured")
       return false
@@ -248,6 +261,43 @@ class NotificationServiceImpl implements NotificationService {
         "Failed to send WhatsApp message",
       )
       return false
+    }
+  }
+
+  // Deliver a plain-text WhatsApp message through the Baileys wa-bridge
+  // (flash-support-infra/services/wa-bridge, authed POST /send). Message
+  // content is never logged — invite links carry one-time tokens.
+  private async sendWhatsAppViaBridge(
+    url: string,
+    secret: string,
+    to: string,
+    body: string,
+  ): Promise<boolean> {
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), 15_000)
+    try {
+      const resp = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "X-Send-Token": secret },
+        body: JSON.stringify({ to, text: body }),
+        signal: controller.signal,
+      })
+      const payload = (await resp.json().catch(() => ({}))) as { ok?: boolean }
+      const ok = resp.ok && payload.ok === true
+      if (ok) {
+        baseLogger.info(
+          { to, bodyLength: body.length },
+          "WhatsApp message sent via wa-bridge",
+        )
+      } else {
+        baseLogger.error({ to, status: resp.status }, "wa-bridge send failed")
+      }
+      return ok
+    } catch (error) {
+      baseLogger.error({ error: String(error), to }, "wa-bridge send error")
+      return false
+    } finally {
+      clearTimeout(timeout)
     }
   }
 }

--- a/src/services/notifications/invite.ts
+++ b/src/services/notifications/invite.ts
@@ -1,5 +1,9 @@
 import { InviteMethod } from "@domain/invite"
-import { notificationService, NotificationMethod } from "@services/notification"
+import {
+  notificationService,
+  NotificationMethod,
+  waBridgeConfig,
+} from "@services/notification"
 import { baseLogger } from "@services/logger"
 
 const buildInviteLink = (token: string): string => {
@@ -61,7 +65,7 @@ export const sendInviteNotification = async ({
         break
 
       case InviteMethod.WHATSAPP:
-        if (process.env.WA_BRIDGE_URL && process.env.WA_BRIDGE_SECRET) {
+        if (waBridgeConfig()) {
           // Baileys wa-bridge delivery: plain text, no Meta template needed.
           messageBody = `${senderName} invited you to Flash! Join using this link: ${inviteLink}`
         } else {

--- a/src/services/notifications/invite.ts
+++ b/src/services/notifications/invite.ts
@@ -61,14 +61,19 @@ export const sendInviteNotification = async ({
         break
 
       case InviteMethod.WHATSAPP:
-        // For WhatsApp templates (if using approved templates)
-        messageBody = JSON.stringify({
-          templateName: "flash_invite",
-          templateVariables: {
-            "1": senderName,
-            "2": token,
-          },
-        })
+        if (process.env.WA_BRIDGE_URL && process.env.WA_BRIDGE_SECRET) {
+          // Baileys wa-bridge delivery: plain text, no Meta template needed.
+          messageBody = `${senderName} invited you to Flash! Join using this link: ${inviteLink}`
+        } else {
+          // Twilio path: approved WhatsApp template.
+          messageBody = JSON.stringify({
+            templateName: "flash_invite",
+            templateVariables: {
+              "1": senderName,
+              "2": token,
+            },
+          })
+        }
         break
 
       case InviteMethod.SMS:

--- a/test/flash/unit/services/notification/wa-bridge.spec.ts
+++ b/test/flash/unit/services/notification/wa-bridge.spec.ts
@@ -1,0 +1,81 @@
+import { notificationService, NotificationMethod } from "@services/notification"
+
+// The Twilio client is intentionally unconfigured in this suite (no TWILIO_*
+// env), so the non-bridge path deterministically fails — which lets us assert
+// the bridge path is what succeeded.
+
+describe("wa-bridge WhatsApp delivery", () => {
+  const realFetch = global.fetch
+  let fetchMock: jest.Mock
+
+  beforeEach(() => {
+    fetchMock = jest.fn()
+    global.fetch = fetchMock as unknown as typeof fetch
+    process.env.WA_BRIDGE_URL = "http://bridge.local:3850/send"
+    process.env.WA_BRIDGE_SECRET = "sekrit"
+  })
+
+  afterEach(() => {
+    global.fetch = realFetch
+    delete process.env.WA_BRIDGE_URL
+    delete process.env.WA_BRIDGE_SECRET
+  })
+
+  const okResponse = (body: unknown, status = 200) =>
+    ({ ok: status >= 200 && status < 300, status, json: async () => body }) as Response
+
+  it("sends via the bridge with the auth header and {to, text} body", async () => {
+    fetchMock.mockResolvedValue(okResponse({ ok: true, id: "MSGID" }))
+
+    const result = await notificationService.sendNotification(
+      NotificationMethod.WHATSAPP,
+      "+18765550123",
+      "hello from flash",
+    )
+
+    expect(result).toBe(true)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe("http://bridge.local:3850/send")
+    expect(init.method).toBe("POST")
+    expect(init.headers["X-Send-Token"]).toBe("sekrit")
+    expect(JSON.parse(init.body)).toEqual({
+      to: "+18765550123",
+      text: "hello from flash",
+    })
+  })
+
+  it("returns false when the bridge responds without ok:true", async () => {
+    fetchMock.mockResolvedValue(okResponse({ error: "unauthorized" }, 401))
+    const result = await notificationService.sendNotification(
+      NotificationMethod.WHATSAPP,
+      "+18765550123",
+      "hello",
+    )
+    expect(result).toBe(false)
+  })
+
+  it("returns false when the bridge call throws (network)", async () => {
+    fetchMock.mockRejectedValue(new Error("ECONNREFUSED"))
+    const result = await notificationService.sendNotification(
+      NotificationMethod.WHATSAPP,
+      "+18765550123",
+      "hello",
+    )
+    expect(result).toBe(false)
+  })
+
+  it("falls back to the Twilio path (and does not call the bridge) when unconfigured", async () => {
+    delete process.env.WA_BRIDGE_URL
+    delete process.env.WA_BRIDGE_SECRET
+    const result = await notificationService.sendNotification(
+      NotificationMethod.WHATSAPP,
+      "+18765550123",
+      "hello",
+    )
+    // No Twilio client in this suite -> the fallback path fails, proving the
+    // bridge really is the only reason the configured case succeeds.
+    expect(result).toBe(false)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})

--- a/test/flash/unit/services/notification/wa-bridge.spec.ts
+++ b/test/flash/unit/services/notification/wa-bridge.spec.ts
@@ -1,4 +1,8 @@
-import { notificationService, NotificationMethod } from "@services/notification"
+import {
+  notificationService,
+  NotificationMethod,
+  waBridgeConfig,
+} from "@services/notification"
 
 // The Twilio client is intentionally unconfigured in this suite (no TWILIO_*
 // env), so the non-bridge path deterministically fails — which lets us assert
@@ -77,5 +81,36 @@ describe("wa-bridge WhatsApp delivery", () => {
     // bridge really is the only reason the configured case succeeds.
     expect(result).toBe(false)
     expect(fetchMock).not.toHaveBeenCalled()
+  })
+})
+
+// waBridgeConfig is the single gate both the transport and the invite body
+// selection read, so it can never let the two disagree.
+describe("waBridgeConfig", () => {
+  afterEach(() => {
+    delete process.env.WA_BRIDGE_URL
+    delete process.env.WA_BRIDGE_SECRET
+  })
+
+  it("returns url + secret when both are set", () => {
+    process.env.WA_BRIDGE_URL = "http://bridge.local:3850/send"
+    process.env.WA_BRIDGE_SECRET = "sekrit"
+    expect(waBridgeConfig()).toEqual({
+      url: "http://bridge.local:3850/send",
+      secret: "sekrit",
+    })
+  })
+
+  it("returns null when neither is set", () => {
+    expect(waBridgeConfig()).toBeNull()
+  })
+
+  it("returns null (never partially enables) when only one var is set", () => {
+    process.env.WA_BRIDGE_URL = "http://bridge.local:3850/send"
+    expect(waBridgeConfig()).toBeNull() // secret missing -> not enabled
+
+    delete process.env.WA_BRIDGE_URL
+    process.env.WA_BRIDGE_SECRET = "sekrit"
+    expect(waBridgeConfig()).toBeNull() // url missing -> not enabled
   })
 })

--- a/test/flash/unit/services/notifications/invite-body.spec.ts
+++ b/test/flash/unit/services/notifications/invite-body.spec.ts
@@ -1,0 +1,58 @@
+import { InviteMethod } from "@domain/invite"
+
+const mockSendNotification = jest.fn()
+jest.mock("@services/notification", () => ({
+  NotificationMethod: { EMAIL: "EMAIL", SMS: "SMS", WHATSAPP: "WHATSAPP" },
+  notificationService: {
+    sendNotification: (...a: unknown[]) => mockSendNotification(...a),
+  },
+}))
+
+import { sendInviteNotification } from "@services/notifications/invite"
+
+const TOKEN = "a".repeat(40)
+
+describe("sendInviteNotification WHATSAPP body selection", () => {
+  beforeEach(() => {
+    mockSendNotification.mockReset()
+    mockSendNotification.mockResolvedValue(true)
+  })
+
+  afterEach(() => {
+    delete process.env.WA_BRIDGE_URL
+    delete process.env.WA_BRIDGE_SECRET
+  })
+
+  it("uses plain text with the invite link when the wa-bridge is configured", async () => {
+    process.env.WA_BRIDGE_URL = "http://bridge.local:3850/send"
+    process.env.WA_BRIDGE_SECRET = "sekrit"
+
+    const ok = await sendInviteNotification({
+      method: InviteMethod.WHATSAPP,
+      contact: "+18765550123",
+      token: TOKEN,
+      senderName: "dreadlocks",
+    })
+
+    expect(ok).toBe(true)
+    const body = mockSendNotification.mock.calls[0][2] as string
+    expect(body).toContain("dreadlocks invited you to Flash!")
+    expect(body).toContain(`token=${TOKEN}`)
+    expect(() => JSON.parse(body)).toThrow() // plain text, not a template blob
+  })
+
+  it("uses the Twilio template blob when the bridge is not configured", async () => {
+    const ok = await sendInviteNotification({
+      method: InviteMethod.WHATSAPP,
+      contact: "+18765550123",
+      token: TOKEN,
+      senderName: "dreadlocks",
+    })
+
+    expect(ok).toBe(true)
+    const body = mockSendNotification.mock.calls[0][2] as string
+    const parsed = JSON.parse(body)
+    expect(parsed.templateName).toBe("flash_invite")
+    expect(parsed.templateVariables["2"]).toBe(TOKEN)
+  })
+})

--- a/test/flash/unit/services/notifications/invite-body.spec.ts
+++ b/test/flash/unit/services/notifications/invite-body.spec.ts
@@ -6,6 +6,13 @@ jest.mock("@services/notification", () => ({
   notificationService: {
     sendNotification: (...a: unknown[]) => mockSendNotification(...a),
   },
+  // Mirror the real gate (env-driven) so this suite drives the body selection
+  // via WA_BRIDGE_* exactly as the transport does — one gate, one behavior.
+  waBridgeConfig: () => {
+    const url = process.env.WA_BRIDGE_URL
+    const secret = process.env.WA_BRIDGE_SECRET
+    return url && secret ? { url, secret } : null
+  },
 }))
 
 import { sendInviteNotification } from "@services/notifications/invite"


### PR DESCRIPTION
Env-switched WhatsApp delivery provider: when `WA_BRIDGE_URL` + `WA_BRIDGE_SECRET` are set, invite WhatsApp messages go through the flash-support-infra wa-bridge's authed `POST /send` (Baileys, plain text + invite link — no Meta template needed); otherwise the existing Twilio template path is unchanged.

**Why:** no environment has a Twilio WhatsApp sender provisioned (`TWILIO_WHATSAPP_FROM` unset in TEST *and* PROD — only the Verify service is wired), so WhatsApp invite delivery has never worked. The bridge endpoint is deployed on pulse-server and smoke-tested (authed, timing-safe compare, 401 negative-controls, content never logged).

**Scope:** TEST/dev delivery now. Prod should provision the official Twilio WhatsApp sender + approved template before launch, or deliberately opt into the bridge.

Tests: 6 new (transport auth/payload/error/fallback + body selection). Suite green; tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C7z7o9J18BWbUnYJcemMtg