### PR TITLE
feat(graphql): expose referralRewardEnabled on Globals

### DIFF
--- a/dev/apollo-federation/supergraph.graphql
+++ b/dev/apollo-federation/supergraph.graphql
@@ -1105,6 +1105,14 @@ type Globals
   """
   nodesIds: [String!]!
 
+  """
+  Whether referral-reward entry points (e.g. the "invite a
+  friend" home-screen card) should be shown to the user. Controlled by the
+  instance-wide referralReward feature flag; when false the referral payout is
+  disabled, so reward-promising UI must stay hidden.
+  """
+  referralRewardEnabled: Boolean!
+
   """A list of countries and their supported auth channels"""
   supportedCountries: [Country!]!
 

--- a/src/graphql/public/root/query/globals.ts
+++ b/src/graphql/public/root/query/globals.ts
@@ -7,6 +7,7 @@ import {
   getGaloyBuildInformation,
   getLightningAddressDomain,
   getLightningAddressDomainAliases,
+  getReferralRewardConfig,
 } from "@config"
 
 import { getSupportedCountries } from "@app/authentication/get-supported-countries"
@@ -39,6 +40,7 @@ const GlobalsQuery = GT.Field({
       topupEnabled: Topup.Enabled,
       cashoutEnabled: Cashout.Enabled,
       bridgeEnabled: BridgeConfig.enabled,
+      referralRewardEnabled: getReferralRewardConfig().enabled,
     }
   },
 })

--- a/src/graphql/public/schema.graphql
+++ b/src/graphql/public/schema.graphql
@@ -884,6 +884,14 @@ type Globals {
   """
   nodesIds: [String!]!
 
+  """
+  Whether referral-reward entry points (e.g. the "invite a
+  friend" home-screen card) should be shown to the user. Controlled by the
+  instance-wide referralReward feature flag; when false the referral payout is
+  disabled, so reward-promising UI must stay hidden.
+  """
+  referralRewardEnabled: Boolean!
+
   """A list of countries and their supported auth channels"""
   supportedCountries: [Country!]!
 

--- a/src/graphql/public/types/object/globals.ts
+++ b/src/graphql/public/types/object/globals.ts
@@ -52,6 +52,13 @@ const Globals = GT.Object({
       description: dedent`Whether Bridge (international bank transfer) entry points
         should be shown to the user. Controlled by the instance-wide bridge feature flag.`,
     },
+    referralRewardEnabled: {
+      type: GT.NonNull(GT.Boolean),
+      description: dedent`Whether referral-reward entry points (e.g. the "invite a
+        friend" home-screen card) should be shown to the user. Controlled by the
+        instance-wide referralReward feature flag; when false the referral payout is
+        disabled, so reward-promising UI must stay hidden.`,
+    },
   }),
 })
 


### PR DESCRIPTION
## What
Adds a public `Globals.referralRewardEnabled` boolean, resolved from `getReferralRewardConfig().enabled` — the **same** config flag that already gates the referral payout (`src/app/invite/award-referral-reward.ts`). Mirrors the existing `topupEnabled`/`cashoutEnabled`/`bridgeEnabled` pattern on `Globals`.

## Why
The flash-mobile invite feature (#679) shows a home-screen QuickStart card that promises *"Get rewards for inviting friends to Flash."* Rewards are default-disabled and dark in prod, so that card is a false promise while off. Surfacing this flag lets the client show the reward-promising UI **only when referral rewards are actually enabled** — one source of truth, no drift between the promise and the payout. (Chosen over a Firebase Remote Config flag precisely to avoid a second source of truth.)

## Behavior
- TEST has `referralReward.enabled=true` → field returns true → mobile card shows.
- Prod has it `false` → field returns false → mobile card stays hidden until rewards are activated.

## ⚠️ Deploy ordering (important)
This must be **deployed to an environment before the flash-mobile query that selects it ships to that env.** Apollo validates the whole `globals` selection server-side, so an unknown field errors the *entire* `globals` query (breaking every flag read); a client `?? false` fallback only covers null, not an unknown field. Sequence: merge + deploy this → confirm the field resolves on TEST → then merge the flash-mobile filter (#679 follow-up).

## Tests
No bespoke resolver test — this is a config passthrough identical to the three sibling flags (topup/cashout/bridge), which are covered by the checked-in public SDL snapshot (`check:sdl`) rather than a unit test. The regenerated `schema.graphql` + `supergraph.graphql` are included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)