### PR TITLE
fix(cash-wallet): route recipient wallet ids in intraledger send mutations

### DIFF
--- a/src/graphql/public/root/mutation/intraledger-payment-send.ts
+++ b/src/graphql/public/root/mutation/intraledger-payment-send.ts
@@ -7,6 +7,7 @@ import PaymentSendPayload from "@graphql/public/types/payload/payment-send"
 import Memo from "@graphql/shared/types/scalar/memo"
 import SatAmount from "@graphql/shared/types/scalar/sat-amount"
 import WalletId from "@graphql/shared/types/scalar/wallet-id"
+import { notifyOpsEvent } from "@services/alerts/ops-events"
 import dedent from "dedent"
 
 const IntraLedgerPaymentSendInput = GT.Input({
@@ -66,6 +67,17 @@ const IntraLedgerPaymentSendMutation = GT.Field<null, GraphQLPublicContextAuth>(
       client: cashWalletClientCapabilities,
     })
     if (routedRecipientWalletId instanceof Error) {
+      notifyOpsEvent({
+        flow: "transfer",
+        phase: "failed",
+        status: "failed",
+        error: routedRecipientWalletId.constructor.name,
+        meta: {
+          senderWalletId,
+          recipientWalletId: recipientWalletIdChecked,
+          reason: "recipient-routing",
+        },
+      })
       return {
         status: "failed",
         errors: [mapAndParseErrorForGqlResponse(routedRecipientWalletId)],

--- a/src/graphql/public/root/mutation/intraledger-payment-send.ts
+++ b/src/graphql/public/root/mutation/intraledger-payment-send.ts
@@ -88,7 +88,7 @@ const IntraLedgerPaymentSendMutation = GT.Field<null, GraphQLPublicContextAuth>(
       recipientWalletId: routedRecipientWalletId,
       memo,
       amount,
-      senderWalletId: walletId,
+      senderWalletId,
       senderAccount: domainAccount,
       idempotencyKey,
     })

--- a/src/graphql/public/root/mutation/intraledger-payment-send.ts
+++ b/src/graphql/public/root/mutation/intraledger-payment-send.ts
@@ -1,4 +1,5 @@
 import { Accounts, Payments } from "@app"
+import { resolveCashWalletRecipientMutationWalletId } from "@app/cash-wallet-cutover"
 import { checkedToWalletId } from "@domain/wallets"
 import { mapAndParseErrorForGqlResponse } from "@graphql/error-map"
 import { GT } from "@graphql/index"
@@ -34,7 +35,7 @@ const IntraLedgerPaymentSendMutation = GT.Field<null, GraphQLPublicContextAuth>(
   args: {
     input: { type: GT.NonNull(IntraLedgerPaymentSendInput) },
   },
-  resolve: async (_, args, { domainAccount }) => {
+  resolve: async (_, args, { domainAccount, cashWalletClientCapabilities }) => {
     const { walletId, recipientWalletId, amount, memo, idempotencyKey } = args.input
     for (const input of [walletId, recipientWalletId, amount, memo]) {
       if (input instanceof Error) {
@@ -60,8 +61,19 @@ const IntraLedgerPaymentSendMutation = GT.Field<null, GraphQLPublicContextAuth>(
       return { errors: [mapAndParseErrorForGqlResponse(recipientUsername)] }
     }
 
+    const routedRecipientWalletId = await resolveCashWalletRecipientMutationWalletId({
+      recipientWalletId: recipientWalletIdChecked,
+      client: cashWalletClientCapabilities,
+    })
+    if (routedRecipientWalletId instanceof Error) {
+      return {
+        status: "failed",
+        errors: [mapAndParseErrorForGqlResponse(routedRecipientWalletId)],
+      }
+    }
+
     const status = await Payments.intraledgerPaymentSendWalletIdForBtcWallet({
-      recipientWalletId,
+      recipientWalletId: routedRecipientWalletId,
       memo,
       amount,
       senderWalletId: walletId,

--- a/src/graphql/public/root/mutation/intraledger-usd-payment-send.ts
+++ b/src/graphql/public/root/mutation/intraledger-usd-payment-send.ts
@@ -1,5 +1,8 @@
 import { Payments } from "@app"
-import { resolveCashWalletMutationWalletIdForAccount } from "@app/cash-wallet-cutover"
+import {
+  resolveCashWalletMutationWalletIdForAccount,
+  resolveCashWalletRecipientMutationWalletId,
+} from "@app/cash-wallet-cutover"
 import { checkedToWalletId } from "@domain/wallets"
 import { mapAndParseErrorForGqlResponse } from "@graphql/error-map"
 import { GT } from "@graphql/index"
@@ -73,8 +76,19 @@ const IntraLedgerUsdPaymentSendMutation = GT.Field<null, GraphQLPublicContextAut
       }
     }
 
+    const routedRecipientWalletId = await resolveCashWalletRecipientMutationWalletId({
+      recipientWalletId: recipientWalletIdChecked,
+      client: cashWalletClientCapabilities,
+    })
+    if (routedRecipientWalletId instanceof Error) {
+      return {
+        status: "failed",
+        errors: [mapAndParseErrorForGqlResponse(routedRecipientWalletId)],
+      }
+    }
+
     const status = await Payments.intraledgerPaymentSendWalletIdForUsdWallet({
-      recipientWalletId,
+      recipientWalletId: routedRecipientWalletId,
       memo,
       amount,
       senderWalletId: routedSenderWalletId,

--- a/src/graphql/public/root/mutation/intraledger-usd-payment-send.ts
+++ b/src/graphql/public/root/mutation/intraledger-usd-payment-send.ts
@@ -10,6 +10,7 @@ import PaymentSendPayload from "@graphql/public/types/payload/payment-send"
 // import CentAmount from "@graphql/public/types/scalar/cent-amount"
 import Memo from "@graphql/shared/types/scalar/memo"
 import WalletId from "@graphql/shared/types/scalar/wallet-id"
+import { notifyOpsEvent } from "@services/alerts/ops-events"
 import dedent from "dedent"
 import FractionalCentAmount from "@graphql/public/types/scalar/cent-amount-fraction"
 // import { RequestInit, Response } from 'node-fetch'
@@ -28,6 +29,28 @@ const IntraLedgerUsdPaymentSendInput = GT.Input({
     },
   }),
 })
+
+const notifyCashWalletRoutingFailure = ({
+  error,
+  senderWalletId,
+  recipientWalletId,
+  amount,
+  reason,
+}: {
+  error: ApplicationError
+  senderWalletId: string
+  recipientWalletId: string
+  amount: number
+  reason: "sender-routing" | "recipient-routing"
+}): void =>
+  notifyOpsEvent({
+    flow: "transfer",
+    phase: "failed",
+    status: "failed",
+    error: error.constructor.name,
+    amount: { value: (Number(amount) / 100).toFixed(2), currency: "USD" },
+    meta: { senderWalletId, recipientWalletId, reason },
+  })
 
 const IntraLedgerUsdPaymentSendMutation = GT.Field<null, GraphQLPublicContextAuth>({
   extensions: {
@@ -70,6 +93,13 @@ const IntraLedgerUsdPaymentSendMutation = GT.Field<null, GraphQLPublicContextAut
       client: cashWalletClientCapabilities,
     })
     if (routedSenderWalletId instanceof Error) {
+      notifyCashWalletRoutingFailure({
+        error: routedSenderWalletId,
+        senderWalletId,
+        recipientWalletId: recipientWalletIdChecked,
+        amount,
+        reason: "sender-routing",
+      })
       return {
         status: "failed",
         errors: [mapAndParseErrorForGqlResponse(routedSenderWalletId)],
@@ -81,6 +111,13 @@ const IntraLedgerUsdPaymentSendMutation = GT.Field<null, GraphQLPublicContextAut
       client: cashWalletClientCapabilities,
     })
     if (routedRecipientWalletId instanceof Error) {
+      notifyCashWalletRoutingFailure({
+        error: routedRecipientWalletId,
+        senderWalletId: routedSenderWalletId,
+        recipientWalletId: recipientWalletIdChecked,
+        amount,
+        reason: "recipient-routing",
+      })
       return {
         status: "failed",
         errors: [mapAndParseErrorForGqlResponse(routedRecipientWalletId)],

--- a/test/flash/unit/app/cash-wallet-cutover/recipient-routing.spec.ts
+++ b/test/flash/unit/app/cash-wallet-cutover/recipient-routing.spec.ts
@@ -1,3 +1,14 @@
+const mockGetConfig = jest.fn()
+
+jest.mock("@services/mongoose", () => ({
+  AccountsRepository: () => ({ findById: jest.fn() }),
+  WalletsRepository: () => ({ findById: jest.fn(), listByAccountId: jest.fn() }),
+  CashWalletCutoverRepository: () => ({
+    getConfig: (...args: Parameters<typeof mockGetConfig>) => mockGetConfig(...args),
+    findMigrationByAccountId: jest.fn(),
+  }),
+}))
+
 import { resolveCashWalletRecipientMutationWalletId } from "@app/cash-wallet-cutover/recipient-routing"
 import { WalletCurrency } from "@domain/shared"
 import { WalletType } from "@domain/wallets"
@@ -54,5 +65,72 @@ describe("resolveCashWalletRecipientMutationWalletId", () => {
       client,
       walletsRepo,
     })
+  })
+})
+
+// Composition test: the real recipient resolver through the real
+// presentation/routing logic, with only the repos stubbed. This is the
+// production incident scenario — a legacy-capability client submitting a
+// recipient's legacy USD wallet id after the cutover completed.
+describe("resolveCashWalletRecipientMutationWalletId (real routing)", () => {
+  const usdtWalletId = "55555555-5555-4555-8555-555555555555" as WalletId
+  const usdtWallet = {
+    id: usdtWalletId,
+    accountId: recipientAccountId,
+    currency: WalletCurrency.Usdt,
+    type: WalletType.Checking,
+    onChainAddressIdentifiers: [],
+    onChainAddresses: () => [],
+    lnurlp: "lnurlp-recipient-usdt" as Lnurl,
+  } as Wallet
+
+  const legacyClient = {
+    cashWalletPresentation: "legacy_compat",
+    hasUsdtCashWalletSupport: false,
+  } as const
+
+  const accountsRepo = {
+    findById: jest.fn(),
+  }
+  const walletsRepo = {
+    findById: jest.fn(),
+    listByAccountId: jest.fn(),
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetConfig.mockResolvedValue({
+      state: "complete",
+      cutoverVersion: 1,
+      updatedAt: new Date(),
+    })
+    accountsRepo.findById.mockResolvedValue(recipientAccount)
+    walletsRepo.listByAccountId.mockResolvedValue([recipientWallet, usdtWallet])
+  })
+
+  it("resolves a legacy USD recipient id to the USDT settlement wallet post-cutover", async () => {
+    walletsRepo.findById.mockResolvedValue(recipientWallet)
+
+    const result = await resolveCashWalletRecipientMutationWalletId({
+      recipientWalletId,
+      client: legacyClient,
+      walletsRepo,
+      accountsRepo,
+    })
+
+    expect(result).toBe(usdtWalletId)
+  })
+
+  it("passes a recipient id that is already the settlement wallet through unchanged", async () => {
+    walletsRepo.findById.mockResolvedValue(usdtWallet)
+
+    const result = await resolveCashWalletRecipientMutationWalletId({
+      recipientWalletId: usdtWalletId,
+      client: legacyClient,
+      walletsRepo,
+      accountsRepo,
+    })
+
+    expect(result).toBe(usdtWalletId)
   })
 })

--- a/test/flash/unit/graphql/public/root/mutation/intraledger-payment-send.spec.ts
+++ b/test/flash/unit/graphql/public/root/mutation/intraledger-payment-send.spec.ts
@@ -1,0 +1,99 @@
+const mockIntraledgerPaymentSendWalletIdForBtcWallet = jest.fn()
+const mockGetUsernameFromWalletId = jest.fn()
+const mockResolveCashWalletRecipientMutationWalletId = jest.fn()
+
+jest.mock("@app", () => ({
+  Accounts: {
+    getUsernameFromWalletId: (...args: Parameters<typeof mockGetUsernameFromWalletId>) =>
+      mockGetUsernameFromWalletId(...args),
+  },
+  Payments: {
+    intraledgerPaymentSendWalletIdForBtcWallet: (
+      ...args: Parameters<typeof mockIntraledgerPaymentSendWalletIdForBtcWallet>
+    ) => mockIntraledgerPaymentSendWalletIdForBtcWallet(...args),
+  },
+}))
+
+jest.mock("@app/cash-wallet-cutover", () => ({
+  resolveCashWalletRecipientMutationWalletId: (
+    ...args: Parameters<typeof mockResolveCashWalletRecipientMutationWalletId>
+  ) => mockResolveCashWalletRecipientMutationWalletId(...args),
+}))
+
+import { MismatchedCurrencyForWalletError } from "@domain/errors"
+import IntraLedgerPaymentSendMutation from "@graphql/public/root/mutation/intraledger-payment-send"
+
+const senderWalletId = "11111111-1111-4111-8111-111111111111" as WalletId
+const recipientWalletId = "22222222-2222-4222-8222-222222222222" as WalletId
+const routedRecipientWalletId = "44444444-4444-4444-8444-444444444444" as WalletId
+const amount = 2100 as Satoshis
+
+const domainAccount = { id: "sender-account-id" } as Account
+
+const client = {
+  cashWalletPresentation: "legacy_compat",
+  hasUsdtCashWalletSupport: false,
+} as const
+
+const resolve = (input: Record<string, unknown>) =>
+  IntraLedgerPaymentSendMutation.resolve?.(
+    null,
+    { input },
+    { domainAccount, cashWalletClientCapabilities: client } as GraphQLPublicContextAuth,
+    {} as never,
+  )
+
+describe("IntraLedgerPaymentSendMutation", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetUsernameFromWalletId.mockResolvedValue("recipient" as Username)
+    mockResolveCashWalletRecipientMutationWalletId.mockResolvedValue(
+      routedRecipientWalletId,
+    )
+    mockIntraledgerPaymentSendWalletIdForBtcWallet.mockResolvedValue({
+      value: "success",
+    })
+  })
+
+  it("routes the recipient wallet id through cash-wallet recipient routing", async () => {
+    const result = await resolve({
+      walletId: senderWalletId,
+      recipientWalletId,
+      amount,
+      memo: "test memo" as Memo,
+      idempotencyKey: "idem-1",
+    })
+
+    expect(mockResolveCashWalletRecipientMutationWalletId).toHaveBeenCalledWith({
+      recipientWalletId,
+      client,
+    })
+    expect(mockIntraledgerPaymentSendWalletIdForBtcWallet).toHaveBeenCalledWith({
+      recipientWalletId: routedRecipientWalletId,
+      memo: "test memo",
+      amount,
+      senderWalletId,
+      senderAccount: domainAccount,
+      idempotencyKey: "idem-1",
+    })
+    expect(result).toEqual({ errors: [], status: "success" })
+  })
+
+  it("returns failed without paying when recipient routing errors", async () => {
+    mockResolveCashWalletRecipientMutationWalletId.mockResolvedValue(
+      new MismatchedCurrencyForWalletError(),
+    )
+
+    const result = (await resolve({
+      walletId: senderWalletId,
+      recipientWalletId,
+      amount,
+      memo: null,
+      idempotencyKey: undefined,
+    })) as { status?: string; errors: unknown[] }
+
+    expect(result.status).toBe("failed")
+    expect(result.errors).toHaveLength(1)
+    expect(mockIntraledgerPaymentSendWalletIdForBtcWallet).not.toHaveBeenCalled()
+  })
+})

--- a/test/flash/unit/graphql/public/root/mutation/intraledger-payment-send.spec.ts
+++ b/test/flash/unit/graphql/public/root/mutation/intraledger-payment-send.spec.ts
@@ -1,6 +1,12 @@
 const mockIntraledgerPaymentSendWalletIdForBtcWallet = jest.fn()
 const mockGetUsernameFromWalletId = jest.fn()
 const mockResolveCashWalletRecipientMutationWalletId = jest.fn()
+const mockNotifyOpsEvent = jest.fn()
+
+jest.mock("@services/alerts/ops-events", () => ({
+  notifyOpsEvent: (...args: Parameters<typeof mockNotifyOpsEvent>) =>
+    mockNotifyOpsEvent(...args),
+}))
 
 jest.mock("@app", () => ({
   Accounts: {
@@ -77,6 +83,7 @@ describe("IntraLedgerPaymentSendMutation", () => {
       idempotencyKey: "idem-1",
     })
     expect(result).toEqual({ errors: [], status: "success" })
+    expect(mockNotifyOpsEvent).not.toHaveBeenCalled()
   })
 
   it("returns failed without paying when recipient routing errors", async () => {
@@ -95,5 +102,13 @@ describe("IntraLedgerPaymentSendMutation", () => {
     expect(result.status).toBe("failed")
     expect(result.errors).toHaveLength(1)
     expect(mockIntraledgerPaymentSendWalletIdForBtcWallet).not.toHaveBeenCalled()
+    expect(mockNotifyOpsEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        flow: "transfer",
+        status: "failed",
+        error: "MismatchedCurrencyForWalletError",
+        meta: expect.objectContaining({ reason: "recipient-routing" }),
+      }),
+    )
   })
 })

--- a/test/flash/unit/graphql/public/root/mutation/intraledger-usd-payment-send.spec.ts
+++ b/test/flash/unit/graphql/public/root/mutation/intraledger-usd-payment-send.spec.ts
@@ -1,0 +1,106 @@
+const mockIntraledgerPaymentSendWalletIdForUsdWallet = jest.fn()
+const mockResolveCashWalletMutationWalletIdForAccount = jest.fn()
+const mockResolveCashWalletRecipientMutationWalletId = jest.fn()
+
+jest.mock("@app", () => ({
+  Payments: {
+    intraledgerPaymentSendWalletIdForUsdWallet: (
+      ...args: Parameters<typeof mockIntraledgerPaymentSendWalletIdForUsdWallet>
+    ) => mockIntraledgerPaymentSendWalletIdForUsdWallet(...args),
+  },
+}))
+
+jest.mock("@app/cash-wallet-cutover", () => ({
+  resolveCashWalletMutationWalletIdForAccount: (
+    ...args: Parameters<typeof mockResolveCashWalletMutationWalletIdForAccount>
+  ) => mockResolveCashWalletMutationWalletIdForAccount(...args),
+  resolveCashWalletRecipientMutationWalletId: (
+    ...args: Parameters<typeof mockResolveCashWalletRecipientMutationWalletId>
+  ) => mockResolveCashWalletRecipientMutationWalletId(...args),
+}))
+
+import { MismatchedCurrencyForWalletError } from "@domain/errors"
+import IntraLedgerUsdPaymentSendMutation from "@graphql/public/root/mutation/intraledger-usd-payment-send"
+
+const senderWalletId = "11111111-1111-4111-8111-111111111111" as WalletId
+const recipientWalletId = "22222222-2222-4222-8222-222222222222" as WalletId
+const routedSenderWalletId = "33333333-3333-4333-8333-333333333333" as WalletId
+const routedRecipientWalletId = "44444444-4444-4444-8444-444444444444" as WalletId
+const amount = 1234 as UsdCents
+
+const domainAccount = { id: "sender-account-id" } as Account
+
+const client = {
+  cashWalletPresentation: "legacy_compat",
+  hasUsdtCashWalletSupport: false,
+} as const
+
+const resolve = (input: Record<string, unknown>) =>
+  IntraLedgerUsdPaymentSendMutation.resolve?.(
+    null,
+    { input },
+    { domainAccount, cashWalletClientCapabilities: client } as GraphQLPublicContextAuth,
+    {} as never,
+  )
+
+describe("IntraLedgerUsdPaymentSendMutation", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockResolveCashWalletMutationWalletIdForAccount.mockResolvedValue(
+      routedSenderWalletId,
+    )
+    mockResolveCashWalletRecipientMutationWalletId.mockResolvedValue(
+      routedRecipientWalletId,
+    )
+    mockIntraledgerPaymentSendWalletIdForUsdWallet.mockResolvedValue({
+      value: "success",
+    })
+  })
+
+  it("routes both sender and recipient wallet ids through cash-wallet routing", async () => {
+    const result = await resolve({
+      walletId: senderWalletId,
+      recipientWalletId,
+      amount,
+      memo: "test memo" as Memo,
+      idempotencyKey: "idem-1",
+    })
+
+    expect(mockResolveCashWalletMutationWalletIdForAccount).toHaveBeenCalledWith({
+      account: domainAccount,
+      walletId: senderWalletId,
+      client,
+    })
+    expect(mockResolveCashWalletRecipientMutationWalletId).toHaveBeenCalledWith({
+      recipientWalletId,
+      client,
+    })
+    expect(mockIntraledgerPaymentSendWalletIdForUsdWallet).toHaveBeenCalledWith({
+      recipientWalletId: routedRecipientWalletId,
+      memo: "test memo",
+      amount,
+      senderWalletId: routedSenderWalletId,
+      senderAccount: domainAccount,
+      idempotencyKey: "idem-1",
+    })
+    expect(result).toEqual({ errors: [], status: "success" })
+  })
+
+  it("returns failed without paying when recipient routing errors", async () => {
+    mockResolveCashWalletRecipientMutationWalletId.mockResolvedValue(
+      new MismatchedCurrencyForWalletError(),
+    )
+
+    const result = (await resolve({
+      walletId: senderWalletId,
+      recipientWalletId,
+      amount,
+      memo: null,
+      idempotencyKey: undefined,
+    })) as { status?: string; errors: unknown[] }
+
+    expect(result.status).toBe("failed")
+    expect(result.errors).toHaveLength(1)
+    expect(mockIntraledgerPaymentSendWalletIdForUsdWallet).not.toHaveBeenCalled()
+  })
+})

