### PR TITLE
fix(lightning): terminal EXPIRED for purged invoices in lnInvoicePaymentStatus

### DIFF
--- a/src/app/lightning/payment-status-checker.ts
+++ b/src/app/lightning/payment-status-checker.ts
@@ -3,6 +3,12 @@ import Ibex from "@services/ibex/client"
 import { IbexError } from "@services/ibex/errors"
 import { baseLogger } from "@services/logger"
 
+// Invoice states: https://docs.ibexmercado.com/reference/flow#invoice-states-table
+const IBEX_INVOICE_STATE_SETTLED = 1
+const HTTP_NOT_FOUND = 404
+
+export type InvoicePaymentStatus = "PAID" | "PENDING" | "EXPIRED"
+
 export const PaymentStatusChecker = async (uncheckedPaymentRequest: string) => {
   const decodedInvoice = decodeInvoice(uncheckedPaymentRequest)
   if (decodedInvoice instanceof Error) return decodedInvoice
@@ -12,12 +18,22 @@ export const PaymentStatusChecker = async (uncheckedPaymentRequest: string) => {
     paymentHash,
     expiresAt,
     isExpired,
-    // invoiceIsPaid should have no awareness of Ibex. TODO: add to Wallets interface
-    invoiceIsPaid: async (): Promise<boolean | IbexError> => {
+    // status should have no awareness of Ibex. TODO: add to Wallets interface
+    status: async (): Promise<InvoicePaymentStatus | IbexError> => {
       const ibexResp = await Ibex.invoiceFromHash(paymentHash)
-      if (ibexResp instanceof IbexError) return ibexResp
+      if (ibexResp instanceof IbexError) {
+        // IBEX purges invoices some time after they expire. A 404 for an
+        // invoice that is already past its own expiry is therefore a
+        // terminal EXPIRED, not a server error — without this, clients
+        // polling an old invoice never receive a terminal status and
+        // retry forever (observed as 15+ days of 1/min from-hash 404s
+        // at IBEX's edge).
+        if (ibexResp.httpCode === HTTP_NOT_FOUND && isExpired) return "EXPIRED"
+        return ibexResp
+      }
       baseLogger.info(ibexResp.status)
-      return ibexResp.state?.id === 1 // Invoice states: https://docs.ibexmercado.com/reference/flow#invoice-states-table
+      if (ibexResp.state?.id === IBEX_INVOICE_STATE_SETTLED) return "PAID"
+      return isExpired ? "EXPIRED" : "PENDING"
     },
   }
 }

--- a/src/graphql/public/root/query/ln-invoice-payment-status.ts
+++ b/src/graphql/public/root/query/ln-invoice-payment-status.ts
@@ -17,12 +17,9 @@ const LnInvoicePaymentStatusQuery = GT.Field({
     const paymentStatusChecker = await Lightning.PaymentStatusChecker(paymentRequest)
     if (paymentStatusChecker instanceof Error) throw mapError(paymentStatusChecker)
 
-    const paid = await paymentStatusChecker.invoiceIsPaid()
-    if (paid instanceof Error) throw mapError(paid)
+    const status = await paymentStatusChecker.status()
+    if (status instanceof Error) throw mapError(status)
 
-    if (paid) return { errors: [], status: "PAID" }
-
-    const status = paymentStatusChecker.isExpired ? "EXPIRED" : "PENDING"
     return { errors: [], status }
   },
 })

--- a/src/graphql/public/root/subscription/ln-invoice-payment-status.ts
+++ b/src/graphql/public/root/subscription/ln-invoice-payment-status.ts
@@ -74,24 +74,19 @@ const LnInvoicePaymentStatusSubscription = {
       event: PubSubDefaultTriggers.LnPaymentStatus,
       suffix: paymentStatusChecker.paymentHash,
     })
-    const paid = await paymentStatusChecker.invoiceIsPaid()
+    const status = await paymentStatusChecker.status()
 
