### PR TITLE
feat(invite): referral push notifications — accepted, inviter reward, invitee reward

### DIFF
--- a/src/app/invite/award-referral-reward.ts
+++ b/src/app/invite/award-referral-reward.ts
@@ -10,6 +10,8 @@ import { InviteRepository } from "@services/mongoose/models/invite"
 import { nextReferralRewardSeq } from "@services/mongoose/models/referral-reward-counter"
 import { baseLogger } from "@services/logger"
 
+import { sendReferralRewardNotificationBestEffort } from "./send-referral-notifications"
+
 const REWARDS_ROLE = "rewards"
 
 type PartyPayResult = "paid" | "pending" | "failed"
@@ -208,6 +210,23 @@ export const awardReferralRewardOnKycApproval = async ({
           `inviteeWallet=${Boolean(inviteeWalletId)}`
       }
       await markReward(invite._id, update)
+
+      // Per-leg reward pushes, only for confirmed-paid legs (a "pending" IBEX
+      // leg would be premature; ops reconciles those first). Fire-and-forget.
+      if (inviterResult === "paid") {
+        sendReferralRewardNotificationBestEffort({
+          accountId: inviterAccountId,
+          leg: "inviter",
+          amountCents,
+        })
+      }
+      if (inviteeResult === "paid") {
+        sendReferralRewardNotificationBestEffort({
+          accountId,
+          leg: "invitee",
+          amountCents,
+        })
+      }
 
       if (rewardStatus === "paid") {
         baseLogger.info(

--- a/src/app/invite/send-referral-notifications.ts
+++ b/src/app/invite/send-referral-notifications.ts
@@ -1,0 +1,146 @@
+import { getI18nInstance } from "@config"
+import { checkedToAccountId } from "@domain/accounts"
+import { getLanguageOrDefault } from "@domain/locale"
+import {
+  DeviceTokensNotRegisteredNotificationsServiceError,
+  FlashNotificationCategories,
+  NotificationsServiceError,
+} from "@domain/notifications"
+import { removeDeviceTokens } from "@app/users/remove-device-tokens"
+import { baseLogger } from "@services/logger"
+import { AccountsRepository } from "@services/mongoose/accounts"
+import { UsersRepository } from "@services/mongoose/users"
+import {
+  PushNotificationsService,
+  SendFilteredPushNotificationStatus,
+} from "@services/notifications/push-notifications"
+
+const i18n = getI18nInstance()
+
+// Referral-flow push notifications (the invite slice of ENG-531):
+//  - inviter: their invite was accepted (redeem transition)
+//  - inviter: their referral-reward leg paid
+//  - invitee: their welcome-reward leg paid
+// All senders follow the bridge-KYC pattern: resolve account -> user ->
+// deviceTokens, localized phrases, best-effort wrappers that can never throw
+// into the calling money/redeem path.
+
+type ReferralNotificationKind = "accepted" | "inviterReward" | "inviteeReward"
+
+const formatAmount = (amountCents: number): string => (amountCents / 100).toFixed(2)
+
+const sendReferralNotification = async ({
+  accountId: accountIdRaw,
+  kind,
+  amountCents,
+  inviteeName,
+}: {
+  accountId: string
+  kind: ReferralNotificationKind
+  amountCents?: number
+  inviteeName?: string
+}): Promise<true | ApplicationError> => {
+  const accountId = checkedToAccountId(accountIdRaw)
+  if (accountId instanceof Error) return accountId
+
+  const account = await AccountsRepository().findById(accountId)
+  if (account instanceof Error) return account
+
+  const user = await UsersRepository().findById(account.kratosUserId)
+  if (user instanceof Error) return user
+
+  const locale = getLanguageOrDefault(user.language)
+  const phraseBase = `notification.referral.${kind}`
+
+  const title = i18n.__({ phrase: `${phraseBase}.title`, locale })
+  const bodyPhrase =
+    kind === "accepted" && !inviteeName
+      ? `${phraseBase}.bodyNoName`
+      : `${phraseBase}.body`
+  const body = i18n.__(
+    { phrase: bodyPhrase, locale },
+    {
+      name: inviteeName ?? "",
+      amount: amountCents !== undefined ? formatAmount(amountCents) : "",
+    },
+  )
+
+  const result = await PushNotificationsService().sendFilteredNotification({
+    deviceTokens: user.deviceTokens,
+    title,
+    body,
+    notificationCategory: FlashNotificationCategories.Payments,
+    notificationSettings: account.notificationSettings,
+    data: {
+      type: `referral_${kind}`,
+      ...(amountCents !== undefined ? { amountCents: String(amountCents) } : {}),
+    },
+  })
+
+  if (result instanceof NotificationsServiceError) return result
+
+  if (result.status === SendFilteredPushNotificationStatus.Filtered) {
+    return true
+  }
+
+  return true
+}
+
+const bestEffort = async (
+  args: Parameters<typeof sendReferralNotification>[0],
+): Promise<void> => {
+  try {
+    const result = await sendReferralNotification(args)
+
+    if (result instanceof DeviceTokensNotRegisteredNotificationsServiceError) {
+      const accountId = checkedToAccountId(args.accountId)
+      if (accountId instanceof Error) return
+
+      const account = await AccountsRepository().findById(accountId)
+      if (account instanceof Error) return
+
+      await removeDeviceTokens({
+        userId: account.kratosUserId,
+        deviceTokens: result.tokens,
+      })
+      return
+    }
+
+    if (result instanceof Error) {
+      baseLogger.warn(
+        { accountId: args.accountId, kind: args.kind, error: result },
+        "Failed to send referral push notification",
+      )
+    }
+  } catch (err) {
+    // Never let a push failure disturb the redeem or payout path.
+    baseLogger.warn(
+      { accountId: args.accountId, kind: args.kind, err },
+      "Unexpected error sending referral push notification",
+    )
+  }
+}
+
+export const sendInviteAcceptedNotificationBestEffort = async ({
+  inviterAccountId,
+  inviteeName,
+}: {
+  inviterAccountId: string
+  inviteeName?: string
+}): Promise<void> =>
+  bestEffort({ accountId: inviterAccountId, kind: "accepted", inviteeName })
+
+export const sendReferralRewardNotificationBestEffort = async ({
+  accountId,
+  leg,
+  amountCents,
+}: {
+  accountId: string
+  leg: "inviter" | "invitee"
+  amountCents: number
+}): Promise<void> =>
+  bestEffort({
+    accountId,
+    kind: leg === "inviter" ? "inviterReward" : "inviteeReward",
+    amountCents,
+  })

--- a/src/config/locales/en.json
+++ b/src/config/locales/en.json
@@ -105,6 +105,21 @@
         "bodyWithReason": "Your identity verification was not approved: {{reason}}.",
         "title": "Verification unsuccessful"
       }
+    },
+    "referral": {
+      "accepted": {
+        "title": "Your invite was accepted 🎉",
+        "body": "{{name}} just joined Flash from your invite.",
+        "bodyNoName": "Someone just joined Flash from your invite."
+      },
+      "inviterReward": {
+        "title": "Referral reward earned",
+        "body": "US${{amount}} was credited to your wallet for inviting a friend."
+      },
+      "inviteeReward": {
+        "title": "Welcome reward received",
+        "body": "US${{amount}} was credited to your wallet for joining through an invite."
+      }
     }
   }
 }