--- a/test/flash/unit/graphql/public/root/mutation/intraledger-usd-payment-send.spec.ts
+++ b/test/flash/unit/graphql/public/root/mutation/intraledger-usd-payment-send.spec.ts
@@ -1,6 +1,12 @@
 const mockIntraledgerPaymentSendWalletIdForUsdWallet = jest.fn()
 const mockResolveCashWalletMutationWalletIdForAccount = jest.fn()
 const mockResolveCashWalletRecipientMutationWalletId = jest.fn()
+const mockNotifyOpsEvent = jest.fn()
+
+jest.mock("@services/alerts/ops-events", () => ({
+  notifyOpsEvent: (...args: Parameters<typeof mockNotifyOpsEvent>) =>
+    mockNotifyOpsEvent(...args),
+}))
 
 jest.mock("@app", () => ({
   Payments: {
@@ -84,6 +90,7 @@ describe("IntraLedgerUsdPaymentSendMutation", () => {
       idempotencyKey: "idem-1",
     })
     expect(result).toEqual({ errors: [], status: "success" })
+    expect(mockNotifyOpsEvent).not.toHaveBeenCalled()
   })
 
   it("returns failed without paying when recipient routing errors", async () => {
@@ -102,5 +109,37 @@ describe("IntraLedgerUsdPaymentSendMutation", () => {
     expect(result.status).toBe("failed")
     expect(result.errors).toHaveLength(1)
     expect(mockIntraledgerPaymentSendWalletIdForUsdWallet).not.toHaveBeenCalled()
+    expect(mockNotifyOpsEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        flow: "transfer",
+        status: "failed",
+        error: "MismatchedCurrencyForWalletError",
+        meta: expect.objectContaining({ reason: "recipient-routing" }),
+      }),
+    )
+  })
+
+  it("reports sender routing failures to the ops feed", async () => {
+    mockResolveCashWalletMutationWalletIdForAccount.mockResolvedValue(
+      new MismatchedCurrencyForWalletError(),
+    )
+
+    const result = (await resolve({
+      walletId: senderWalletId,
+      recipientWalletId,
+      amount,
+      memo: null,
+      idempotencyKey: undefined,
+    })) as { status?: string }
+
+    expect(result.status).toBe("failed")
+    expect(mockIntraledgerPaymentSendWalletIdForUsdWallet).not.toHaveBeenCalled()
+    expect(mockNotifyOpsEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        flow: "transfer",
+        status: "failed",
+        meta: expect.objectContaining({ reason: "sender-routing" }),
+      }),
+    )
   })
 })


