### PR TITLE
feat(cashout): expose the JMD settlement rate pre-quote (cashoutRate query)

### DIFF
--- a/dev/apollo-federation/supergraph.graphql
+++ b/dev/apollo-federation/supergraph.graphql
@@ -854,6 +854,20 @@ type CashoutOffer
   walletId: WalletId!
 }
 
+type CashoutRate
+  @join__type(graph: PUBLIC)
+{
+  """
+  JMD cents per 1 USD at which a JMD cashout would settle right now — the same rate a cashout offer locks in.
+  """
+  exchangeRate: JMDCents!
+
+  """
+  Flash cashout service fee in basis points, deducted from the USD amount before conversion.
+  """
+  feeBasisPoints: Int!
+}
+
 type CashWalletCutover
   @join__type(graph: PUBLIC)
 {
@@ -2209,6 +2223,7 @@ type Query
   btcPriceList(range: PriceGraphRange!): [PricePoint]
   businessMapMarkers: [MapMarker!]!
   cashWalletCutover: CashWalletCutover!
+  cashoutRate: CashoutRate!
   currencyList: [Currency!]!
   globals: Globals
   invitePreview(token: String!): InvitePreview

--- a/src/domain/api-keys/scope-map.ts
+++ b/src/domain/api-keys/scope-map.ts
@@ -16,6 +16,7 @@ export const apiKeyScopeForField: Readonly<Record<string, ApiKeyFieldAccess>> =
     transactionDetails: "read:transactions",
     latestAccountUpgradeRequest: "BLOCKED",
     bridgeKycStatus: "BLOCKED",
+    cashoutRate: "BLOCKED",
     myReferrals: "BLOCKED",
     bridgeVirtualAccount: "BLOCKED",
     bridgeExternalAccounts: "BLOCKED",

--- a/src/graphql/public/queries.ts
+++ b/src/graphql/public/queries.ts
@@ -30,6 +30,7 @@ import BridgeWithdrawalRequestQuery from "./root/query/bridge-withdrawal-request
 import BridgeWithdrawalsQuery from "./root/query/bridge-withdrawals"
 import ApiKeysQuery from "./root/query/api-keys"
 import InvitePreviewQuery from "./root/query/invite-preview"
+import CashoutRateQuery from "./root/query/cashout-rate"
 import MyReferralsQuery from "./root/query/my-referrals"
 
 export const queryFields = {
@@ -63,6 +64,7 @@ export const queryFields = {
       bridgeWithdrawalRequest: BridgeWithdrawalRequestQuery,
       bridgeWithdrawals: BridgeWithdrawalsQuery,
       apiKeys: ApiKeysQuery,
+      cashoutRate: CashoutRateQuery,
       myReferrals: MyReferralsQuery,
     },
     atWalletLevel: {

--- a/src/graphql/public/root/query/cashout-rate.ts
+++ b/src/graphql/public/root/query/cashout-rate.ts
@@ -1,0 +1,50 @@
+import { Cashout } from "@config"
+import { JMDAmount } from "@domain/shared"
+import { GT } from "@graphql/index"
+import { mapAndParseErrorForGqlResponse } from "@graphql/error-map"
+import JMDCentsScalar from "@graphql/shared/types/scalar/jmd-cent-amount"
+import ErpNext from "@services/frappe/ErpNext"
+
+// The settlement rate the app shows BEFORE a cashout offer exists. This is the
+// same source `CashoutManager.createOffer` locks into a JMD offer (ERPNext
+// Currency Exchange, NCB for_buying side), so the entry-screen preview matches
+// the offer and the ERPNext Cashout doc — unlike the realtimePrice display
+// rate, which is a mid-market feed with no bank spread.
+type CashoutRateSource = {
+  exchangeRate: JMDAmount
+  feeBasisPoints: number
+}
+
+const CashoutRateType = GT.Object({
+  name: "CashoutRate",
+  fields: () => ({
+    exchangeRate: {
+      type: GT.NonNull(JMDCentsScalar),
+      description:
+        "JMD cents per 1 USD at which a JMD cashout would settle right now — the same rate a cashout offer locks in.",
+      resolve: (source: CashoutRateSource) => source.exchangeRate,
+    },
+    feeBasisPoints: {
+      type: GT.NonNull(GT.Int),
+      description:
+        "Flash cashout service fee in basis points, deducted from the USD amount before conversion.",
+      resolve: (source: CashoutRateSource) => source.feeBasisPoints,
+    },
+  }),
+})
+
+const CashoutRateQuery = GT.Field({
+  type: GT.NonNull(CashoutRateType),
+  resolve: async () => {
+    const exchangeRate = await ErpNext.getCashoutExchangeRate()
+    if (exchangeRate instanceof Error) {
+      throw mapAndParseErrorForGqlResponse(exchangeRate)
+    }
+    return {
+      exchangeRate,
+      feeBasisPoints: Number(Cashout.OfferConfig.fee),
+    }
+  },
+})
+
+export default CashoutRateQuery

--- a/src/graphql/public/schema.graphql
+++ b/src/graphql/public/schema.graphql
@@ -698,6 +698,18 @@ type CashoutOffer {
   walletId: WalletId!
 }
 
+type CashoutRate {
+  """
+  JMD cents per 1 USD at which a JMD cashout would settle right now — the same rate a cashout offer locks in.
+  """
+  exchangeRate: JMDCents!
+
+  """
+  Flash cashout service fee in basis points, deducted from the USD amount before conversion.
+  """
+  feeBasisPoints: Int!
+}
+
 """(Positive) Cent amount (1/100 of a dollar)"""
 scalar CentAmount
 
@@ -1769,6 +1781,7 @@ type Query {
   btcPriceList(range: PriceGraphRange!): [PricePoint]
   businessMapMarkers: [MapMarker!]!
   cashWalletCutover: CashWalletCutover!
+  cashoutRate: CashoutRate!
   currencyList: [Currency!]!
   globals: Globals
   invitePreview(token: String!): InvitePreview

--- a/test/flash/unit/graphql/public/root/query/cashout-rate.spec.ts
+++ b/test/flash/unit/graphql/public/root/query/cashout-rate.spec.ts
@@ -1,0 +1,64 @@
+const mockGetCashoutExchangeRate = jest.fn()
+jest.mock("@services/frappe/ErpNext", () => ({
+  __esModule: true,
+  default: {
+    getCashoutExchangeRate: (...a: unknown[]) => mockGetCashoutExchangeRate(...a),
+  },
+}))
+
+import { Cashout } from "@config"
+import { JMDAmount } from "@domain/shared"
+import CashoutRateQuery from "@graphql/public/root/query/cashout-rate"
+import { ExchangeRateQueryError } from "@services/frappe/errors"
+
+type CashoutRateResult = {
+  exchangeRate: JMDAmount
+  feeBasisPoints: number
+}
+
+const resolveQuery = async (): Promise<CashoutRateResult> => {
+  const query = CashoutRateQuery as unknown as {
+    resolve: (
+      source: null,
+      args: Record<string, never>,
+      context: unknown,
+      info: never,
+    ) => Promise<CashoutRateResult>
+  }
+  return query.resolve(null, {}, {}, undefined as never)
+}
+
+beforeEach(() => {
+  mockGetCashoutExchangeRate.mockReset()
+})
+
+describe("cashoutRate query", () => {
+  it("returns the live ERPNext settlement rate and the configured fee", async () => {
+    const rate = JMDAmount.dollars(152.7)
+    if (rate instanceof Error) throw rate
+    mockGetCashoutExchangeRate.mockResolvedValue(rate)
+
+    const result = await resolveQuery()
+
+    expect(result.exchangeRate).toBe(rate)
+    // Serialized by JMDCentsScalar as cents: 152.70 JMD -> 15270
+    expect(Number(result.exchangeRate.asCents())).toBe(15270)
+    expect(result.feeBasisPoints).toBe(Number(Cashout.OfferConfig.fee))
+    expect(Number.isInteger(result.feeBasisPoints)).toBe(true)
+  })
+
+  it("fails closed when ERPNext has no rate — never quotes a guessed rate", async () => {
+    mockGetCashoutExchangeRate.mockResolvedValue(
+      new ExchangeRateQueryError("No USD->JMD for_buying rate found in ERPNext"),
+    )
+
+    // The resolver throws the mapped IError object (same pattern as
+    // myReferrals) — a plain object, so assert its shape, not instanceof.
+    await expect(resolveQuery()).rejects.toMatchObject({
+      message:
+        "Cashout is temporarily unavailable while we refresh the exchange rate. Please try again shortly.",
+      code: expect.any(String),
+    })
+    expect(mockGetCashoutExchangeRate).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## Why

Users see a JMD amount in the app during a settle request that doesn't match the JMD that lands in their bank. Root cause (traced end-to-end): the entry screen previews JMD with the **realtimePrice display rate** (free-currency-rates mid-market, no spread), while JMD offers settle at the **ERPNext NCB `for_buying` rate minus the 2% service fee** — a structural ~5-7% gap, always in the app-shows-more direction. The confirmation screen already shows the offer's true numbers, but the anchor is set one screen earlier.

## What

New authed public query, exposing the settlement side *before* a quote exists:

```graphql
query { cashoutRate { exchangeRate feeBasisPoints } }
```

- `exchangeRate`: `JMDCents!` per 1 USD — the **same** `ErpNext.getCashoutExchangeRate()` a JMD offer locks; fails closed through the existing `ExchangeRateQueryError` mapping (no guessed rates, same behavior as `createOffer`).
- `feeBasisPoints`: `Cashout.OfferConfig.fee` (currently 200).
- Registered under `authed.atAccountLevel`, scope-map `BLOCKED` (mirrors `myReferrals`); SDL + supergraph regenerated via `make codegen`.

## Tests

- `test/flash/unit/graphql/public/root/query/cashout-rate.spec.ts`: rate + fee happy path (incl. cents serialization: 152.70 → 15270) and fail-closed path asserting the mapped user-facing error.
- `check:sdl`, `tsc-check`, api-key-scope-enforcement spec, eslint: all green locally.

Companion UI PR: flash-mobile `feat/cashout-rate-preview` (renders "You'll receive about J$X" + the settlement rate on the cashout entry screen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017iEVSCGxZMRjwsmSsd6ZNU