--- a/src/config/locales/es.json
+++ b/src/config/locales/es.json
@@ -101,6 +101,21 @@
         "bodyWithReason": "Su verificación de identidad no fue aprobada: {{reason}}.",
         "title": "Verificación no exitosa"
       }
+    },
+    "referral": {
+      "accepted": {
+        "title": "Tu invitación fue aceptada 🎉",
+        "body": "{{name}} acaba de unirse a Flash con tu invitación.",
+        "bodyNoName": "Alguien acaba de unirse a Flash con tu invitación."
+      },
+      "inviterReward": {
+        "title": "Recompensa por referido",
+        "body": "Se acreditaron US${{amount}} a tu billetera por invitar a un amigo."
+      },
+      "inviteeReward": {
+        "title": "Recompensa de bienvenida",
+        "body": "Se acreditaron US${{amount}} a tu billetera por unirte con una invitación."
+      }
     }
   }
 }

--- a/src/graphql/public/root/mutation/redeem-invite.ts
+++ b/src/graphql/public/root/mutation/redeem-invite.ts
@@ -5,6 +5,7 @@ import { hashToken } from "@utils"
 import { baseLogger } from "@services/logger"
 import mongoose from "mongoose"
 import { AccountsRepository, UsersRepository } from "@services/mongoose"