### PR DESCRIPTION
## Problem

Repeated `Transfer — failed` events in the #flash-activity ops feed: `MismatchedCurrencyForWalletError`, always the same wallet pair, small USD amounts, `reason: error-return`.

Root cause: post-cutover, `intraLedgerUsdPaymentSend` routes the **sender's** wallet through cash-wallet routing (`resolveCashWalletMutationWalletIdForAccount`, legacy USD → USDT) but passes the **recipient's** wallet id through raw. A client that doesn't send `x-flash-client-capabilities: cash-wallet-usdt-v1` (pre-0.6.0 app, scripts, or any hop that strips the header) resolves a recipient via `accountDefaultWallet` and gets handed the recipient's **legacy USD** wallet id by the compat presentation. The send then arrives as USDT sender wallet → USD recipient wallet and is rejected deterministically at `send-intraledger.ts` (`senderWallet.currency !== recipientWallet.currency`). Every intraledger send from a legacy client fails, 100% of the time.

## Fix

Wire `resolveCashWalletRecipientMutationWalletId` — already used by `lnUsdInvoiceCreateOnBehalfOfRecipient` — into:

- `intraLedgerUsdPaymentSend`
- `intraLedgerPaymentSend`

It resolves a legacy USD recipient wallet id to the recipient account's **active settlement (USDT) wallet**, so funds settle where the compat read-side already points: the `UsdWallet.balance` and `transactions` resolvers alias the legacy wallet to the settlement wallet, so legacy-app recipients see the funds. Current-client ids pass through unchanged (no-op).

## Tests

- New mutation-level unit specs for both mutations (mirroring `ln-usd-invoice-create-on-behalf-of-recipient.spec.ts`):
  - recipient id is routed and the routed id is what reaches `Payments.intraledgerPaymentSendWalletIdFor{Usd,Btc}Wallet`
  - routing errors return `status: failed` without initiating a payment
- `yarn tsc-check` clean, eslint clean, unit suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AP1XZs5anZjsHYgGRGVyDT