### PR TITLE
feat(fygaro): fee-aware auto-credit — credit net, configurable via ERPNext

### DIFF
--- a/dev/apollo-federation/supergraph.graphql
+++ b/dev/apollo-federation/supergraph.graphql
@@ -1083,6 +1083,30 @@ scalar FractionalCentAmount
   @join__type(graph: PUBLIC)
 
 """
+Fee parameters for Fygaro card top-ups, so the client can
+compute the net amount a user will receive. Null when the operator settings
+are unavailable — clients should degrade gracefully (hide the estimate).
+"""
+type FygaroTopupInfo
+  @join__type(graph: PUBLIC)
+{
+  """Flash margin fixed fee, in USD."""
+  flashFeeFixed: Float!
+
+  """Flash margin percentage fee (e.g. 2.0 = 2.0%)."""
+  flashFeePercent: Float!
+
+  """Minimum top-up amount, in USD."""
+  minimumAmount: Float!
+
+  """Payment-processor fixed fee, in USD."""
+  processorFeeFixed: Float!
+
+  """Payment-processor percentage fee (e.g. 2.99 = 2.99%)."""
+  processorFeePercent: Float!
+}
+
+"""
 Provides global settings for the application which might have an impact for the user.
 """
 type Globals
@@ -1101,6 +1125,13 @@ type Globals
   """
   cashoutEnabled: Boolean!
   feesInformation: FeesInformation!
+
+  """
+  Fee parameters for Fygaro card top-ups so the app can
+  preview the net amount a user will receive. Null when operator settings
+  are unavailable — the app should hide the estimate and fall back gracefully.
+  """
+  fygaroTopup: FygaroTopupInfo
 
   """
   The domain name for lightning addresses accepted by this Galoy instance