+import { sendInviteAcceptedNotificationBestEffort } from "@app/invite/send-referral-notifications"
 
 const RedeemInviteInput = GT.Input({
   name: "RedeemInviteInput",
@@ -198,6 +199,13 @@ const RedeemInviteMutation = GT.Field<null, GraphQLPublicContextAuth>({
         },
         "Invite successfully redeemed by new user",
       )
+
+      // Tell the inviter their invite landed. Fire-and-forget: a push failure
+      // must never affect the redemption result.
+      sendInviteAcceptedNotificationBestEffort({
+        inviterAccountId: invite.inviterId.toString(),
+        inviteeName: domainAccount.username || undefined,
+      })
 
       // The referral reward is NOT paid here: payout is deferred until the
       // invitee's Bridge KYC is approved (awardReferralRewardOnKycApproval,

--- a/test/flash/unit/app/invite/award-referral-reward.spec.ts
+++ b/test/flash/unit/app/invite/award-referral-reward.spec.ts
@@ -289,6 +289,8 @@ describe("awardReferralRewardOnKycApproval", () => {
     expect(set.rewardedAt).toBeUndefined()
     expect(set.rewardError).toContain("inviter=pending")
     expect(set.rewardError).toContain("invitee=pending")
+    // The headline rule: pending (unconfirmed) legs never notify.
+    expect(mockRewardPush).not.toHaveBeenCalled()
   })
 
   it("records 'pending' when one party is paid and the other IBEX-pending", async () => {
@@ -300,6 +302,9 @@ describe("awardReferralRewardOnKycApproval", () => {
     expect(set.rewardStatus).toBe("pending")
     expect(set.inviterRewardedAt).toBeInstanceOf(Date)
     expect(set.inviteeRewardedAt).toBeInstanceOf(Date)
+    // Only the confirmed-paid leg notifies; the pending leg stays silent.
+    const pushedLegs = mockRewardPush.mock.calls.map((c) => c[0].leg)
+    expect(pushedLegs).toEqual(["inviter"])
   })
 
   it("records 'partial' when one party is IBEX-pending and the other fails", async () => {

--- a/test/flash/unit/app/invite/award-referral-reward.spec.ts
+++ b/test/flash/unit/app/invite/award-referral-reward.spec.ts
@@ -43,6 +43,11 @@ jest.mock("@app/payments/send-intraledger", () => ({
   intraledgerPaymentSendWalletIdForUsdWallet: (...a: unknown[]) => mockPay(...a),
 }))
 
+const mockRewardPush = jest.fn()
+jest.mock("@app/invite/send-referral-notifications", () => ({
+  sendReferralRewardNotificationBestEffort: (...a: unknown[]) => mockRewardPush(...a),
+}))
+
 jest.mock("@services/logger", () => ({
   baseLogger: { info: jest.fn(), error: jest.fn(), warn: jest.fn() },
 }))
@@ -164,6 +169,13 @@ describe("awardReferralRewardOnKycApproval", () => {
 
     const set = lastSet()
     expect(set.rewardStatus).toBe("paid")
+    // Both legs paid -> both parties get a reward push.
+    expect(mockRewardPush).toHaveBeenCalledWith(
+      expect.objectContaining({ leg: "inviter", amountCents: 500 }),
+    )
+    expect(mockRewardPush).toHaveBeenCalledWith(
+      expect.objectContaining({ leg: "invitee", amountCents: 500 }),
+    )
     expect(set.rewardSeq).toBe(50)
     expect(set.rewardAmountCents).toBe(500)
     expect(set.rewardedAt).toBeInstanceOf(Date)
@@ -239,6 +251,9 @@ describe("awardReferralRewardOnKycApproval", () => {
     )
     const set = lastSet()
     expect(set.rewardStatus).toBe("partial")
+    // Only the successfully-paid leg gets a push; the failed leg gets none.
+    const pushedLegs = mockRewardPush.mock.calls.map((c) => c[0].leg)
+    expect(pushedLegs).not.toContain("inviter")
     expect(set.inviteeRewardedAt).toBeInstanceOf(Date)
     expect(set.inviterRewardedAt).toBeUndefined()
     expect(set.rewardError).toContain("inviter=failed")

--- a/test/flash/unit/app/invite/send-referral-notifications.spec.ts
+++ b/test/flash/unit/app/invite/send-referral-notifications.spec.ts
@@ -1,0 +1,159 @@
+const mockI18n = jest.fn()
+jest.mock("@config", () => ({
+  ...jest.requireActual("@config"),
+  getI18nInstance: () => ({ __: (...a: unknown[]) => mockI18n(...a) }),
+}))
+
+const mockAccountFindById = jest.fn()
+jest.mock("@services/mongoose/accounts", () => ({
+  AccountsRepository: () => ({
+    findById: (...a: unknown[]) => mockAccountFindById(...a),
+  }),
+}))
+
+const mockUserFindById = jest.fn()
+jest.mock("@services/mongoose/users", () => ({
+  UsersRepository: () => ({ findById: (...a: unknown[]) => mockUserFindById(...a) }),
+}))
+
+const mockSendFiltered = jest.fn()
+jest.mock("@services/notifications/push-notifications", () => {
+  const actual = jest.requireActual("@services/notifications/push-notifications")
+  return {
+    SendFilteredPushNotificationStatus: actual.SendFilteredPushNotificationStatus,
+    PushNotificationsService: () => ({
+      sendFilteredNotification: (...a: unknown[]) => mockSendFiltered(...a),
+    }),
+  }
+})
+
+const mockRemoveTokens = jest.fn()
+jest.mock("@app/users/remove-device-tokens", () => ({
+  removeDeviceTokens: (...a: unknown[]) => mockRemoveTokens(...a),
+}))
+
+jest.mock("@services/logger", () => {
+  const stub: Record<string, unknown> = {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  }
+  stub.child = () => stub
+  return { baseLogger: stub }
+})
+
+import {
+  sendInviteAcceptedNotificationBestEffort,
+  sendReferralRewardNotificationBestEffort,
+} from "@app/invite/send-referral-notifications"
+import { DeviceTokensNotRegisteredNotificationsServiceError } from "@domain/notifications"
+import { SendFilteredPushNotificationStatus } from "@services/notifications/push-notifications"
+
+const ACCOUNT = "507f1f77bcf86cd799439011"
+const TOKENS = ["tok-1", "tok-2"]
+
+describe("referral push notifications", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockAccountFindById.mockResolvedValue({
+      id: ACCOUNT,
+      kratosUserId: "kratos-1",
+      notificationSettings: undefined,
+    })
+    mockUserFindById.mockResolvedValue({
+      id: "kratos-1",
+      language: "",
+      deviceTokens: TOKENS,
+    })
+    mockI18n.mockImplementation((arg: { phrase: string }) => arg.phrase)
+    mockSendFiltered.mockResolvedValue({
+      status: SendFilteredPushNotificationStatus.Sent,
+    })
+  })
+
+  it("sends the inviter-reward push with a formatted dollar amount", async () => {
+    await sendReferralRewardNotificationBestEffort({
+      accountId: ACCOUNT,
+      leg: "inviter",
+      amountCents: 500,
+    })
+
+    expect(mockI18n).toHaveBeenCalledWith(
+      expect.objectContaining({ phrase: "notification.referral.inviterReward.title" }),
+    )
+    expect(mockI18n).toHaveBeenCalledWith(
+      expect.objectContaining({ phrase: "notification.referral.inviterReward.body" }),
+      expect.objectContaining({ amount: "5.00" }),
+    )
+    expect(mockSendFiltered).toHaveBeenCalledWith(
+      expect.objectContaining({
+        deviceTokens: TOKENS,
+        data: expect.objectContaining({
+          type: "referral_inviterReward",
+          amountCents: "500",
+        }),
+      }),
+    )
+  })
+
+  it("sends the invitee-reward push under the invitee phrase set", async () => {
+    await sendReferralRewardNotificationBestEffort({
+      accountId: ACCOUNT,
+      leg: "invitee",
+      amountCents: 250,
+    })
+    expect(mockI18n).toHaveBeenCalledWith(
+      expect.objectContaining({ phrase: "notification.referral.inviteeReward.body" }),
+      expect.objectContaining({ amount: "2.50" }),
+    )
+  })
+
+  it("uses the named body when the invitee has a username", async () => {
+    await sendInviteAcceptedNotificationBestEffort({
+      inviterAccountId: ACCOUNT,
+      inviteeName: "bob",
+    })
+    expect(mockI18n).toHaveBeenCalledWith(
+      expect.objectContaining({ phrase: "notification.referral.accepted.body" }),
+      expect.objectContaining({ name: "bob" }),
+    )
+  })
+
+  it("falls back to the no-name body when the invitee has no username", async () => {
+    await sendInviteAcceptedNotificationBestEffort({ inviterAccountId: ACCOUNT })
+    expect(mockI18n).toHaveBeenCalledWith(
+      expect.objectContaining({ phrase: "notification.referral.accepted.bodyNoName" }),
+      expect.anything(),
+    )
+  })
+
+  it("prunes dead device tokens", async () => {
+    mockSendFiltered.mockResolvedValue(
+      new DeviceTokensNotRegisteredNotificationsServiceError(["dead-1" as DeviceToken]),
+    )
+    await sendInviteAcceptedNotificationBestEffort({ inviterAccountId: ACCOUNT })
+    expect(mockRemoveTokens).toHaveBeenCalledWith(
+      expect.objectContaining({ deviceTokens: ["dead-1"] }),
+    )
+  })
+
+  it("never throws into the caller — push-service explosion is swallowed", async () => {
+    mockSendFiltered.mockRejectedValue(new Error("fcm down"))
+    await expect(
+      sendReferralRewardNotificationBestEffort({
+        accountId: ACCOUNT,
+        leg: "invitee",
+        amountCents: 500,
+      }),
+    ).resolves.toBeUndefined()
+  })
+
+  it("never throws when the account lookup fails", async () => {
+    mockAccountFindById.mockResolvedValue(new Error("mongo down"))
+    await expect(
+      sendInviteAcceptedNotificationBestEffort({ inviterAccountId: ACCOUNT }),
+    ).resolves.toBeUndefined()
+    expect(mockSendFiltered).not.toHaveBeenCalled()
+  })
+})

--- a/test/flash/unit/graphql/public/root/mutation/redeem-invite.spec.ts
+++ b/test/flash/unit/graphql/public/root/mutation/redeem-invite.spec.ts
@@ -25,6 +25,11 @@ jest.mock("@services/logger", () => ({
   baseLogger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
 }))
 
+const mockAcceptedPush = jest.fn()
+jest.mock("@app/invite/send-referral-notifications", () => ({
+  sendInviteAcceptedNotificationBestEffort: (...a: unknown[]) => mockAcceptedPush(...a),
+}))
+
 import RedeemInviteMutation from "@graphql/public/root/mutation/redeem-invite"
 import { InviteStatus } from "@services/mongoose/models/invite"
 
@@ -198,6 +203,10 @@ describe("redeemInvite resolver", () => {
     const result = await resolveRedeem()
 
     expect(result).toEqual({ success: true, errors: [] })
+    // The inviter gets an "invite accepted" push, fire-and-forget.
+    expect(mockAcceptedPush).toHaveBeenCalledWith(
+      expect.objectContaining({ inviterAccountId: INVITER_ACCOUNT }),
+    )
     expect(invite.status).toBe(InviteStatus.ACCEPTED)
     expect(invite.redeemedAt).toBeInstanceOf(Date)
     expect(

--- a/test/flash/unit/services/bridge/webhook-server/kyc.spec.ts
+++ b/test/flash/unit/services/bridge/webhook-server/kyc.spec.ts
@@ -6,9 +6,16 @@ jest.mock("@services/lock", () => ({
   LockService: jest.fn(),
 }))
 
-jest.mock("@services/logger", () => ({
-  baseLogger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
-}))
+jest.mock("@services/logger", () => {
+  const stub: Record<string, unknown> = {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  }
+  stub.child = () => stub
+  return { baseLogger: stub }
+})
 
 jest.mock("@services/bridge", () => ({
   __esModule: true,


### PR DESCRIPTION
## What
The invite slice of **ENG-531** (event notifications): three pushes across the referral flow, queued since the feature launch plan.

| Recipient | Trigger | Copy |
|---|---|---|
| Inviter | invite redeemed (ACCEPTED transition, redeem resolver) | *"Your invite was accepted 🎉 — {name} just joined Flash from your invite"* (no-name fallback) |
| Inviter | their reward leg confirmed **paid** (award-referral-reward) | *"Referral reward earned — US$X credited to your wallet"* |
| Invitee | their reward leg confirmed **paid** | *"Welcome reward received — US$X credited to your wallet"* |

## Design
- **Best-effort throughout** — the senders can never throw into the redeem or payout paths (outer try/catch + logged warns; fire-and-forget call sites).
- **Pending IBEX legs do NOT notify** — money unconfirmed, ops reconciles first; only `paid` legs push.
- Mirrors the bridge-KYC push module exactly: account → user → deviceTokens, localized phrases (`notification.referral.*` added to **en + es**), dead-token pruning via `removeDeviceTokens`, Payments category, typed `data` payload (`referral_accepted` / `referral_inviterReward` / `referral_inviteeReward`) for client-side routing.

## Tests
7 new module tests (phrase selection, $ formatting, dead-token pruning, never-throws ×2) + wiring assertions: award spec (both legs push on paid; failed leg never), redeem spec (accepted push fires with the inviter's id). Full unit suite **1396 passed**. (kyc.spec's logger stub gained `.child()` — the new import chain reaches the push module's load-time child logger.)

No schema changes, no migrations — deployable on the next train.

🤖 Generated with [Claude Code](https://claude.com/claude-code)