-    if (paid instanceof Error) {
+    if (status instanceof Error) {
       pubsub.publishDelayed({
         trigger,
-        payload: { errors: [mapAndParseErrorForGqlResponse(paid)] },
+        payload: { errors: [mapAndParseErrorForGqlResponse(status)] },
       })
-    }
-
-    if (paid) {
-      pubsub.publishDelayed({ trigger, payload: { status: "PAID" } })
       return pubsub.createAsyncIterator({ trigger })
     }
 
-    const status = paymentStatusChecker.isExpired ? "EXPIRED" : "PENDING"
     pubsub.publishDelayed({ trigger, payload: { status } })
 
-    if (!paymentStatusChecker.isExpired) {
+    if (status === "PENDING") {
       const timeout = Math.max(paymentStatusChecker.expiresAt.getTime() - Date.now(), 0)
       setTimeout(() => {
         pubsub.publish({ trigger, payload: { status: "EXPIRED" } })

--- a/test/flash/unit/app/lightning/payment-status-checker.spec.ts
+++ b/test/flash/unit/app/lightning/payment-status-checker.spec.ts
@@ -31,7 +31,9 @@ const PAYMENT_HASH = "b568463e07106d12fe406b2a1069bdc67ee4a6e67b4227934e8a7bed4d
 const PAYMENT_REQUEST = "lnbc1fakerequest"
 
 const ibexErrorWithHttpCode = (httpCode: number): IbexError =>
-  new IbexError(new ApiError(Object.assign(new Error(`http ${httpCode}`), { status: httpCode })))
+  new IbexError(
+    new ApiError(Object.assign(new Error(`http ${httpCode}`), { status: httpCode })),
+  )
 
 const decodedInvoice = ({ isExpired }: { isExpired: boolean }) => ({
   paymentHash: PAYMENT_HASH,

--- a/test/flash/unit/app/lightning/payment-status-checker.spec.ts
+++ b/test/flash/unit/app/lightning/payment-status-checker.spec.ts
@@ -1,0 +1,121 @@
+jest.mock("@services/ibex/client", () => ({
+  __esModule: true,
+  default: { invoiceFromHash: jest.fn() },
+}))
+jest.mock("@services/logger", () => {
+  const logger = {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+    child: jest.fn(() => logger),
+  }
+  return { baseLogger: logger }
+})
+jest.mock("@domain/bitcoin/lightning", () => ({
+  ...jest.requireActual("@domain/bitcoin/lightning"),
+  decodeInvoice: jest.fn(),
+}))
+
+import { ApiError } from "ibex-client"
+
+import { PaymentStatusChecker } from "@app/lightning/payment-status-checker"
+import { IbexError } from "@services/ibex/errors"
+
+const mockInvoiceFromHash = jest.requireMock("@services/ibex/client").default
+  .invoiceFromHash as jest.Mock
+const mockDecodeInvoice = jest.requireMock("@domain/bitcoin/lightning")
+  .decodeInvoice as jest.Mock
+
+const PAYMENT_HASH = "b568463e07106d12fe406b2a1069bdc67ee4a6e67b4227934e8a7bed4d6e853b"
+const PAYMENT_REQUEST = "lnbc1fakerequest"
+
+const ibexErrorWithHttpCode = (httpCode: number): IbexError =>
+  new IbexError(new ApiError(Object.assign(new Error(`http ${httpCode}`), { status: httpCode })))
+
+const decodedInvoice = ({ isExpired }: { isExpired: boolean }) => ({
+  paymentHash: PAYMENT_HASH,
+  expiresAt: new Date(Date.now() + (isExpired ? -1 : +1) * 60 * 60 * 1000),
+  isExpired,
+})
+
+const checkerWith = async ({ isExpired }: { isExpired: boolean }) => {
+  mockDecodeInvoice.mockReturnValue(decodedInvoice({ isExpired }))
+  const checker = await PaymentStatusChecker(PAYMENT_REQUEST)
+  if (checker instanceof Error) throw checker
+  return checker
+}
+
+beforeEach(() => {
+  mockInvoiceFromHash.mockReset()
+  mockDecodeInvoice.mockReset()
+})
+
+describe("PaymentStatusChecker", () => {
+  it("returns the decode error for an invalid payment request", async () => {
+    const decodeError = new Error("invalid invoice")
+    mockDecodeInvoice.mockReturnValue(decodeError)
+    const checker = await PaymentStatusChecker("not-an-invoice")
+    expect(checker).toBe(decodeError)
+  })
+
+  it("queries IBEX by the decoded payment hash", async () => {
+    const checker = await checkerWith({ isExpired: false })
+    mockInvoiceFromHash.mockResolvedValue({ state: { id: 1 } })
+    await checker.status()
+    expect(mockInvoiceFromHash).toHaveBeenCalledWith(PAYMENT_HASH)
+  })
+
+  describe("status", () => {
+    it("returns PAID when IBEX reports the invoice settled", async () => {
+      const checker = await checkerWith({ isExpired: false })
+      mockInvoiceFromHash.mockResolvedValue({ state: { id: 1, name: "SETTLED" } })
+      expect(await checker.status()).toBe("PAID")
+    })
+
+    it("returns PAID for a settled invoice even after its expiry has passed", async () => {
+      const checker = await checkerWith({ isExpired: true })
+      mockInvoiceFromHash.mockResolvedValue({ state: { id: 1, name: "SETTLED" } })
+      expect(await checker.status()).toBe("PAID")
+    })
+
+    it("returns PENDING for an unsettled, unexpired invoice", async () => {
+      const checker = await checkerWith({ isExpired: false })
+      mockInvoiceFromHash.mockResolvedValue({ state: { id: 0, name: "OPEN" } })
+      expect(await checker.status()).toBe("PENDING")
+    })
+
+    it("returns EXPIRED for an unsettled invoice past its expiry", async () => {
+      const checker = await checkerWith({ isExpired: true })
+      mockInvoiceFromHash.mockResolvedValue({ state: { id: 2, name: "EXPIRED" } })
+      expect(await checker.status()).toBe("EXPIRED")
+    })
+
+    it("returns EXPIRED when IBEX 404s an invoice past its expiry (purged invoice)", async () => {
+      const checker = await checkerWith({ isExpired: true })
+      mockInvoiceFromHash.mockResolvedValue(ibexErrorWithHttpCode(404))
+      expect(await checker.status()).toBe("EXPIRED")
+    })
+
+    it("returns the error when IBEX 404s an invoice that has not expired", async () => {
+      const checker = await checkerWith({ isExpired: false })
+      const err = ibexErrorWithHttpCode(404)
+      mockInvoiceFromHash.mockResolvedValue(err)
+      expect(await checker.status()).toBe(err)
+    })
+
+    it("returns the error for a non-404 IBEX failure even when expired", async () => {
+      const checker = await checkerWith({ isExpired: true })
+      const err = ibexErrorWithHttpCode(500)
+      mockInvoiceFromHash.mockResolvedValue(err)
+      expect(await checker.status()).toBe(err)
+    })
+
+    it("returns the error for an IBEX failure without an http code even when expired", async () => {
+      const checker = await checkerWith({ isExpired: true })
+      const err = new IbexError(new Error("connection reset"))
+      mockInvoiceFromHash.mockResolvedValue(err)
+      expect(await checker.status()).toBe(err)
+    })
+  })
+})

--- a/test/flash/unit/graphql/ln-invoice-payment-status.spec.ts
+++ b/test/flash/unit/graphql/ln-invoice-payment-status.spec.ts
@@ -1,0 +1,164 @@
+jest.mock("@app", () => ({
+  Lightning: { PaymentStatusChecker: jest.fn() },
+}))
+jest.mock("@services/logger", () => {
+  const logger = {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+    child: jest.fn(() => logger),
+  }
+  return { baseLogger: logger }
+})
+
+jest.mock("@services/pubsub", () => {
+  const service = {
+    publishDelayed: jest.fn(),
+    publish: jest.fn(),
+    createAsyncIterator: jest.fn().mockReturnValue("async-iterator"),
+  }
+  return { PubSubService: () => service, __service: service }
+})
+
+import LnInvoicePaymentStatusQuery from "@graphql/public/root/query/ln-invoice-payment-status"
+import LnInvoicePaymentStatusSubscription from "@graphql/public/root/subscription/ln-invoice-payment-status"
+import { IbexError } from "@services/ibex/errors"
+
+const mockPaymentStatusChecker = jest.requireMock("@app").Lightning
+  .PaymentStatusChecker as jest.Mock
+const pubsubService = jest.requireMock("@services/pubsub").__service
+const mockPublishDelayed = pubsubService.publishDelayed as jest.Mock
+const mockPublish = pubsubService.publish as jest.Mock
+const mockCreateAsyncIterator = pubsubService.createAsyncIterator as jest.Mock
+
+const PAYMENT_REQUEST = "lnbc1fakerequest"
+
+const checker = ({
+  status,
+  isExpired = false,
+  expiresAt = new Date(Date.now() + 60 * 60 * 1000),
+}: {
+  status: string | Error
+  isExpired?: boolean
+  expiresAt?: Date
+}) => ({
+  paymentHash: "a".repeat(64),
+  expiresAt,
+  isExpired,
+  status: jest.fn().mockResolvedValue(status),
+})
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe("lnInvoicePaymentStatus query", () => {
+  const resolve = LnInvoicePaymentStatusQuery.resolve as (
+    parent: unknown,
+    args: { input: { paymentRequest: string | Error } },
+  ) => Promise<{ errors: unknown[]; status: string }>
+
+  it("returns the checker status", async () => {
+    mockPaymentStatusChecker.mockResolvedValue(checker({ status: "PAID" }))
+    const result = await resolve(undefined, { input: { paymentRequest: PAYMENT_REQUEST } })
+    expect(result).toEqual({ errors: [], status: "PAID" })
+  })
+
+  it("returns EXPIRED for a purged, expired invoice instead of throwing", async () => {
+    mockPaymentStatusChecker.mockResolvedValue(
+      checker({ status: "EXPIRED", isExpired: true }),
+    )
+    const result = await resolve(undefined, { input: { paymentRequest: PAYMENT_REQUEST } })
+    expect(result).toEqual({ errors: [], status: "EXPIRED" })
+  })
+
+  it("throws a mapped error when the status check fails", async () => {
+    mockPaymentStatusChecker.mockResolvedValue(
+      checker({ status: new IbexError(new Error("boom")) }),
+    )
+    await expect(
+      resolve(undefined, { input: { paymentRequest: PAYMENT_REQUEST } }),
+    ).rejects.toThrow()
+  })
+
+  it("throws when the payment request does not decode", async () => {
+    mockPaymentStatusChecker.mockResolvedValue(new Error("invalid invoice"))
+    await expect(
+      resolve(undefined, { input: { paymentRequest: PAYMENT_REQUEST } }),
+    ).rejects.toThrow()
+  })
+})
+
+describe("lnInvoicePaymentStatus subscription", () => {
+  const subscribe = LnInvoicePaymentStatusSubscription.subscribe as (
+    source: unknown,
+    args: { input: { paymentRequest: string | Error } },
+  ) => Promise<unknown>
+
+  it("publishes the terminal EXPIRED status for a purged, expired invoice", async () => {
+    mockPaymentStatusChecker.mockResolvedValue(
+      checker({ status: "EXPIRED", isExpired: true }),
+    )
+    const iterator = await subscribe(undefined, {
+      input: { paymentRequest: PAYMENT_REQUEST },
+    })
+    expect(iterator).toBe("async-iterator")
+    expect(mockPublishDelayed).toHaveBeenCalledWith(
+      expect.objectContaining({ payload: { status: "EXPIRED" } }),
+    )
+  })
+
+  it("publishes only the error payload when the status check fails (no PAID)", async () => {
+    mockPaymentStatusChecker.mockResolvedValue(
+      checker({ status: new IbexError(new Error("boom")) }),
+    )
+    await subscribe(undefined, { input: { paymentRequest: PAYMENT_REQUEST } })
+    expect(mockPublishDelayed).toHaveBeenCalledTimes(1)
+    const payload = mockPublishDelayed.mock.calls[0][0].payload
+    expect(payload.errors).toBeDefined()
+    expect(payload.status).toBeUndefined()
+  })
+
+  it("publishes PAID when the invoice is settled", async () => {
+    mockPaymentStatusChecker.mockResolvedValue(checker({ status: "PAID" }))
+    await subscribe(undefined, { input: { paymentRequest: PAYMENT_REQUEST } })
+    expect(mockPublishDelayed).toHaveBeenCalledWith(
+      expect.objectContaining({ payload: { status: "PAID" } }),
+    )
+  })
+
+  it("publishes PENDING and arms the expiry timer for a live invoice", async () => {
+    jest.useFakeTimers()
+    try {
+      const expiresAt = new Date(Date.now() + 5_000)
+      mockPaymentStatusChecker.mockResolvedValue(
+        checker({ status: "PENDING", expiresAt }),
+      )
+      await subscribe(undefined, { input: { paymentRequest: PAYMENT_REQUEST } })
+      expect(mockPublishDelayed).toHaveBeenCalledWith(
+        expect.objectContaining({ payload: { status: "PENDING" } }),
+      )
+      jest.advanceTimersByTime(7_000)
+      expect(mockPublish).toHaveBeenCalledWith(
+        expect.objectContaining({ payload: { status: "EXPIRED" } }),
+      )
+    } finally {
+      jest.useRealTimers()
+    }
+  })
+
+  it("does not arm an expiry timer for a terminal EXPIRED status", async () => {
+    jest.useFakeTimers()
+    try {
+      mockPaymentStatusChecker.mockResolvedValue(
+        checker({ status: "EXPIRED", isExpired: true }),
+      )
+      await subscribe(undefined, { input: { paymentRequest: PAYMENT_REQUEST } })
+      jest.advanceTimersByTime(60 * 60 * 1000)
+      expect(mockPublish).not.toHaveBeenCalled()
+    } finally {
+      jest.useRealTimers()
+    }
+  })
+})

--- a/test/flash/unit/graphql/ln-invoice-payment-status.spec.ts
+++ b/test/flash/unit/graphql/ln-invoice-payment-status.spec.ts
@@ -30,7 +30,6 @@ const mockPaymentStatusChecker = jest.requireMock("@app").Lightning
 const pubsubService = jest.requireMock("@services/pubsub").__service
 const mockPublishDelayed = pubsubService.publishDelayed as jest.Mock
 const mockPublish = pubsubService.publish as jest.Mock
-const mockCreateAsyncIterator = pubsubService.createAsyncIterator as jest.Mock
 
 const PAYMENT_REQUEST = "lnbc1fakerequest"
 
@@ -61,7 +60,9 @@ describe("lnInvoicePaymentStatus query", () => {
 
   it("returns the checker status", async () => {
     mockPaymentStatusChecker.mockResolvedValue(checker({ status: "PAID" }))
-    const result = await resolve(undefined, { input: { paymentRequest: PAYMENT_REQUEST } })
+    const result = await resolve(undefined, {
+      input: { paymentRequest: PAYMENT_REQUEST },
+    })
     expect(result).toEqual({ errors: [], status: "PAID" })
   })
 
@@ -69,7 +70,9 @@ describe("lnInvoicePaymentStatus query", () => {
     mockPaymentStatusChecker.mockResolvedValue(
       checker({ status: "EXPIRED", isExpired: true }),
     )
-    const result = await resolve(undefined, { input: { paymentRequest: PAYMENT_REQUEST } })
+    const result = await resolve(undefined, {
+      input: { paymentRequest: PAYMENT_REQUEST },
+    })
     expect(result).toEqual({ errors: [], status: "EXPIRED" })
   })
 


### PR DESCRIPTION
## Why

IBEX reported (2026-08-07) that we were calling `GET /invoice/from-hash/b568463e…` **every minute, 404ing, for 15+ days**, with a firewall-block warning.

Root cause chain:

1. Flash Forge (the Cashu mint) uses Flash's GraphQL API as its USD Lightning backend and had ~501 stuck `PENDING` melt quotes from an April dev/test burst. Its hourly-loop checker polls `lnInvoicePaymentStatus` for the first pending quote every minute.
2. `lnInvoicePaymentStatus` resolves invoice status by calling IBEX `invoice/from-hash`. **IBEX purges invoices some time after they expire** (~1 week retention observed), so the lookup 404s forever.
3. The resolver treated that 404 as a server error and threw — so no client polling an old invoice ever receives a terminal status, and well-behaved pollers retry indefinitely. The mint is just the loudest instance of the class.

The immediate spam was stopped operationally on 2026-08-07 (~20:35 UTC) by freezing the mint's 501 stale `PENDING` melt quotes to `UNPAID` (proofs left pending — no money-state change, reversible, backup taken on the forge box at `/root/backups/melt_freeze_20260807.sql`). This PR fixes the class.

## What

- `PaymentStatusChecker`: replaced `invoiceIsPaid()` (boolean) with `status()` (`PAID | PENDING | EXPIRED`), which maps an IBEX **404 on an invoice already past its own expiry** to terminal `EXPIRED`. Everything else is unchanged: non-404 IBEX errors, errors without an http code, and 404s on *unexpired* invoices still surface as errors; a settled invoice still reports `PAID` after expiry for as long as IBEX retains it.
- Query + subscription resolvers use `status()` directly.
- **Latent subscription bug fixed en passant**: on an IBEX error, `paid` held a truthy `Error` object, so the subscription published the error payload *and then* `{status: PAID}`. Subscribers of unresolvable invoices were being told PAID.

## ⚠️ Deploy sequencing note

Flash Forge's `FlashWallet` backend maps `EXPIRED → PaymentResult.FAILED`. If this had deployed while the mint still had those 501 quotes `PENDING`, the mint would have rolled back proofs for melts that may have actually paid (double-pay exposure). That hazard is already removed — the quotes were frozen to `UNPAID` first and the mint's checker verifiably skips them — but keep the ordering in mind if any pending melt quotes are ever un-frozen: **reconcile the mint's melt quotes against IBEX truth before or together with running a mint that re-checks them.**

## Tests

- `test/flash/unit/app/lightning/payment-status-checker.spec.ts` — full matrix: settled (fresh + past expiry) → PAID; unsettled fresh → PENDING; unsettled expired → EXPIRED; **404 + expired → EXPIRED**; 404 + fresh → error; 500 + expired → error; no-http-code error → error; decode failure.
- `test/flash/unit/graphql/ln-invoice-payment-status.spec.ts` — query returns status / throws on real errors; subscription publishes terminal EXPIRED, publishes *only* the error payload on failure (regression test for the truthy-Error PAID bug), arms the expiry timer only for PENDING.
- Full unit suite: 161 suites, 1355 passed.

## Related findings (not in this PR)

- Account `transactions` pagination is unusable: `CURSOR_REGEX` requires a 24-hex ObjectId but IBEX-era `endCursor` is a UUID, so any `after` is rejected.
- `InitiationViaLn.paymentHash` is returned as an empty string for IBEX transactions.
- Forge-side (mint repo): `FlashWallet._invoice_payment_status` crashes on GraphQL error responses (`data: null` → `NoneType.get`), and melt (outgoing) status is checked via the *invoice* endpoint, which can never resolve for non-Flash destinations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GK5Lgo77sQyWoJqMsuk3tC