### PR TITLE
fix(cashout): enforce caller wallet ownership on cashout mutations

### DIFF
--- a/src/app/offers/CashoutManager.ts
+++ b/src/app/offers/CashoutManager.ts
@@ -28,11 +28,15 @@ const CashoutManager = {
     walletId: WalletId,
     userPayment: USDAmount,
     bankAccountId: string,
+    accountId: AccountId,
   ): Promise<PersistedOffer | Error> => {
     const bankOwnerUsdWalletId = await getBankOwnerIbexAccount()
 
     const wallet = await WalletsRepository().findById(walletId)
     if (wallet instanceof RepositoryError) return new ValidationError(wallet)
+    // Object-level authz: never trust a client-supplied walletId on its own.
+    if (wallet.accountId !== accountId)
+      return new ValidationError("Wallet does not belong to account")
     const account = await AccountsRepository().findById(wallet.accountId)
     if (account instanceof RepositoryError) return new ValidationError(account)
     if (!account.erpParty) return new Error("Could not find erpParty for account")
@@ -113,16 +117,20 @@ const CashoutManager = {
   executeCashout: async (
     id: OfferId,
     walletId: WalletId,
+    accountId: AccountId,
   ): Promise<InitiatedCashout | Error> => {
     const offer = await Storage.get(id)
     if (offer instanceof Error) return offer
 
-    // walletId authenticates the caller at the wallet level; the offer's settlement wallet
-    // may differ from it (e.g. a USDT cash wallet post-cutover while an older client still
-    // presents the legacy USD walletId). Authorize when both belong to the same account.
+    // Object-level authorization: the presented wallet must belong to the
+    // authenticated caller; the offer's settlement wallet may differ from it
+    // (e.g. a USDT cash wallet post-cutover while an older client still
+    // presents the legacy USD walletId). Both must sit on the caller's account.
     const providedWallet = await WalletsRepository().findById(walletId)
     if (providedWallet instanceof RepositoryError)
       return new ValidationError(providedWallet)
+    if (providedWallet.accountId !== accountId)
+      return new ValidationError("Wallet does not belong to account")
     const settlementWallet = await WalletsRepository().findById(
       offer.details.payment.userAcct,
     )

--- a/src/graphql/public/root/mutation/offers/initiate-cash-out.ts
+++ b/src/graphql/public/root/mutation/offers/initiate-cash-out.ts
@@ -43,8 +43,9 @@ const InitiateCashoutMutation = GT.Field({
   extensions: {
     complexity: 60,
   },
-  resolve: async (_, args) => {
+  resolve: async (_, args, { domainAccount }: GraphQLPublicContextAuth) => {
     if (!Cashout.Enabled) return new NotImplementedError("Cashout feature is not enabled")
+    if (!domainAccount) throw new Error("Authentication required")
 
     const { offerId, walletId } = args.input
     // Parse for input errors
@@ -52,7 +53,7 @@ const InitiateCashoutMutation = GT.Field({
       if (f instanceof Error) return { errors: [{ message: f.message, success: false }] }
     }
 
-    const offer = await CashoutManager.executeCashout(offerId, walletId)
+    const offer = await CashoutManager.executeCashout(offerId, walletId, domainAccount.id)
     if (offer instanceof Error) {
       recordExceptionInCurrentSpan({
         error: offer,

--- a/src/graphql/public/root/mutation/offers/request-cash-out.ts
+++ b/src/graphql/public/root/mutation/offers/request-cash-out.ts
@@ -49,8 +49,9 @@ const RequestCashoutMutation = GT.Field({
   extensions: {
     complexity: 120,
   },
-  resolve: async (_, args) => {
+  resolve: async (_, args, { domainAccount }: GraphQLPublicContextAuth) => {
     if (!Cashout.Enabled) return new NotImplementedError("Cashout feature is not enabled")
+    if (!domainAccount) throw new Error("Authentication required")
 
     const { walletId, amount, bankAccountId } = args.input
     for (const input of [walletId, amount, bankAccountId]) {
@@ -59,7 +60,12 @@ const RequestCashoutMutation = GT.Field({
       }
     }
 
-    const offer = await CashoutManager.createOffer(walletId, amount, bankAccountId)
+    const offer = await CashoutManager.createOffer(
+      walletId,
+      amount,
+      bankAccountId,
+      domainAccount.id,
+    )
     if (offer instanceof Error) return { errors: mapToGqlErrorList(offer) }
 
     return {

--- a/test/flash/integration/offers/execute-offer.spec.ts
+++ b/test/flash/integration/offers/execute-offer.spec.ts
@@ -91,11 +91,11 @@ afterEach(async () => {
 
 describe("Offers", () => {
   it("successfully makes and executes an offer", async () => {
-    const offer = await CashoutManager.createOffer(alice.usdWalletD.id, send, "")
+    const offer = await CashoutManager.createOffer(alice.usdWalletD.id, send, "", alice.account.id)
     if (offer instanceof Error) throw offer
 
     const { id } = offer
-    const status = await CashoutManager.executeCashout(id, alice.usdWalletD.id)
+    const status = await CashoutManager.executeCashout(id, alice.usdWalletD.id, alice.account.id)
 
     // make assertions against ledger
     expect(status).toBeDefined()

--- a/test/flash/integration/offers/execute-offer.spec.ts
+++ b/test/flash/integration/offers/execute-offer.spec.ts
@@ -91,11 +91,20 @@ afterEach(async () => {
 
 describe("Offers", () => {
   it("successfully makes and executes an offer", async () => {
-    const offer = await CashoutManager.createOffer(alice.usdWalletD.id, send, "", alice.account.id)
+    const offer = await CashoutManager.createOffer(
+      alice.usdWalletD.id,
+      send,
+      "",
+      alice.account.id,
+    )
     if (offer instanceof Error) throw offer
 
     const { id } = offer
-    const status = await CashoutManager.executeCashout(id, alice.usdWalletD.id, alice.account.id)
+    const status = await CashoutManager.executeCashout(
+      id,
+      alice.usdWalletD.id,
+      alice.account.id,
+    )
 
     // make assertions against ledger
     expect(status).toBeDefined()

--- a/test/flash/integration/offers/make-cashout-offer.spec.ts
+++ b/test/flash/integration/offers/make-cashout-offer.spec.ts
@@ -85,7 +85,7 @@ afterEach(async () => {
 
 describe("Offers", () => {
   it("successfully makes and persists an offer using default config", async () => {
-    const offer = await CashoutManager.createOffer(alice.usdWalletD.id, send, "")
+    const offer = await CashoutManager.createOffer(alice.usdWalletD.id, send, "", alice.account.id)
 
     if (offer instanceof Error) throw offer
     expect(offer.details.payment.amount.currencyCode).toMatch(/^USD/)

--- a/test/flash/integration/offers/make-cashout-offer.spec.ts
+++ b/test/flash/integration/offers/make-cashout-offer.spec.ts
@@ -85,7 +85,12 @@ afterEach(async () => {
 
 describe("Offers", () => {
   it("successfully makes and persists an offer using default config", async () => {
-    const offer = await CashoutManager.createOffer(alice.usdWalletD.id, send, "", alice.account.id)
+    const offer = await CashoutManager.createOffer(
+      alice.usdWalletD.id,
+      send,
+      "",
+      alice.account.id,
+    )
 
     if (offer instanceof Error) throw offer
     expect(offer.details.payment.amount.currencyCode).toMatch(/^USD/)

--- a/test/flash/unit/app/offers/cashout-manager-authz.spec.ts
+++ b/test/flash/unit/app/offers/cashout-manager-authz.spec.ts
@@ -1,0 +1,201 @@
+const mockStorageGet = jest.fn()
+const mockStorageAdd = jest.fn()
+const mockFindWalletById = jest.fn()
+const mockFindAccountById = jest.fn()
+const mockValidOfferFrom = jest.fn()
+const mockResolveSelection = jest.fn()
+const mockAddInvoice = jest.fn()
+const mockGetBankOwner = jest.fn()
+const mockGetBankAccounts = jest.fn()
+
+jest.mock("@services/alerts/ops-events", () => ({
+  notifyOpsEvent: jest.fn(),
+  toDisplayAmount: jest.requireActual("@services/alerts/ops-events").toDisplayAmount,
+}))
+
+jest.mock("@config", () => ({
+  Cashout: {
+    OfferConfig: { fee: 100n as BasisPoints, duration: 3600 as Seconds },
+    SkipPayment: false,
+  },
+  ExchangeRates: {},
+}))
+
+jest.mock("@app/cash-wallet-cutover/cashout-routing", () => ({
+  resolveCashoutWalletSelection: (...args: unknown[]) => mockResolveSelection(...args),
+}))
+
+jest.mock("@services/ibex/client", () => ({
+  __esModule: true,
+  default: { addInvoice: (...args: unknown[]) => mockAddInvoice(...args) },
+}))
+
+jest.mock("@services/ledger/caching", () => ({
+  getBankOwnerIbexAccount: () => mockGetBankOwner(),
+}))
+
+jest.mock("@services/email", () => ({
+  EmailService: { sendCashoutInitiatedEmail: jest.fn() },
+}))
+
+jest.mock("@services/frappe/ErpNext", () => ({
+  __esModule: true,
+  default: {
+    getBankAccountsByCustomer: (...args: unknown[]) => mockGetBankAccounts(...args),
+  },
+}))
+
+jest.mock("@services/mongoose", () => ({
+  AccountsRepository: jest.fn(() => ({
+    findById: (...args: unknown[]) => mockFindAccountById(...args),
+  })),
+  WalletsRepository: jest.fn(() => ({
+    findById: (...args: unknown[]) => mockFindWalletById(...args),
+  })),
+}))
+
+jest.mock("@app/offers/storage/Redis", () => ({
+  __esModule: true,
+  default: {
+    get: (...args: unknown[]) => mockStorageGet(...args),
+    add: (...args: unknown[]) => mockStorageAdd(...args),
+  },
+}))
+
+jest.mock("@app/offers/ValidOffer", () => ({
+  __esModule: true,
+  default: { from: (...args: unknown[]) => mockValidOfferFrom(...args) },
+}))
+
+jest.mock("@domain/bitcoin/lightning", () => {
+  const actual = jest.requireActual("@domain/bitcoin/lightning")
+  return {
+    ...actual,
+    decodeInvoice: jest.fn(() => ({
+      destination: "0".repeat(66) as Pubkey,
+      paymentHash:
+        "8862fa7f4dcea0533952783bda143ff7fb7242a9573ac74f1ff944a601f02319" as PaymentHash,
+      paymentRequest: "lnbc1test" as EncodedPaymentRequest,
+      milliSatsAmount: 0 as MilliSatoshis,
+      description: "",
+      cltvDelta: null,
+      amount: null,
+      paymentAmount: null,
+      routeHints: [],
+      paymentSecret: null,
+      features: [],
+      expiresAt: new Date(Date.now() + 600_000),
+      isExpired: false,
+    })),
+  }
+})
+
+import CashoutManager from "@app/offers/CashoutManager"
+import { USDAmount, ValidationError } from "@domain/shared"
+
+const offerId = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" as OfferId
+const walletId = "11111111-1111-4111-8111-111111111111" as WalletId
+const flashWalletId = "22222222-2222-4222-8222-222222222222" as WalletId
+const callerAccountId = "64df1a2b3c4d5e6f78901234" as AccountId
+const otherAccountId = "75ef2b3c4d5e6f78901234aa" as AccountId
+
+const amount = USDAmount.cents("50000")
+if (amount instanceof Error) throw amount
+
+describe("CashoutManager authorization", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetBankOwner.mockResolvedValue(flashWalletId)
+    mockFindWalletById.mockResolvedValue({ id: walletId, accountId: callerAccountId })
+    mockFindAccountById.mockResolvedValue({ id: callerAccountId, erpParty: "party-1" })
+    mockResolveSelection.mockResolvedValue({
+      route: "usd",
+      userWalletId: walletId,
+      flashWalletId,
+    })
+    mockAddInvoice.mockResolvedValue({ invoice: { bolt11: "lnbc1test" } })
+    mockGetBankAccounts.mockResolvedValue([{ name: "bank-1", currency: "USD" }])
+    mockValidOfferFrom.mockResolvedValue({
+      details: {},
+      execute: jest.fn().mockResolvedValue({ erpSubmitted: true, cashoutId: "c-1" }),
+    })
+    mockStorageGet.mockResolvedValue({
+      details: {
+        payment: { userAcct: walletId, flashAcct: flashWalletId, amount },
+        payout: { bankAccountId: "bank-1", amount, serviceFee: amount },
+      },
+    })
+    mockStorageAdd.mockResolvedValue({ id: offerId, details: {} })
+  })
+
+  describe("createOffer", () => {
+    it("rejects when the walletId belongs to a different account", async () => {
+      // Given a wallet owned by someone other than the caller
+      mockFindWalletById.mockResolvedValue({ id: walletId, accountId: otherAccountId })
+
+      // When the caller requests an offer against that wallet
+      const result = await CashoutManager.createOffer(
+        walletId,
+        amount,
+        "bank-1",
+        callerAccountId,
+      )
+
+      // Then it is rejected before any money-moving side effect runs
+      expect(result).toBeInstanceOf(ValidationError)
+      expect(mockResolveSelection).not.toHaveBeenCalled()
+      expect(mockAddInvoice).not.toHaveBeenCalled()
+      expect(mockStorageAdd).not.toHaveBeenCalled()
+    })
+
+    it("proceeds when the walletId belongs to the caller", async () => {
+      // Given the default fixtures (wallet owned by callerAccountId)
+
+      // When the caller requests an offer against their own wallet
+      const result = await CashoutManager.createOffer(
+        walletId,
+        amount,
+        "bank-1",
+        callerAccountId,
+      )
+
+      // Then the offer is created
+      expect(result).not.toBeInstanceOf(Error)
+      if (result instanceof Error) throw result
+      expect(result.id).toEqual(offerId)
+    })
+  })
+
+  describe("executeCashout", () => {
+    it("rejects when the provided walletId belongs to a different account", async () => {
+      // Given a caller presenting a wallet owned by someone else
+      mockFindWalletById.mockResolvedValue({ id: walletId, accountId: otherAccountId })
+
+      // When the caller executes an offer with that wallet
+      const result = await CashoutManager.executeCashout(
+        offerId,
+        walletId,
+        callerAccountId,
+      )
+
+      // Then it is rejected before validation/execution runs
+      expect(result).toBeInstanceOf(ValidationError)
+      expect(mockValidOfferFrom).not.toHaveBeenCalled()
+    })
+
+    it("proceeds when the provided walletId belongs to the caller", async () => {
+      // Given the default fixtures (provided + settlement wallet both caller-owned)
+
+      // When the caller executes their offer
+      const result = await CashoutManager.executeCashout(
+        offerId,
+        walletId,
+        callerAccountId,
+      )
+
+      // Then execution proceeds
+      expect(result).not.toBeInstanceOf(Error)
+      expect(mockValidOfferFrom).toHaveBeenCalled()
+    })
+  })
+})

--- a/test/flash/unit/app/offers/ops-events-cashout-manager.spec.ts
+++ b/test/flash/unit/app/offers/ops-events-cashout-manager.spec.ts
@@ -85,7 +85,7 @@ describe("ops events — CashoutManager.executeCashout", () => {
       })),
     })
 
-    const result = await CashoutManager.executeCashout(offerId, walletId)
+    const result = await CashoutManager.executeCashout(offerId, walletId, accountId)
 
     expect(result).not.toBeInstanceOf(Error)
     expect(EmailService.sendCashoutInitiatedEmail).toHaveBeenCalled()
@@ -123,7 +123,7 @@ describe("ops events — CashoutManager.executeCashout", () => {
       })),
     })
 
-    const result = await CashoutManager.executeCashout(offerId, walletId)
+    const result = await CashoutManager.executeCashout(offerId, walletId, accountId)
 
     // caller-visible result is unchanged; the terminal failed event was
     // already emitted by ValidOffer.execute
@@ -138,7 +138,7 @@ describe("ops events — CashoutManager.executeCashout", () => {
   it("notifies a terminal failed event when offer validation fails", async () => {
     mockValidOfferFrom.mockResolvedValue(new Error("offer no longer valid"))
 
-    const result = await CashoutManager.executeCashout(offerId, walletId)
+    const result = await CashoutManager.executeCashout(offerId, walletId, accountId)
 
     expect(result).toBeInstanceOf(Error)
     expect(notifyOpsEvent).toHaveBeenCalledTimes(2)
@@ -162,7 +162,7 @@ describe("ops events — CashoutManager.executeCashout", () => {
       execute: jest.fn(async () => new Error("erp down")),
     })
 
-    const result = await CashoutManager.executeCashout(offerId, walletId)
+    const result = await CashoutManager.executeCashout(offerId, walletId, accountId)
 
     expect(result).toBeInstanceOf(Error)
     expect(EmailService.sendCashoutInitiatedEmail).not.toHaveBeenCalled()
@@ -177,7 +177,7 @@ describe("ops events — CashoutManager.executeCashout", () => {
       .mockResolvedValueOnce({ id: walletId, accountId: "other-account" })
       .mockResolvedValueOnce({ id: walletId, accountId })
 
-    const result = await CashoutManager.executeCashout(offerId, walletId)
+    const result = await CashoutManager.executeCashout(offerId, walletId, accountId)
 
     expect(result).toBeInstanceOf(Error)
     expect(notifyOpsEvent).not.toHaveBeenCalled()


### PR DESCRIPTION
## Summary
- **Security fix (IDOR / missing object-level authz):** `requestCashOut` and `initiateCashOut` enforced only "any valid session" — the resolvers never read `domainAccount`, so any authenticated user could create and execute cashout offers against **any** `walletId`, forcing liquidation of another account's USD/USDT balance. Payout stayed bound to the victim's own ERPNext bank accounts (`verifyBankAccount`), so this was unauthorized liquidation / griefing rather than direct theft — but fully unauthorized either way.
- Ownership is now enforced at the shared seam: `CashoutManager.createOffer` / `executeCashout` require the caller's `accountId` and reject foreign wallets **before any Ibex/ERPNext side effect**. Both resolvers pass `domainAccount.id`, matching the existing `lnurl-payment-send` pattern; the prior provided-vs-settlement wallet check remains as defense in depth.
- New unit spec `cashout-manager-authz.spec.ts` proves the cross-account rejection on both entry points (written red-first) and that legitimate flows still proceed. Existing offers suites updated to the new signatures.

## Test plan
- `npx jest --config ./test/flash/unit/jest.config.js offers` — 16/16 pass (4 suites)
- `tsc --noEmit -p tsconfig.d.json && tsc --noEmit` — clean
- `npx eslint` on changed files — clean
- Integration specs (`test/flash/integration/offers/*`) updated to the new signatures; require the docker dev stack to run