--- a/src/graphql/public/root/query/globals.ts
+++ b/src/graphql/public/root/query/globals.ts
@@ -12,6 +12,8 @@ import {
 
 import { getSupportedCountries } from "@app/authentication/get-supported-countries"
 
+import { getFygaroSettings } from "@services/fygaro/webhook-server/fygaro-settings"
+
 import { GT } from "@graphql/index"
 import Globals from "@graphql/public/types/object/globals"
 
@@ -22,6 +24,10 @@ const GlobalsQuery = GT.Field({
   resolve: async () => {
     // let nodesIds = await Lightning.listNodesPubkeys()
     // if (nodesIds instanceof Error) nodesIds = []
+
+    // Fee params for the card-topup "you'll receive $X" preview. Sourced from
+    // the cached Fygaro Settings; null when unavailable so the app degrades.
+    const fygaroSettings = await getFygaroSettings()
 
     return {
       nodesIds: [],
@@ -41,6 +47,15 @@ const GlobalsQuery = GT.Field({
       cashoutEnabled: Cashout.Enabled,
       bridgeEnabled: BridgeConfig.enabled,
       referralRewardEnabled: getReferralRewardConfig().enabled,
+      fygaroTopup: fygaroSettings
+        ? {
+            minimumAmount: fygaroSettings.minimumTopup,
+            processorFeePercent: fygaroSettings.processorFeePercent,
+            processorFeeFixed: fygaroSettings.processorFeeFixed,
+            flashFeePercent: fygaroSettings.flashMarginPercent,
+            flashFeeFixed: fygaroSettings.flashMarginFixed,
+          }
+        : null,
     }
   },
 })

--- a/src/graphql/public/schema.graphql
+++ b/src/graphql/public/schema.graphql
@@ -862,6 +862,28 @@ Cent amount (1/100 of a dollar) as a float, can be positive or negative
 scalar FractionalCentAmount
 
 """
+Fee parameters for Fygaro card top-ups, so the client can
+compute the net amount a user will receive. Null when the operator settings
+are unavailable — clients should degrade gracefully (hide the estimate).
+"""
+type FygaroTopupInfo {
+  """Flash margin fixed fee, in USD."""
+  flashFeeFixed: Float!
+
+  """Flash margin percentage fee (e.g. 2.0 = 2.0%)."""
+  flashFeePercent: Float!
+
+  """Minimum top-up amount, in USD."""
+  minimumAmount: Float!
+
+  """Payment-processor fixed fee, in USD."""
+  processorFeeFixed: Float!
+
+  """Payment-processor percentage fee (e.g. 2.99 = 2.99%)."""
+  processorFeePercent: Float!
+}
+
+"""
 Provides global settings for the application which might have an impact for the user.
 """
 type Globals {
@@ -878,6 +900,13 @@ type Globals {
   """
   cashoutEnabled: Boolean!
   feesInformation: FeesInformation!
+
+  """
+  Fee parameters for Fygaro card top-ups so the app can
+  preview the net amount a user will receive. Null when operator settings
+  are unavailable — the app should hide the estimate and fall back gracefully.
+  """
+  fygaroTopup: FygaroTopupInfo
 
   """
   The domain name for lightning addresses accepted by this Galoy instance

--- a/src/graphql/public/types/object/fygaro-topup-info.ts
+++ b/src/graphql/public/types/object/fygaro-topup-info.ts
@@ -1,0 +1,37 @@
+import dedent from "dedent"
+import { GT } from "@graphql/index"
+
+// Fee parameters the mobile app needs to preview "you'll receive $X" locally
+// before a Fygaro card top-up. Sourced from the ERPNext "Fygaro Settings"
+// doctype (through the webhook's 60s cache). All amounts are in USD; percents
+// are whole-number percents (e.g. 2.99 means 2.99%).
+const FygaroTopupInfo = GT.Object({
+  name: "FygaroTopupInfo",
+  description: dedent`Fee parameters for Fygaro card top-ups, so the client can
+    compute the net amount a user will receive. Null when the operator settings
+    are unavailable — clients should degrade gracefully (hide the estimate).`,
+  fields: () => ({
+    minimumAmount: {
+      type: GT.NonNull(GT.Float),
+      description: "Minimum top-up amount, in USD.",
+    },
+    processorFeePercent: {
+      type: GT.NonNull(GT.Float),
+      description: "Payment-processor percentage fee (e.g. 2.99 = 2.99%).",
+    },
+    processorFeeFixed: {
+      type: GT.NonNull(GT.Float),
+      description: "Payment-processor fixed fee, in USD.",
+    },
+    flashFeePercent: {
+      type: GT.NonNull(GT.Float),
+      description: "Flash margin percentage fee (e.g. 2.0 = 2.0%).",
+    },
+    flashFeeFixed: {
+      type: GT.NonNull(GT.Float),
+      description: "Flash margin fixed fee, in USD.",
+    },
+  }),
+})
+
+export default FygaroTopupInfo

--- a/src/graphql/public/types/object/globals.ts
+++ b/src/graphql/public/types/object/globals.ts
@@ -6,6 +6,7 @@ import Network from "../scalar/network"
 import Country from "./country"
 import FeesInformation from "./fees-information"
 import BuildInformation from "./build-information"
+import FygaroTopupInfo from "./fygaro-topup-info"
 
 const Globals = GT.Object({
   name: "Globals",
@@ -58,6 +59,12 @@ const Globals = GT.Object({
         friend" home-screen card) should be shown to the user. Controlled by the
         instance-wide referralReward feature flag; when false the referral payout is
         disabled, so reward-promising UI must stay hidden.`,
+    },
+    fygaroTopup: {
+      type: FygaroTopupInfo,
+      description: dedent`Fee parameters for Fygaro card top-ups so the app can
+        preview the net amount a user will receive. Null when operator settings
+        are unavailable — the app should hide the estimate and fall back gracefully.`,
     },
   }),
 })

--- a/src/services/alerts/dedup-key.ts
+++ b/src/services/alerts/dedup-key.ts
@@ -33,6 +33,10 @@ export const generateDedupKey = {
     `fygaro-webhook:payment:${transactionId}`,
   fygaroUnattributed: (transactionId: string) => `fygaro:unattributed:${transactionId}`,
   fygaroCreditFailed: (transactionId: string) => `fygaro:credit-failed:${transactionId}`,
+  // A gate blocked auto-credit (over-limit, settings unavailable, disabled,
+  // non-USD, non-positive net). Distinct from fygaroCreditFailed so a "skipped"
+  // warning never suppresses a later "credit attempt failed" critical.
+  fygaroNotCredited: (transactionId: string) => `fygaro:not-credited:${transactionId}`,
 }
 
 export const normalizeDedupKey = (key: string): string =>

--- a/src/services/frappe/BridgeTransferRequestWriter.ts
+++ b/src/services/frappe/BridgeTransferRequestWriter.ts
@@ -262,14 +262,21 @@ export const isFygaroTopupCompleted = async (transactionId: string): Promise<boo
 }
 
 // Called after the treasury -> user intraledger credit succeeds: promotes the
-// Fygaro topup row to Completed and stamps the credited wallet on it. The
-// upsert's monotonic status guard makes this safe to repeat.
+// Fygaro topup row to Completed and stamps the credited wallet plus the fee
+// breakdown on it. `initialAmount` is the gross face value, `processorFee` /
+// `flashFee` are the deducted fees, and `finalAmount` is the NET amount that
+// was actually credited (all in USD dollars). The upsert's monotonic status
+// guard makes this safe to repeat.
 export const completeFygaroTopup = async ({
   transactionId,
   accountId,
   walletId,
   amount,
   currency,
+  initialAmount,
+  processorFee,
+  flashFee,
+  finalAmount,
   rawPayload,
 }: {
   transactionId: string
@@ -277,6 +284,10 @@ export const completeFygaroTopup = async ({
   walletId: WalletId | string
   amount: string
   currency: string
+  initialAmount?: string
+  processorFee?: string
+  flashFee?: string
+  finalAmount?: string
   rawPayload: unknown
 }): Promise<true | BridgeTransferRequestUpsertError> => {
   return upsert(
@@ -291,6 +302,10 @@ export const completeFygaroTopup = async ({
       currency: String(currency),
       accountId,
       walletId,
+      initialAmount,
+      processorFee,
+      flashFee,
+      finalAmount,
       sourceEventId: transactionId,
       sourceEventType: "fygaro.payment",
       sourceSystemsSeen: ["fygaro_webhook", "ibex_intraledger_credit"],

--- a/src/services/frappe/ErpNext.ts
+++ b/src/services/frappe/ErpNext.ts
@@ -14,6 +14,7 @@ import {
   CashoutDraftError,
   CashoutSubmitError,
   ExchangeRateQueryError,
+  FygaroSettingsQueryError,
   JournalEntryDeleteError,
   SetDocTypeValueError,
   UpgradeRequestCreateError,
@@ -85,6 +86,20 @@ export type BridgeTransferRequestDoc = {
   source_systems_seen?: string
   account_id?: string
   wallet_id?: string
+}
+
+// Raw "Fygaro Settings" Single doctype as ERPNext returns it. Numeric fields
+// may arrive as numbers or numeric strings depending on the Frappe field type;
+// the caller (fygaro-settings.ts) coerces and validates before use.
+export type FygaroSettingsDoc = {
+  processor?: string
+  processor_fee_percent?: number | string
+  processor_fee_fixed?: number | string
+  flash_margin_percent?: number | string
+  flash_margin_fixed?: number | string
+  auto_credit_limit?: number | string
+  minimum_topup?: number | string
+  auto_credit_enabled?: number | boolean | string
 }
 
 export class ErpNext {
@@ -362,6 +377,34 @@ export class ErpNext {
         attributes: { "erpnext.exception": responseData?.exception },
       })
       return new ExchangeRateQueryError(err)
+    }
+  }
+
+  // Reads the "Fygaro Settings" Single doctype (one global row) that carries
+  // the operator-tuned processor/margin fees, auto-credit threshold, minimum
+  // top-up, and the auto-credit master toggle. The webhook consults this per
+  // payment (through a 60s cache) to compute the NET amount to credit.
+  async getFygaroSettings(): Promise<FygaroSettingsDoc | FygaroSettingsQueryError> {
+    try {
+      const resp = await axios.get(
+        `${this.url}/api/resource/${encodeURIComponent("Fygaro Settings")}/${encodeURIComponent("Fygaro Settings")}`,
+        { headers: this.headers },
+      )
+      const data = resp.data?.data
+      if (!data)
+        return new FygaroSettingsQueryError("No data in Fygaro Settings response")
+      return data as FygaroSettingsDoc
+    } catch (err) {
+      const responseData = isAxiosError(err) ? err.response?.data : undefined
+      baseLogger.error(
+        { err, responseData },
+        "Error querying Fygaro Settings from ERPNext",
+      )
+      recordExceptionInCurrentSpan({
+        error: err,
+        attributes: { "erpnext.exception": responseData?.exception },
+      })
+      return new FygaroSettingsQueryError(err)
     }
   }
 

--- a/src/services/frappe/errors.ts
+++ b/src/services/frappe/errors.ts
@@ -13,3 +13,4 @@ export class BankAccountUpdateRequestCreateError extends ErpNextError {}
 export class BankAccountUpdateRequestQueryError extends ErpNextError {}
 export class ExchangeRateQueryError extends ErpNextError {}
 export class BridgeTransferRequestUpsertError extends ErpNextError {}
+export class FygaroSettingsQueryError extends ErpNextError {}

--- a/src/services/frappe/models/BridgeTransferRequest.ts
+++ b/src/services/frappe/models/BridgeTransferRequest.ts
@@ -24,6 +24,8 @@ export type BridgeTransferRequestInput = {
   initialAmount?: string
   subtotalAmount?: string
   finalAmount?: string
+  processorFee?: string
+  flashFee?: string
   accountId?: AccountId | string
   walletId?: WalletId | string
   bridgeCustomerId?: string
@@ -77,6 +79,8 @@ export class BridgeTransferRequest {
       initial_amount: this.input.initialAmount,
       subtotal_amount: this.input.subtotalAmount,
       final_amount: this.input.finalAmount,
+      processor_fee: this.input.processorFee,
+      flash_fee: this.input.flashFee,
       account_id: this.input.accountId,
       wallet_id: this.input.walletId,
       bridge_customer_id: this.input.bridgeCustomerId,

--- a/src/services/fygaro/webhook-server/fees.ts
+++ b/src/services/fygaro/webhook-server/fees.ts
@@ -1,0 +1,99 @@
+/**
+ * Fygaro top-up fee math and the auto-credit gate.
+ *
+ * Fygaro / PayPal take a processor cut off the gross face value before it
+ * settles to Flash, and Flash keeps a configurable margin. Crediting the gross
+ * (as the pre-fix webhook did) loses money on every top-up. These helpers turn
+ * the operator-tuned Fygaro Settings into the NET cents to credit.
+ *
+ * Everything is done in integer cents; each individual fee component is rounded
+ * to the nearest cent before subtraction, so the numbers reconcile exactly with
+ * what an operator computes by hand from the settings.
+ */
+import type { FygaroSettings } from "./fygaro-settings"
+
+export type FygaroFees = {
+  grossCents: number
+  processorFeeCents: number
+  flashFeeCents: number
+  netCents: number
+}
+
+type FeeSettings = Pick<
+  FygaroSettings,
+  "processorFeePercent" | "processorFeeFixed" | "flashMarginPercent" | "flashMarginFixed"
+>
+
+/**
+ * gross_cents          = round(amount * 100)                          (caller supplies)
+ * processor_fee_cents  = round(gross * pct/100) + round(fixed * 100)
+ * flash_fee_cents      = round(gross * pct/100) + round(fixed * 100)
+ * net_cents            = gross - processor_fee - flash_fee
+ */
+export const computeFygaroFees = ({
+  grossCents,
+  settings,
+}: {
+  grossCents: number
+  settings: FeeSettings
+}): FygaroFees => {
+  const processorFeeCents =
+    Math.round((grossCents * settings.processorFeePercent) / 100) +
+    Math.round(settings.processorFeeFixed * 100)
+  const flashFeeCents =
+    Math.round((grossCents * settings.flashMarginPercent) / 100) +
+    Math.round(settings.flashMarginFixed * 100)
+  const netCents = grossCents - processorFeeCents - flashFeeCents
+
+  return { grossCents, processorFeeCents, flashFeeCents, netCents }
+}
+
+// Why a payment was NOT auto-credited. `credit-disabled` is the deploy-level
+// master gate (FygaroConfig.credit.enabled) and is handled silently; the rest
+// are runtime conditions worth an ops alert because credit IS supposed to be on.
+export type RecordOnlyReason =
+  | "credit-disabled"
+  | "settings-unavailable"
+  | "auto-credit-disabled"
+  | "non-usd"
+  | "over-limit"
+  | "non-positive-net"
+
+export type CreditGate =
+  | { credit: true; fees: FygaroFees }
+  | { credit: false; reason: RecordOnlyReason }
+
+/**
+ * Auto-credit runs ONLY if every gate holds, evaluated in this order:
+ *   1. credit enabled at deploy level (FygaroConfig.credit.enabled)
+ *   2. Fygaro Settings available AND auto_credit_enabled
+ *   3. currency === "USD"
+ *   4. gross <= auto_credit_limit (threshold on GROSS)
+ *   5. net > 0 (after fees)
+ * The first failing gate names the record-only reason.
+ */
+export const evaluateCreditGate = ({
+  creditEnabled,
+  currency,
+  settings,
+  grossCents,
+}: {
+  creditEnabled: boolean
+  currency: string
+  settings: FygaroSettings | undefined
+  grossCents: number
+}): CreditGate => {
+  if (!creditEnabled) return { credit: false, reason: "credit-disabled" }
+  if (!settings) return { credit: false, reason: "settings-unavailable" }
+  if (!settings.autoCreditEnabled)
+    return { credit: false, reason: "auto-credit-disabled" }
+  if (currency !== "USD") return { credit: false, reason: "non-usd" }
+  if (grossCents > Math.round(settings.autoCreditLimit * 100)) {
+    return { credit: false, reason: "over-limit" }
+  }
+
+  const fees = computeFygaroFees({ grossCents, settings })
+  if (fees.netCents <= 0) return { credit: false, reason: "non-positive-net" }
+
+  return { credit: true, fees }
+}

--- a/src/services/fygaro/webhook-server/fees.ts
+++ b/src/services/fygaro/webhook-server/fees.ts
@@ -57,6 +57,7 @@ export type RecordOnlyReason =
   | "auto-credit-disabled"
   | "non-usd"
   | "over-limit"
+  | "under-minimum"
   | "non-positive-net"
 
 export type CreditGate =
@@ -68,9 +69,18 @@ export type CreditGate =
  *   1. credit enabled at deploy level (FygaroConfig.credit.enabled)
  *   2. Fygaro Settings available AND auto_credit_enabled
  *   3. currency === "USD"
- *   4. gross <= auto_credit_limit (threshold on GROSS)
+ *   4. gross <= auto_credit_limit (inclusive upper bound on GROSS)
  *   5. net > 0 (after fees)
+ *   6. gross >= minimum_topup (inclusive lower bound on GROSS)
  * The first failing gate names the record-only reason.
+ *
+ * `under-minimum` is checked last (after the net gate) on purpose: a payment
+ * below the operator minimum is a valid, positive-net, in-limit USD top-up that
+ * is simply too small to auto-credit, so it records for manual handling. A
+ * payment whose fees already sink the net non-positive surfaces as
+ * `non-positive-net` (the more fundamental problem) rather than `under-minimum`.
+ * Both bounds on gross are inclusive: exactly at the limit or exactly at the
+ * minimum still auto-credits.
  */
 export const evaluateCreditGate = ({
   creditEnabled,
@@ -94,6 +104,9 @@ export const evaluateCreditGate = ({
 
   const fees = computeFygaroFees({ grossCents, settings })
   if (fees.netCents <= 0) return { credit: false, reason: "non-positive-net" }
+  if (grossCents < Math.round(settings.minimumTopup * 100)) {
+    return { credit: false, reason: "under-minimum" }
+  }
 
   return { credit: true, fees }
 }

--- a/src/services/fygaro/webhook-server/fygaro-settings.ts
+++ b/src/services/fygaro/webhook-server/fygaro-settings.ts
@@ -1,0 +1,114 @@
+/**
+ * Cached reader for the ERPNext "Fygaro Settings" Single doctype.
+ *
+ * The payment webhook consults these settings on every delivery to compute the
+ * NET amount to credit and to gate auto-crediting. Hitting ERPNext per payment
+ * would hammer it, so the result is memoised for ~60s (both successes AND
+ * failures — a failure is cached so an ERPNext outage degrades to record-only
+ * without a fetch storm, and recovers within the TTL).
+ *
+ * A read failure, a missing row, or a malformed row all resolve to `undefined`
+ * ("settings unavailable"). Callers must treat `undefined` as a hard stop on
+ * auto-credit — never as "assume zero fees" — so a broken settings row can
+ * never make Flash credit the gross face value again.
+ */
+import ErpNext, { type FygaroSettingsDoc } from "@services/frappe/ErpNext"
+import { baseLogger } from "@services/logger"
+
+export type FygaroSettings = {
+  processor: string
+  processorFeePercent: number
+  processorFeeFixed: number // USD
+  flashMarginPercent: number
+  flashMarginFixed: number // USD
+  autoCreditLimit: number // USD
+  minimumTopup: number // USD
+  autoCreditEnabled: boolean
+}
+
+const CACHE_TTL_MS = 60_000
+
+let cache: { value: FygaroSettings | undefined; at: number } | undefined
+
+// Coerce a value that ERPNext may send as a number or a numeric string. Returns
+// undefined for anything that is not a finite number.
+const toFiniteNumber = (value: unknown): number | undefined => {
+  if (typeof value === "number") return Number.isFinite(value) ? value : undefined
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number(value)
+    return Number.isFinite(parsed) ? parsed : undefined
+  }
+  return undefined
+}
+
+// ERPNext Check fields come back as 1/0; be liberal about truthy encodings.
+const toBoolean = (value: unknown): boolean =>
+  value === 1 || value === true || value === "1"
+
+// Validates the raw doctype into a typed FygaroSettings, or undefined when any
+// fee-relevant field is missing / non-numeric / negative (i.e. "garbage").
+export const validateFygaroSettings = (
+  doc: FygaroSettingsDoc | undefined,
+): FygaroSettings | undefined => {
+  if (!doc || typeof doc !== "object") return undefined
+
+  const processorFeePercent = toFiniteNumber(doc.processor_fee_percent)
+  const processorFeeFixed = toFiniteNumber(doc.processor_fee_fixed)
+  const flashMarginPercent = toFiniteNumber(doc.flash_margin_percent)
+  const flashMarginFixed = toFiniteNumber(doc.flash_margin_fixed)
+  const autoCreditLimit = toFiniteNumber(doc.auto_credit_limit)
+  const minimumTopup = toFiniteNumber(doc.minimum_topup)
+
+  const numbers = [
+    processorFeePercent,
+    processorFeeFixed,
+    flashMarginPercent,
+    flashMarginFixed,
+    autoCreditLimit,
+    minimumTopup,
+  ]
+  // A missing or negative fee/limit is not something we can safely credit off.
+  if (numbers.some((n) => n === undefined || n < 0)) return undefined
+
+  return {
+    processor: typeof doc.processor === "string" ? doc.processor : "",
+    processorFeePercent: processorFeePercent as number,
+    processorFeeFixed: processorFeeFixed as number,
+    flashMarginPercent: flashMarginPercent as number,
+    flashMarginFixed: flashMarginFixed as number,
+    autoCreditLimit: autoCreditLimit as number,
+    minimumTopup: minimumTopup as number,
+    autoCreditEnabled: toBoolean(doc.auto_credit_enabled),
+  }
+}
+
+/**
+ * Returns the current Fygaro Settings, or `undefined` when unavailable
+ * (ERPNext unreachable, no row, or a malformed row). Memoised for ~60s.
+ */
+export const getFygaroSettings = async (): Promise<FygaroSettings | undefined> => {
+  const now = Date.now()
+  if (cache && now - cache.at < CACHE_TTL_MS) return cache.value
+
+  const doc = ErpNext?.getFygaroSettings ? await ErpNext.getFygaroSettings() : undefined
+  if (doc instanceof Error) {
+    baseLogger.warn(
+      { error: doc },
+      "Failed to read Fygaro Settings; treating as unavailable (record-only)",
+    )
+    cache = { value: undefined, at: now }
+    return undefined
+  }
+
+  const validated = validateFygaroSettings(doc)
+  if (!validated) {
+    baseLogger.warn({ doc }, "Fygaro Settings row is malformed; treating as unavailable")
+  }
+  cache = { value: validated, at: now }
+  return validated
+}
+
+/** Test-only: clears the module cache so specs start from a cold read. */
+export const _resetFygaroSettingsCache = (): void => {
+  cache = undefined
+}

--- a/src/services/fygaro/webhook-server/routes/payment.ts
+++ b/src/services/fygaro/webhook-server/routes/payment.ts
@@ -353,6 +353,11 @@ export const paymentHandler = async (req: Request, res: Response) => {
           return { code: 200, body: { status: "recorded", credited: false } }
         }
 
+        // Contract with the admin fee-breakdown view: on a credited (Completed)
+        // row every fee MUST be an explicit string, including "0.00" for a
+        // zero-rate promo — `centsToDollars` never returns undefined. The admin
+        // renders a missing fee as "Pending", which is correct only for an
+        // uncredited (Fiat Received) row; never omit these here.
         const completeResult = await completeFygaroTopup({
           transactionId,
           accountId: creditAccountId,

--- a/src/services/fygaro/webhook-server/routes/payment.ts
+++ b/src/services/fygaro/webhook-server/routes/payment.ts
@@ -63,6 +63,7 @@ const RECORD_ONLY_ALERT_TITLE: Record<
     "Fygaro auto-credit disabled in settings — payment recorded, not auto-credited",
   "non-usd": "Fygaro payment in unexpected currency — not auto-credited",
   "over-limit": "Fygaro payment over the auto-credit limit — not auto-credited",
+  "under-minimum": "Fygaro payment below the minimum top-up — not auto-credited",
   "non-positive-net": "Fygaro payment net after fees is not positive — not auto-credited",
 }
 
@@ -80,6 +81,26 @@ export const paymentHandler = async (req: Request, res: Response) => {
     return res.status(400).json({
       error: "Invalid payload",
       detail: "Missing one or more required fields: transactionId, amount",
+    })
+  }
+
+  // A non-numeric amount (e.g. "abc") is a malformed payload, not a real
+  // payment — reject it with 400 up front so it never reaches the credit gate.
+  // Otherwise Math.round(Number("abc") * 100) is NaN, which slips past every
+  // numeric gate (all NaN comparisons are false) into the credit path, where
+  // creditFygaroTopup rejects it and fires the CRITICAL "auto-credit failed"
+  // alert — misclassifying garbage input as a credit failure and paging ops.
+  // Fygaro does not retry 4xx, which is correct here: a retry cannot make
+  // "abc" numeric.
+  const grossAmount = Number(payload.amount)
+  if (!Number.isFinite(grossAmount)) {
+    baseLogger.warn(
+      { transactionId, amount: payload.amount },
+      "Fygaro payment webhook rejected: non-numeric amount",
+    )
+    return res.status(400).json({
+      error: "Invalid payload",
+      detail: "amount is not a finite number",
     })
   }
 
@@ -191,15 +212,49 @@ export const paymentHandler = async (req: Request, res: Response) => {
     // are only read when credit is enabled — a disabled deploy never touches
     // ERPNext for this.
     const creditEnabled = Boolean(FygaroConfig.credit?.enabled)
-    const grossCents = Math.round(Number(payload.amount) * 100)
+    const grossCents = Math.round(grossAmount * 100)
     const settings = creditEnabled ? await getFygaroSettings() : undefined
     const gate = evaluateCreditGate({ creditEnabled, currency, settings, grossCents })
 
     if (!gate.credit) {
-      // Record-only path: nothing money-moving happens here, so a
-      // non-releasing timelock is the right dedupe. Taken only after the
-      // audit write succeeds so provider retries can recover audit gaps
-      // after transient persistence failures.
+      // `settings-unavailable` is TRANSIENT (an ERPNext blip, cached undefined
+      // for up to 60s) — unlike the deterministic reasons below, a retry
+      // seconds later would auto-credit cleanly. Acking 200 (record-only) would
+      // stop Fygaro retrying and permanently downgrade the payment to manual
+      // credit over a momentary outage. Return 500 so Fygaro retries and the
+      // read self-heals once ERPNext recovers; it still never credits off
+      // missing data — the retry simply re-reads settings. Deliberately do NOT
+      // take the non-releasing dedupe lock here (it would make the very next
+      // retry ack 200 "already_processed" and defeat the self-heal), and skip
+      // the ops-feed line (it can't be deduped without that lock, so per-retry
+      // emission would spam the feed during an outage). alertBridge is
+      // TTL-deduped, so a genuine sustained outage still pages without spamming.
+      if (gate.reason === "settings-unavailable") {
+        baseLogger.warn(
+          { transactionId },
+          "Fygaro Settings unavailable — returning 500 so Fygaro retries and the read self-heals",
+        )
+        alertBridge({
+          dedupKey: generateDedupKey.fygaroNotCredited(transactionId),
+          source: "fygaro-webhook",
+          severity: "warning",
+          title: RECORD_ONLY_ALERT_TITLE["settings-unavailable"],
+          detail: `reason=settings-unavailable currency=${currency} gross=${centsToDollars(grossCents)}`,
+          context: {
+            transaction_id: transactionId,
+            amount: String(payload.amount),
+            reason: gate.reason,
+          },
+        })
+        return res.status(500).json({ error: "Fygaro Settings unavailable; will retry" })
+      }
+
+      // Deterministic record-only path (non-usd, over-limit, under-minimum,
+      // non-positive-net, auto-credit-disabled, and the silent credit-disabled
+      // master gate): these will never change on retry, so ack 200 and dedupe
+      // with a non-releasing timelock. Nothing money-moving happens here. Taken
+      // only after the audit write succeeds so provider retries can recover
+      // audit gaps after transient persistence failures.
       const lockResult = await LockService().lockIdempotencyKey(
         `fygaro-payment:${transactionId}` as IdempotencyKey,
       )

--- a/src/services/fygaro/webhook-server/routes/payment.ts
+++ b/src/services/fygaro/webhook-server/routes/payment.ts
@@ -34,6 +34,8 @@ import { alertBridge, generateDedupKey } from "@services/alerts"
 import { notifyOpsEvent } from "@services/alerts/ops-events"
 
 import { creditFygaroTopup, FygaroCreditError } from "../credit-topup"
+import { getFygaroSettings } from "../fygaro-settings"
+import { evaluateCreditGate, RecordOnlyReason } from "../fees"
 
 type FygaroPaymentPayload = {
   transactionId?: string
@@ -44,6 +46,24 @@ type FygaroPaymentPayload = {
   authCode?: string | null
   createdAt?: string
   client?: { name?: string; email?: string }
+}
+
+const centsToDollars = (cents: number): string => (cents / 100).toFixed(2)
+
+// Human-readable title for the single record-only ops alert. `credit-disabled`
+// is intentionally absent — that is the deploy-level master gate and records
+// silently (no anomaly worth paging on).
+const RECORD_ONLY_ALERT_TITLE: Record<
+  Exclude<RecordOnlyReason, "credit-disabled">,
+  string
+> = {
+  "settings-unavailable":
+    "Fygaro Settings unavailable — payment recorded, not auto-credited",
+  "auto-credit-disabled":
+    "Fygaro auto-credit disabled in settings — payment recorded, not auto-credited",
+  "non-usd": "Fygaro payment in unexpected currency — not auto-credited",
+  "over-limit": "Fygaro payment over the auto-credit limit — not auto-credited",
+  "non-positive-net": "Fygaro payment net after fees is not positive — not auto-credited",
 }
 
 export const paymentHandler = async (req: Request, res: Response) => {
@@ -164,7 +184,18 @@ export const paymentHandler = async (req: Request, res: Response) => {
       return res.status(200).json({ status: "recorded", attributed: false })
     }
 
-    if (!FygaroConfig.credit?.enabled || currency !== "USD") {
+    // Fee-aware gate: credit the NET (gross minus processor + Flash fees), and
+    // only when every gate holds. The fees/threshold/minimum/toggle live in the
+    // ERPNext "Fygaro Settings" doctype, read through a 60s cache; the yaml
+    // FygaroConfig.credit.enabled stays the deploy-level master gate. Settings
+    // are only read when credit is enabled — a disabled deploy never touches
+    // ERPNext for this.
+    const creditEnabled = Boolean(FygaroConfig.credit?.enabled)
+    const grossCents = Math.round(Number(payload.amount) * 100)
+    const settings = creditEnabled ? await getFygaroSettings() : undefined
+    const gate = evaluateCreditGate({ creditEnabled, currency, settings, grossCents })
+
+    if (!gate.credit) {
       // Record-only path: nothing money-moving happens here, so a
       // non-releasing timelock is the right dedupe. Taken only after the
       // audit write succeeds so provider retries can recover audit gaps
@@ -176,16 +207,22 @@ export const paymentHandler = async (req: Request, res: Response) => {
         baseLogger.info({ transactionId }, "Duplicate Fygaro payment webhook")
         return res.status(200).json({ status: "already_processed" })
       }
-      if (currency !== "USD") {
-        // The payment button is USD-only; a non-USD payment is unexpected
-        // enough to demand human eyes before any crediting.
+      if (gate.reason !== "credit-disabled") {
+        // credit-disabled is the deploy-level master gate and records
+        // silently. Every other reason means credit IS supposed to be on but
+        // this specific payment was skipped — page a human, naming the gate,
+        // since it leaves fiat sitting uncredited.
         alertBridge({
-          dedupKey: generateDedupKey.fygaroCreditFailed(transactionId),
+          dedupKey: generateDedupKey.fygaroNotCredited(transactionId),
           source: "fygaro-webhook",
           severity: "warning",
-          title: "Fygaro payment in unexpected currency — not auto-credited",
-          detail: `currency=${currency}`,
-          context: { transaction_id: transactionId, amount: String(payload.amount) },
+          title: RECORD_ONLY_ALERT_TITLE[gate.reason],
+          detail: `reason=${gate.reason} currency=${currency} gross=${centsToDollars(grossCents)}`,
+          context: {
+            transaction_id: transactionId,
+            amount: String(payload.amount),
+            reason: gate.reason,
+          },
         })
       }
       notifyOpsEvent({
@@ -194,7 +231,12 @@ export const paymentHandler = async (req: Request, res: Response) => {
         status: "pending",
         accountId,
         amount: { value: String(payload.amount), currency },
-        meta: { provider: "Fygaro", transactionId, username: username ?? "" },
+        meta: {
+          provider: "Fygaro",
+          transactionId,
+          username: username ?? "",
+          reason: gate.reason,
+        },
       })
       return res.status(200).json({ status: "recorded", credited: false })
     }
@@ -208,7 +250,7 @@ export const paymentHandler = async (req: Request, res: Response) => {
     // the lock withPaymentIdempotency takes internally (that one is scoped to
     // the sender wallet), so there is no nested-acquire collision.
     const creditAccountId = accountId
-    const amountCents = Math.round(Number(payload.amount) * 100)
+    const { fees } = gate
     const outcome = await LockService().lockPaymentIdempotencyKey(
       `fygaro-payment:${transactionId}` as IdempotencyKey,
       async () => {
@@ -219,7 +261,7 @@ export const paymentHandler = async (req: Request, res: Response) => {
 
         const creditResult = await creditFygaroTopup({
           recipientAccountId: creditAccountId,
-          amountCents,
+          amountCents: fees.netCents,
           transactionId,
         })
         if (creditResult instanceof FygaroCreditError) {
@@ -262,6 +304,10 @@ export const paymentHandler = async (req: Request, res: Response) => {
           walletId: creditResult.walletId,
           amount: String(payload.amount),
           currency,
+          initialAmount: centsToDollars(fees.grossCents),
+          processorFee: centsToDollars(fees.processorFeeCents),
+          flashFee: centsToDollars(fees.flashFeeCents),
+          finalAmount: centsToDollars(fees.netCents),
           rawPayload: req.body,
         })
         if (completeResult instanceof Error) {
@@ -289,6 +335,7 @@ export const paymentHandler = async (req: Request, res: Response) => {
             transactionId,
             username: username ?? "",
             creditStatus: creditResult.status,
+            net: centsToDollars(fees.netCents),
           },
         })
 

--- a/test/flash/unit/graphql/public/root/query/globals.spec.ts
+++ b/test/flash/unit/graphql/public/root/query/globals.spec.ts
@@ -1,0 +1,89 @@
+const mockGetFygaroSettings = jest.fn()
+jest.mock("@services/fygaro/webhook-server/fygaro-settings", () => ({
+  getFygaroSettings: (...a: unknown[]) => mockGetFygaroSettings(...a),
+}))
+
+import GlobalsQuery from "@graphql/public/root/query/globals"
+import type { FygaroSettings } from "@services/fygaro/webhook-server/fygaro-settings"
+
+// The `fygaroTopup` field on Globals is a hand-written remap of the ERPNext
+// Fygaro Settings (minimumTopup -> minimumAmount, flashMargin* -> flashFee*,
+// plus the processor fields). Every value is a Float, so TypeScript cannot
+// catch a swapped source field — only a test can. These specs pin each field
+// to its exact source and, because every source value below is distinct, would
+// fail if any two were transposed (e.g. processorFeeFixed <-> flashFeeFixed).
+type FygaroTopupField = {
+  minimumAmount: number
+  processorFeePercent: number
+  processorFeeFixed: number
+  flashFeePercent: number
+  flashFeeFixed: number
+} | null
+
+type GlobalsResult = { fygaroTopup: FygaroTopupField }
+
+const resolveGlobals = async (): Promise<GlobalsResult> => {
+  const query = GlobalsQuery as unknown as {
+    resolve: (
+      source: null,
+      args: Record<string, never>,
+      context: unknown,
+      info: never,
+    ) => Promise<GlobalsResult>
+  }
+  return query.resolve(null, {}, {}, undefined as never)
+}
+
+// Deliberately all-distinct values so a swap of any two mapped fields is caught.
+const SETTINGS: FygaroSettings = {
+  processor: "Fygaro",
+  processorFeePercent: 2.99,
+  processorFeeFixed: 0.49,
+  flashMarginPercent: 2.0,
+  flashMarginFixed: 0.25,
+  autoCreditLimit: 500,
+  minimumTopup: 10,
+  autoCreditEnabled: true,
+}
+
+beforeEach(() => {
+  mockGetFygaroSettings.mockReset()
+})
+
+describe("globals query — fygaroTopup", () => {
+  it("returns null when Fygaro Settings are unavailable", async () => {
+    mockGetFygaroSettings.mockResolvedValue(undefined)
+
+    const result = await resolveGlobals()
+
+    expect(result.fygaroTopup).toBeNull()
+  })
+
+  it("maps each field from its exact settings source (no swaps)", async () => {
+    mockGetFygaroSettings.mockResolvedValue({ ...SETTINGS })
+
+    const result = await resolveGlobals()
+
+    expect(result.fygaroTopup).toEqual({
+      minimumAmount: SETTINGS.minimumTopup,
+      processorFeePercent: SETTINGS.processorFeePercent,
+      processorFeeFixed: SETTINGS.processorFeeFixed,
+      flashFeePercent: SETTINGS.flashMarginPercent,
+      flashFeeFixed: SETTINGS.flashMarginFixed,
+    })
+  })
+
+  it("does not transpose the processor and flash fixed/percent fees", async () => {
+    mockGetFygaroSettings.mockResolvedValue({ ...SETTINGS })
+
+    const fygaroTopup = (await resolveGlobals()).fygaroTopup
+
+    // Named assertions in addition to the structural toEqual above, so a swap
+    // report points at the exact offending pair.
+    expect(fygaroTopup?.flashFeePercent).toBe(SETTINGS.flashMarginPercent)
+    expect(fygaroTopup?.flashFeeFixed).toBe(SETTINGS.flashMarginFixed)
+    expect(fygaroTopup?.processorFeePercent).toBe(SETTINGS.processorFeePercent)
+    expect(fygaroTopup?.processorFeeFixed).toBe(SETTINGS.processorFeeFixed)
+    expect(fygaroTopup?.minimumAmount).toBe(SETTINGS.minimumTopup)
+  })
+})

--- a/test/flash/unit/services/fygaro/webhook-server/fees.spec.ts
+++ b/test/flash/unit/services/fygaro/webhook-server/fees.spec.ts
@@ -1,0 +1,144 @@
+import {
+  computeFygaroFees,
+  evaluateCreditGate,
+} from "@services/fygaro/webhook-server/fees"
+import type { FygaroSettings } from "@services/fygaro/webhook-server/fygaro-settings"
+
+const settings = (overrides: Partial<FygaroSettings> = {}): FygaroSettings => ({
+  processor: "Fygaro",
+  processorFeePercent: 2.99,
+  processorFeeFixed: 0.49,
+  flashMarginPercent: 2.0,
+  flashMarginFixed: 0,
+  autoCreditLimit: 500,
+  minimumTopup: 10,
+  autoCreditEnabled: true,
+  ...overrides,
+})
+
+describe("computeFygaroFees", () => {
+  // Each case: gross dollars -> expected processor¢, flash¢, net¢ with the
+  // canonical 2.99% + $0.49 processor / 2.0% flash schedule.
+  it.each([
+    // $10.00 — the reference case from the spec
+    [1000, 79, 20, 901],
+    // $1.00 — fixed fee dominates
+    [100, 52, 2, 46],
+    // $500.00 — large, at the auto-credit limit
+    [50000, 1544, 1000, 47456],
+    // $33.33 — exercises rounding on BOTH percentage components
+    // processor: round(3333*2.99/100)=round(99.6567)=100, +49 => 149
+    // flash:     round(3333*2/100)=round(66.66)=67
+    [3333, 149, 67, 3117],
+  ])(
+    "gross %i¢ -> processor %i¢, flash %i¢, net %i¢",
+    (grossCents, processor, flash, net) => {
+      const fees = computeFygaroFees({ grossCents, settings: settings() })
+      expect(fees.processorFeeCents).toBe(processor)
+      expect(fees.flashFeeCents).toBe(flash)
+      expect(fees.netCents).toBe(net)
+      expect(fees.grossCents).toBe(grossCents)
+      // net must reconcile exactly with the components
+      expect(fees.grossCents - fees.processorFeeCents - fees.flashFeeCents).toBe(
+        fees.netCents,
+      )
+    },
+  )
+
+  it("rounds each fee component to the nearest cent independently", () => {
+    // processorFeeFixed of $0.005 rounds to 1¢ on its own (round(0.5)=1),
+    // separately from the percentage component.
+    const fees = computeFygaroFees({
+      grossCents: 1000,
+      settings: settings({
+        processorFeePercent: 0,
+        processorFeeFixed: 0.005,
+        flashMarginPercent: 0,
+        flashMarginFixed: 0,
+      }),
+    })
+    expect(fees.processorFeeCents).toBe(1)
+    expect(fees.flashFeeCents).toBe(0)
+    expect(fees.netCents).toBe(999)
+  })
+
+  it("adds the flash fixed margin in cents", () => {
+    const fees = computeFygaroFees({
+      grossCents: 2000,
+      settings: settings({ flashMarginPercent: 2.0, flashMarginFixed: 0.25 }),
+    })
+    // flash: round(2000*2/100)=40, +round(0.25*100)=25 => 65
+    expect(fees.flashFeeCents).toBe(65)
+  })
+})
+
+describe("evaluateCreditGate", () => {
+  const base = { creditEnabled: true, currency: "USD", grossCents: 1000 }
+
+  it("credits with computed fees when every gate holds", () => {
+    const gate = evaluateCreditGate({ ...base, settings: settings() })
+    expect(gate).toMatchObject({
+      credit: true,
+      fees: { netCents: 901, processorFeeCents: 79, flashFeeCents: 20 },
+    })
+  })
+
+  it("record-only: credit-disabled when the deploy master gate is off", () => {
+    const gate = evaluateCreditGate({
+      ...base,
+      creditEnabled: false,
+      settings: settings(),
+    })
+    expect(gate).toEqual({ credit: false, reason: "credit-disabled" })
+  })
+
+  it("record-only: settings-unavailable when settings are undefined", () => {
+    const gate = evaluateCreditGate({ ...base, settings: undefined })
+    expect(gate).toEqual({ credit: false, reason: "settings-unavailable" })
+  })
+
+  it("record-only: auto-credit-disabled when the operator toggle is off", () => {
+    const gate = evaluateCreditGate({
+      ...base,
+      settings: settings({ autoCreditEnabled: false }),
+    })
+    expect(gate).toEqual({ credit: false, reason: "auto-credit-disabled" })
+  })
+
+  it("record-only: non-usd for a non-USD currency", () => {
+    const gate = evaluateCreditGate({ ...base, currency: "JMD", settings: settings() })
+    expect(gate).toEqual({ credit: false, reason: "non-usd" })
+  })
+
+  it("record-only: over-limit when gross exceeds the auto-credit limit", () => {
+    // $500.01 gross, limit $500
+    const gate = evaluateCreditGate({ ...base, grossCents: 50001, settings: settings() })
+    expect(gate).toEqual({ credit: false, reason: "over-limit" })
+  })
+
+  it("credits exactly at the auto-credit limit (inclusive threshold)", () => {
+    const gate = evaluateCreditGate({ ...base, grossCents: 50000, settings: settings() })
+    expect(gate.credit).toBe(true)
+  })
+
+  it("record-only: non-positive-net when fees meet or exceed gross", () => {
+    // $0.10 gross, $0.49 fixed processor fee => net is negative
+    const gate = evaluateCreditGate({ ...base, grossCents: 10, settings: settings() })
+    expect(gate).toEqual({ credit: false, reason: "non-positive-net" })
+  })
+
+  it("evaluates gates in order: master gate wins over everything", () => {
+    const gate = evaluateCreditGate({
+      ...base,
+      creditEnabled: false,
+      currency: "JMD",
+      settings: undefined,
+    })
+    expect(gate).toEqual({ credit: false, reason: "credit-disabled" })
+  })
+
+  it("evaluates gates in order: settings-unavailable wins over non-usd", () => {
+    const gate = evaluateCreditGate({ ...base, currency: "JMD", settings: undefined })
+    expect(gate).toEqual({ credit: false, reason: "settings-unavailable" })
+  })
+})

--- a/test/flash/unit/services/fygaro/webhook-server/fees.spec.ts
+++ b/test/flash/unit/services/fygaro/webhook-server/fees.spec.ts
@@ -121,8 +121,34 @@ describe("evaluateCreditGate", () => {
     expect(gate.credit).toBe(true)
   })
 
+  it("record-only: under-minimum when a positive-net payment is below the minimum", () => {
+    // $2.00 gross, $10 minimum: net is positive (~$1.41) but the gross is below
+    // the operator minimum, so it must NOT auto-credit.
+    const gate = evaluateCreditGate({ ...base, grossCents: 200, settings: settings() })
+    expect(gate).toEqual({ credit: false, reason: "under-minimum" })
+  })
+
+  it("record-only: under-minimum one cent below the minimum", () => {
+    // $9.99 gross vs $10 minimum: still under-minimum (inclusive lower bound).
+    const gate = evaluateCreditGate({ ...base, grossCents: 999, settings: settings() })
+    expect(gate).toEqual({ credit: false, reason: "under-minimum" })
+  })
+
+  it("credits exactly at the minimum top-up (inclusive lower bound)", () => {
+    // $10.00 gross == $10 minimum: credits.
+    const gate = evaluateCreditGate({ ...base, grossCents: 1000, settings: settings() })
+    expect(gate.credit).toBe(true)
+  })
+
   it("record-only: non-positive-net when fees meet or exceed gross", () => {
     // $0.10 gross, $0.49 fixed processor fee => net is negative
+    const gate = evaluateCreditGate({ ...base, grossCents: 10, settings: settings() })
+    expect(gate).toEqual({ credit: false, reason: "non-positive-net" })
+  })
+
+  it("evaluates gates in order: non-positive-net wins over under-minimum", () => {
+    // $0.10 gross is BOTH below the $10 minimum and non-positive-net. The net
+    // gate is checked first, so the more fundamental reason is reported.
     const gate = evaluateCreditGate({ ...base, grossCents: 10, settings: settings() })
     expect(gate).toEqual({ credit: false, reason: "non-positive-net" })
   })

--- a/test/flash/unit/services/fygaro/webhook-server/fygaro-settings.spec.ts
+++ b/test/flash/unit/services/fygaro/webhook-server/fygaro-settings.spec.ts
@@ -1,0 +1,137 @@
+jest.mock("@services/logger", () => ({
+  baseLogger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}))
+
+jest.mock("@services/frappe/ErpNext", () => ({
+  __esModule: true,
+  default: { getFygaroSettings: (...args: unknown[]) => mockGetFygaroSettings(...args) },
+}))
+
+const mockGetFygaroSettings = jest.fn()
+
+import {
+  getFygaroSettings,
+  validateFygaroSettings,
+  _resetFygaroSettingsCache,
+} from "@services/fygaro/webhook-server/fygaro-settings"
+
+const GOOD_DOC = {
+  processor: "Fygaro",
+  processor_fee_percent: 2.99,
+  processor_fee_fixed: 0.49,
+  flash_margin_percent: 2.0,
+  flash_margin_fixed: 0,
+  auto_credit_limit: 500,
+  minimum_topup: 10,
+  auto_credit_enabled: 1,
+}
+
+let now = 1_000_000
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  _resetFygaroSettingsCache()
+  now = 1_000_000
+  jest.spyOn(Date, "now").mockImplementation(() => now)
+  mockGetFygaroSettings.mockResolvedValue({ ...GOOD_DOC })
+})
+
+afterEach(() => {
+  ;(Date.now as jest.Mock).mockRestore?.()
+})
+
+describe("validateFygaroSettings", () => {
+  it("maps a well-formed doc to typed settings", () => {
+    expect(validateFygaroSettings({ ...GOOD_DOC })).toEqual({
+      processor: "Fygaro",
+      processorFeePercent: 2.99,
+      processorFeeFixed: 0.49,
+      flashMarginPercent: 2.0,
+      flashMarginFixed: 0,
+      autoCreditLimit: 500,
+      minimumTopup: 10,
+      autoCreditEnabled: true,
+    })
+  })
+
+  it("coerces numeric strings from ERPNext", () => {
+    const result = validateFygaroSettings({
+      ...GOOD_DOC,
+      processor_fee_percent: "2.99",
+      auto_credit_limit: "500",
+    })
+    expect(result?.processorFeePercent).toBe(2.99)
+    expect(result?.autoCreditLimit).toBe(500)
+  })
+
+  it.each([
+    ["true boolean", true, true],
+    ["numeric 1", 1, true],
+    ['string "1"', "1", true],
+    ["numeric 0", 0, false],
+    ["undefined", undefined, false],
+  ])("reads auto_credit_enabled from %s", (_label, raw, expected) => {
+    const result = validateFygaroSettings({ ...GOOD_DOC, auto_credit_enabled: raw })
+    expect(result?.autoCreditEnabled).toBe(expected)
+  })
+
+  it.each([
+    ["undefined", undefined],
+    ["a missing numeric field", { ...GOOD_DOC, processor_fee_percent: undefined }],
+    ["a non-numeric string", { ...GOOD_DOC, processor_fee_fixed: "abc" }],
+    ["a negative fee", { ...GOOD_DOC, flash_margin_percent: -1 }],
+    ["a negative limit", { ...GOOD_DOC, auto_credit_limit: -5 }],
+  ])("returns undefined for %s (garbage)", (_label, doc) => {
+    expect(validateFygaroSettings(doc as never)).toBeUndefined()
+  })
+})
+
+describe("getFygaroSettings", () => {
+  it("reads, validates, and returns settings", async () => {
+    const result = await getFygaroSettings()
+    expect(result?.processorFeePercent).toBe(2.99)
+    expect(result?.autoCreditEnabled).toBe(true)
+    expect(mockGetFygaroSettings).toHaveBeenCalledTimes(1)
+  })
+
+  it("caches within the TTL and does not re-read ERPNext", async () => {
+    await getFygaroSettings()
+    now += 30_000 // still inside the 60s window
+    await getFygaroSettings()
+    expect(mockGetFygaroSettings).toHaveBeenCalledTimes(1)
+  })
+
+  it("re-reads ERPNext after the TTL expires", async () => {
+    await getFygaroSettings()
+    now += 61_000
+    await getFygaroSettings()
+    expect(mockGetFygaroSettings).toHaveBeenCalledTimes(2)
+  })
+
+  it("falls back to undefined (record-only) when the ERPNext read fails", async () => {
+    mockGetFygaroSettings.mockResolvedValue(new Error("erpnext down"))
+    expect(await getFygaroSettings()).toBeUndefined()
+  })
+
+  it("caches the failure so an outage does not hammer ERPNext", async () => {
+    mockGetFygaroSettings.mockResolvedValue(new Error("erpnext down"))
+    await getFygaroSettings()
+    now += 30_000
+    await getFygaroSettings()
+    expect(mockGetFygaroSettings).toHaveBeenCalledTimes(1)
+  })
+
+  it("recovers after the TTL once ERPNext returns valid settings again", async () => {
+    mockGetFygaroSettings.mockResolvedValue(new Error("erpnext down"))
+    expect(await getFygaroSettings()).toBeUndefined()
+
+    now += 61_000
+    mockGetFygaroSettings.mockResolvedValue({ ...GOOD_DOC })
+    expect((await getFygaroSettings())?.processorFeePercent).toBe(2.99)
+  })
+
+  it("treats a malformed row as unavailable", async () => {
+    mockGetFygaroSettings.mockResolvedValue({ ...GOOD_DOC, processor_fee_percent: "N/A" })
+    expect(await getFygaroSettings()).toBeUndefined()
+  })
+})

--- a/test/flash/unit/services/fygaro/webhook-server/payment.spec.ts
+++ b/test/flash/unit/services/fygaro/webhook-server/payment.spec.ts
@@ -60,6 +60,12 @@ jest.mock("@services/fygaro/webhook-server/credit-topup", () => {
   }
 })
 
+// The fee math (fees.ts) runs for real; only the ERPNext-backed settings read
+// is mocked, so the gating matrix exercises the actual formula end to end.
+jest.mock("@services/fygaro/webhook-server/fygaro-settings", () => ({
+  getFygaroSettings: (...args: unknown[]) => mockGetFygaroSettings(...args),
+}))
+
 const mockLockIdempotencyKey = jest.fn()
 const mockLockPaymentIdempotencyKey = jest.fn()
 const mockFindByUsername = jest.fn()
@@ -69,6 +75,21 @@ const mockIsFygaroTopupCompleted = jest.fn()
 const mockAlertBridge = jest.fn()
 const mockNotifyOpsEvent = jest.fn()
 const mockCreditFygaroTopup = jest.fn()
+const mockGetFygaroSettings = jest.fn()
+
+// Canonical operator settings: 2.99% + $0.49 processor, 2.0% Flash margin,
+// $500 auto-credit limit, auto-credit on. For a $10.00 top-up this yields a
+// $0.79 processor fee, a $0.20 Flash fee, and $9.01 (901¢) net credited.
+const DEFAULT_SETTINGS = {
+  processor: "Fygaro",
+  processorFeePercent: 2.99,
+  processorFeeFixed: 0.49,
+  flashMarginPercent: 2.0,
+  flashMarginFixed: 0,
+  autoCreditLimit: 500,
+  minimumTopup: 10,
+  autoCreditEnabled: true,
+}
 
 import { ResourceAttemptsLockServiceError } from "@domain/lock"
 
@@ -112,6 +133,7 @@ beforeEach(() => {
   mockWriteFygaroTopup.mockResolvedValue(true)
   mockCompleteFygaroTopup.mockResolvedValue(true)
   mockCreditFygaroTopup.mockResolvedValue({ walletId: WALLET_ID, status: "success" })
+  mockGetFygaroSettings.mockResolvedValue({ ...DEFAULT_SETTINGS })
 })
 
 describe("fygaro paymentHandler", () => {
@@ -215,14 +237,15 @@ describe("fygaro paymentHandler", () => {
       mockFygaroConfig.credit = { enabled: true }
     })
 
-    it("credits the account in cents and promotes the audit row to Completed", async () => {
+    it("credits the NET (not gross) and promotes the audit row with the fee breakdown", async () => {
       const res = makeRes()
 
       await paymentHandler(makeReq(VALID_BODY), res)
 
+      // $10.00 gross -> $0.79 processor + $0.20 flash -> $9.01 (901¢) net
       expect(mockCreditFygaroTopup).toHaveBeenCalledWith({
         recipientAccountId: ACCOUNT_ID,
-        amountCents: 1000,
+        amountCents: 901,
         transactionId: VALID_BODY.transactionId,
       })
       expect(mockCompleteFygaroTopup).toHaveBeenCalledWith(
@@ -230,6 +253,10 @@ describe("fygaro paymentHandler", () => {
           transactionId: VALID_BODY.transactionId,
           accountId: ACCOUNT_ID,
           walletId: WALLET_ID,
+          initialAmount: "10.00",
+          processorFee: "0.79",
+          flashFee: "0.20",
+          finalAmount: "9.01",
         }),
       )
       expect(mockNotifyOpsEvent).toHaveBeenCalledWith(
@@ -321,7 +348,94 @@ describe("fygaro paymentHandler", () => {
       expect(mockAlertBridge).toHaveBeenCalledWith(
         expect.objectContaining({ severity: "warning" }),
       )
+      expect(mockNotifyOpsEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          phase: "fygaro-recorded",
+          meta: expect.objectContaining({ reason: "non-usd" }),
+        }),
+      )
       expect(res.json).toHaveBeenCalledWith({ status: "recorded", credited: false })
+    })
+
+    // Gating matrix: each failing gate records-only and fires exactly one
+    // reason-named ops alert, never crediting.
+    it.each([
+      [
+        "settings-unavailable",
+        (body: Record<string, unknown>) => body,
+        () => mockGetFygaroSettings.mockResolvedValue(undefined),
+      ],
+      [
+        "auto-credit-disabled",
+        (body: Record<string, unknown>) => body,
+        () =>
+          mockGetFygaroSettings.mockResolvedValue({
+            ...DEFAULT_SETTINGS,
+            autoCreditEnabled: false,
+          }),
+      ],
+      [
+        "over-limit",
+        (body: Record<string, unknown>) => ({ ...body, amount: "500.01" }),
+        () => undefined,
+      ],
+      [
+        "non-positive-net",
+        (body: Record<string, unknown>) => ({ ...body, amount: "0.10" }),
+        () => undefined,
+      ],
+    ])(
+      "records-only and alerts %s without crediting",
+      async (reason, mutateBody, arrange) => {
+        arrange()
+        const res = makeRes()
+
+        await paymentHandler(makeReq(mutateBody(VALID_BODY)), res)
+
+        expect(mockCreditFygaroTopup).not.toHaveBeenCalled()
+        expect(mockCompleteFygaroTopup).not.toHaveBeenCalled()
+        expect(mockAlertBridge).toHaveBeenCalledTimes(1)
+        expect(mockAlertBridge).toHaveBeenCalledWith(
+          expect.objectContaining({
+            severity: "warning",
+            context: expect.objectContaining({ reason }),
+          }),
+        )
+        expect(mockNotifyOpsEvent).toHaveBeenCalledWith(
+          expect.objectContaining({
+            phase: "fygaro-recorded",
+            status: "pending",
+            meta: expect.objectContaining({ reason }),
+          }),
+        )
+        expect(res.json).toHaveBeenCalledWith({ status: "recorded", credited: false })
+      },
+    )
+
+    it("does not read Fygaro Settings when credit is disabled at deploy level", async () => {
+      mockFygaroConfig.credit = { enabled: false }
+      const res = makeRes()
+
+      await paymentHandler(makeReq(VALID_BODY), res)
+
+      expect(mockGetFygaroSettings).not.toHaveBeenCalled()
+      expect(mockAlertBridge).not.toHaveBeenCalled()
+      expect(mockNotifyOpsEvent).toHaveBeenCalledWith(
+        expect.objectContaining({ phase: "fygaro-recorded" }),
+      )
+      expect(res.json).toHaveBeenCalledWith({ status: "recorded", credited: false })
+    })
+
+    it("credits a payment sitting exactly at the auto-credit limit", async () => {
+      const res = makeRes()
+
+      await paymentHandler(makeReq({ ...VALID_BODY, amount: "500.00" }), res)
+
+      // $500 gross -> $15.44 processor + $10.00 flash -> $474.56 (47456¢) net
+      expect(mockCreditFygaroTopup).toHaveBeenCalledWith(
+        expect.objectContaining({ amountCents: 47456 }),
+      )
+      expect(res.json).toHaveBeenCalledWith({ status: "success", credited: true })
     })
 
     it("still reports success when only the ERPNext promotion fails after a credit", async () => {

--- a/test/flash/unit/services/fygaro/webhook-server/payment.spec.ts
+++ b/test/flash/unit/services/fygaro/webhook-server/payment.spec.ts
@@ -146,6 +146,21 @@ describe("fygaro paymentHandler", () => {
     expect(mockWriteFygaroTopup).not.toHaveBeenCalled()
   })
 
+  it("rejects a non-numeric amount with 400 and never records, credits, or alerts", async () => {
+    const res = makeRes()
+
+    await paymentHandler(makeReq({ ...VALID_BODY, amount: "abc" }), res)
+
+    expect(res.status).toHaveBeenCalledWith(400)
+    // "abc" -> Math.round(Number("abc") * 100) is NaN. It must be rejected up
+    // front, never reaching the audit/credit path where a NaN gross slips past
+    // every numeric gate and gets misclassified as a CRITICAL auto-credit
+    // failure that pages ops.
+    expect(mockWriteFygaroTopup).not.toHaveBeenCalled()
+    expect(mockCreditFygaroTopup).not.toHaveBeenCalled()
+    expect(mockAlertBridge).not.toHaveBeenCalled()
+  })
+
   it("records an attributed payment and reports pending when credit is disabled", async () => {
     const res = makeRes()
 
@@ -357,14 +372,11 @@ describe("fygaro paymentHandler", () => {
       expect(res.json).toHaveBeenCalledWith({ status: "recorded", credited: false })
     })
 
-    // Gating matrix: each failing gate records-only and fires exactly one
-    // reason-named ops alert, never crediting.
+    // Gating matrix: each DETERMINISTIC failing gate records-only (200), fires
+    // exactly one reason-named ops alert, and never credits. `settings-
+    // unavailable` is intentionally NOT here — it is transient and returns 500
+    // (see its dedicated test below) so Fygaro retries and the read self-heals.
     it.each([
-      [
-        "settings-unavailable",
-        (body: Record<string, unknown>) => body,
-        () => mockGetFygaroSettings.mockResolvedValue(undefined),
-      ],
       [
         "auto-credit-disabled",
         (body: Record<string, unknown>) => body,
@@ -377,6 +389,12 @@ describe("fygaro paymentHandler", () => {
       [
         "over-limit",
         (body: Record<string, unknown>) => ({ ...body, amount: "500.01" }),
+        () => undefined,
+      ],
+      [
+        "under-minimum",
+        // $2.00 vs the $10 default minimum: positive net, but below the minimum.
+        (body: Record<string, unknown>) => ({ ...body, amount: "2.00" }),
         () => undefined,
       ],
       [
@@ -411,6 +429,33 @@ describe("fygaro paymentHandler", () => {
         expect(res.json).toHaveBeenCalledWith({ status: "recorded", credited: false })
       },
     )
+
+    it("returns 500 for settings-unavailable so Fygaro retries (transient), without acking or spamming the feed", async () => {
+      // A brief ERPNext blip caches settings as undefined for up to 60s. That
+      // must NOT permanently downgrade the payment to manual credit: return 500
+      // so Fygaro retries and a recovered read auto-credits cleanly.
+      mockGetFygaroSettings.mockResolvedValue(undefined)
+      const res = makeRes()
+
+      await paymentHandler(makeReq(VALID_BODY), res)
+
+      expect(mockCreditFygaroTopup).not.toHaveBeenCalled()
+      expect(mockCompleteFygaroTopup).not.toHaveBeenCalled()
+      // The non-releasing dedupe lock is deliberately NOT taken here — taking it
+      // would make the very next retry ack 200 "already_processed" and defeat
+      // the self-heal.
+      expect(mockLockIdempotencyKey).not.toHaveBeenCalled()
+      // Paged via alertBridge (TTL-deduped); no ops-feed line, which cannot be
+      // deduped without the lock and would otherwise spam per retry.
+      expect(mockAlertBridge).toHaveBeenCalledWith(
+        expect.objectContaining({
+          severity: "warning",
+          context: expect.objectContaining({ reason: "settings-unavailable" }),
+        }),
+      )
+      expect(mockNotifyOpsEvent).not.toHaveBeenCalled()
+      expect(res.status).toHaveBeenCalledWith(500)
+    })
 
     it("does not read Fygaro Settings when credit is disabled at deploy level", async () => {
       mockFygaroConfig.credit = { enabled: false }


### PR DESCRIPTION
## Money flow

The Fygaro card-topup webhook credited the **full gross face value**. But Fygaro/PayPal take a processor cut off what actually settles to Flash, and Flash wants a margin — so today Flash loses money on every top-up. This PR makes the credited amount the **NET**, driven by operator-configurable fees, and stamps the fee breakdown onto the ERPNext audit row.

## Fee source — ERPNext "Fygaro Settings"

A new `ErpNext.getFygaroSettings()` reads the `Fygaro Settings` Single doctype (`processor`, `processor_fee_percent`, `processor_fee_fixed`, `flash_margin_percent`, `flash_margin_fixed`, `auto_credit_limit`, `minimum_topup`, `auto_credit_enabled`). It is memoised for ~60s in `fygaro-settings.ts` so the webhook never hammers ERPNext per payment. A failed read, a missing row, or a malformed row all resolve to **unavailable** — never "assume zero fees" — and the failure is cached so an outage degrades to record-only without a fetch storm.

## The formula (integer cents; each fee rounded to the nearest cent)

```
gross_cents         = round(amount * 100)
processor_fee_cents = round(gross_cents * processor_fee_percent/100) + round(processor_fee_fixed * 100)
flash_fee_cents     = round(gross_cents * flash_margin_percent/100)  + round(flash_margin_fixed * 100)
net_cents           = gross_cents - processor_fee_cents - flash_fee_cents
```

`$10.00` → processor `$0.79`, flash `$0.20`, **net `$9.01`**.

## Gating

Auto-credit runs **only if all** hold:

1. `FygaroConfig.credit.enabled` — the existing yaml **deploy-level master gate** (kept as-is)
2. Fygaro Settings read succeeded **AND** `auto_credit_enabled`
3. `currency === "USD"`
4. `gross_cents ≤ auto_credit_limit * 100` (threshold on **gross**)
5. `net_cents > 0`

Otherwise → **RECORD-ONLY**: the ERPNext row stays `Fiat Received`, nothing is credited, and **one** ops alert (`notifyOpsEvent` + `alertBridge`) names the specific failing gate: `settings-unavailable` / `auto-credit-disabled` / `non-usd` / `over-limit` / `non-positive-net`. The `credit-disabled` master gate records **silently** (unchanged deploy behavior; settings aren't even read).

When it does credit: it sends `net_cents` (not gross) and populates the row — `initial_amount` = gross, `processor_fee`, `flash_fee`, `final_amount` = net credited (fields added to the `BridgeTransferRequest` model/writer; the doctype fields ship in the companion PR).

**All existing safety is preserved:** idempotency on the transaction id, Pending-means-credited, the releasing-lock + Completed-row processed-marker, and the `ResourceAttemptsLockServiceError`-vs-other-error distinction.

## GraphQL — `globals.fygaroTopup`

New **nullable** public field so the mobile app can compute "you'll receive $X" locally:

```graphql
type FygaroTopupInfo {
  minimumAmount: Float!       # USD, from minimum_topup
  processorFeePercent: Float!
  processorFeeFixed: Float!   # USD
  flashFeePercent: Float!     # from flash_margin_percent
  flashFeeFixed: Float!       # USD, from flash_margin_fixed
}

type Globals {
  # ...
  fygaroTopup: FygaroTopupInfo   # null when settings unavailable → app falls back gracefully
}
```

Sourced from the same 60s-cached settings. SDL regenerated via `yarn write-sdl` (public schema + composed supergraph).

## Safe degradation

If ERPNext is unreachable or the settings row is malformed while credit is enabled, every payment is **recorded, not credited**, with a `settings-unavailable` ops alert — money is never credited off missing fee data, and the GraphQL field returns `null` so the app hides the estimate.

## Tests

`test/flash/unit/services/fygaro/webhook-server/`:
- **fee math** — table ($10/$1/$500/$33.33 rounding), independent per-component rounding, fixed-margin
- **gating matrix** — credits when all gates pass; record-only for each failing gate with the right alert reason; inclusive limit threshold
- **settings** — validation/coercion, 60s caching, failure fallback + failure-caching + recovery, malformed-row rejection
- **row fields** — `initial/processor_fee/flash_fee/final` populated on credit

`yarn tsc-check`, `yarn eslint-check`, and the full `yarn test:unit` (174 suites / 1487 tests) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NcEjF6SS3Ci5D4CzZqdPjb
