### PR TITLE
feat(fygaro): per-level daily top-up limits (L1 $125 / L2 $1000 / L3 $2500)

### DIFF
--- a/dev/apollo-federation/supergraph.graphql
+++ b/dev/apollo-federation/supergraph.graphql
@@ -1096,6 +1096,21 @@ type FygaroTopupInfo
   """Flash margin percentage fee (e.g. 2.0 = 2.0%)."""
   flashFeePercent: Float!
 
+  """
+  Maximum gross card top-up per rolling 24h for level-1 accounts, in USD.
+  """
+  l1DailyLimit: Float!
+
+  """
+  Maximum gross card top-up per rolling 24h for level-2 accounts, in USD.
+  """
+  l2DailyLimit: Float!
+
+  """
+  Maximum gross card top-up per rolling 24h for level-3 (Business) accounts, in USD.
+  """
+  l3DailyLimit: Float!
+
   """Minimum top-up amount, in USD."""
   minimumAmount: Float!
 

--- a/src/graphql/public/root/query/globals.ts
+++ b/src/graphql/public/root/query/globals.ts
@@ -54,6 +54,9 @@ const GlobalsQuery = GT.Field({
             processorFeeFixed: fygaroSettings.processorFeeFixed,
             flashFeePercent: fygaroSettings.flashMarginPercent,
             flashFeeFixed: fygaroSettings.flashMarginFixed,
+            l1DailyLimit: fygaroSettings.dailyTopupLimits[1],
+            l2DailyLimit: fygaroSettings.dailyTopupLimits[2],
+            l3DailyLimit: fygaroSettings.dailyTopupLimits[3],
           }
         : null,
     }

--- a/src/graphql/public/schema.graphql
+++ b/src/graphql/public/schema.graphql
@@ -873,6 +873,21 @@ type FygaroTopupInfo {
   """Flash margin percentage fee (e.g. 2.0 = 2.0%)."""
   flashFeePercent: Float!
 
+  """
+  Maximum gross card top-up per rolling 24h for level-1 accounts, in USD.
+  """
+  l1DailyLimit: Float!
+
+  """
+  Maximum gross card top-up per rolling 24h for level-2 accounts, in USD.
+  """
+  l2DailyLimit: Float!
+
+  """
+  Maximum gross card top-up per rolling 24h for level-3 (Business) accounts, in USD.
+  """
+  l3DailyLimit: Float!
+
   """Minimum top-up amount, in USD."""
   minimumAmount: Float!
 

--- a/src/graphql/public/types/object/fygaro-topup-info.ts
+++ b/src/graphql/public/types/object/fygaro-topup-info.ts
@@ -31,6 +31,21 @@ const FygaroTopupInfo = GT.Object({
       type: GT.NonNull(GT.Float),
       description: "Flash margin fixed fee, in USD.",
     },
+    l1DailyLimit: {
+      type: GT.NonNull(GT.Float),
+      description:
+        "Maximum gross card top-up per rolling 24h for level-1 accounts, in USD.",
+    },
+    l2DailyLimit: {
+      type: GT.NonNull(GT.Float),
+      description:
+        "Maximum gross card top-up per rolling 24h for level-2 accounts, in USD.",
+    },
+    l3DailyLimit: {
+      type: GT.NonNull(GT.Float),
+      description:
+        "Maximum gross card top-up per rolling 24h for level-3 (Business) accounts, in USD.",
+    },
   }),
 })
 

--- a/src/services/frappe/BridgeTransferRequestWriter.ts
+++ b/src/services/frappe/BridgeTransferRequestWriter.ts
@@ -1,6 +1,9 @@
 import ErpNext from "@services/frappe/ErpNext"
 import { baseLogger } from "@services/logger"
-import { BridgeTransferRequestUpsertError } from "@services/frappe/errors"
+import {
+  BridgeTransferRequestUpsertError,
+  FygaroTopupHistoryQueryError,
+} from "@services/frappe/errors"
 
 import {
   BridgeTransferRequest,
@@ -241,6 +244,28 @@ export const writeFygaroTopupRequest = async ({
       rawPayload,
     }),
   )
+}
+
+// Gross cents this account was charged via Fygaro over the trailing 24h,
+// excluding the given transaction's own audit row (which is written before the
+// credit gate runs). Feeds the per-level daily top-up cap. An unconfigured
+// ERPNext client is an error, not zero — the gate must fail closed rather
+// than treat a missing history as a clean slate.
+export const sumFygaroTopupGrossCentsLast24h = async ({
+  accountId,
+  excludeTransactionId,
+}: {
+  accountId: AccountId | string
+  excludeTransactionId: string
+}): Promise<number | FygaroTopupHistoryQueryError> => {
+  if (!ErpNext?.sumFygaroTopupGrossCentsSince) {
+    return new FygaroTopupHistoryQueryError("ERPNext client is not configured")
+  }
+  return ErpNext.sumFygaroTopupGrossCentsSince({
+    accountId: String(accountId),
+    since: new Date(Date.now() - 24 * 60 * 60 * 1000),
+    excludeRequestId: `fygaro:${excludeTransactionId}`,
+  })
 }
 
 // Whether this Fygaro payment was already fully processed (its audit row

--- a/src/services/frappe/ErpNext.ts
+++ b/src/services/frappe/ErpNext.ts
@@ -414,11 +414,19 @@ export class ErpNext {
 
   // Sums the GROSS USD cents of one account's Fygaro card top-ups over a
   // trailing window, for the per-level daily top-up limit gate. Counts every
-  // captured payment (Fiat Received or Completed — i.e. the card was charged,
-  // whether or not it has been credited yet), excludes Cancelled rows, and
-  // excludes the current delivery's own audit row (written before the gate
-  // runs) via excludeRequestId. Any read/shape/parse problem is an error, not
-  // zero — under-counting the window would quietly defeat the cap.
+  // captured USD payment (Fiat Received or Completed — i.e. the card was
+  // charged, whether or not it has been credited yet), excludes Cancelled
+  // rows, and excludes the current delivery's own audit row (written before
+  // the gate runs) via excludeRequestId. Non-USD rows are excluded because
+  // their `amount` is the raw foreign-currency figure — a 5,000 JMD payment
+  // counted at face value would look like $5,000 of prior gross and lock the
+  // account out of auto-credit for a day. The window filters on
+  // `last_seen_at`, which this code writes in UTC on every upsert (a
+  // re-delivery bump only widens the window — fails closed), NOT Frappe's
+  // `creation`, which is stored naive in the ERP site's configured time zone:
+  // comparing that against a UTC-rendered cutoff would silently shrink the
+  // window by the site's UTC offset. Any read/shape/parse problem is an
+  // error, not zero — under-counting the window would quietly defeat the cap.
   async sumFygaroTopupGrossCentsSince({
     accountId,
     since,
@@ -438,6 +446,7 @@ export class ErpNext {
           BridgeTransferRequestTransactionType.Topup,
         ],
         [BridgeTransferRequest.doctype, "account_id", "=", accountId],
+        [BridgeTransferRequest.doctype, "currency", "=", "USD"],
         [
           BridgeTransferRequest.doctype,
           "status",
@@ -449,7 +458,7 @@ export class ErpNext {
         ],
         [
           BridgeTransferRequest.doctype,
-          "creation",
+          "last_seen_at",
           ">=",
           toFrappeDatetime(since.toISOString()),
         ],
@@ -468,7 +477,18 @@ export class ErpNext {
         return new FygaroTopupHistoryQueryError("No data in top-up history response")
       }
       let sumCents = 0
-      for (const row of rows as { request_id?: string; amount?: number | string }[]) {
+      for (const row of rows as {
+        request_id?: string
+        amount?: number | string | null
+      }[]) {
+        // Frappe's list API returns null for unset fields, and Number(null)
+        // is 0 — a null amount must fail closed like any other unparseable
+        // row, not silently contribute nothing to the sum.
+        if (row.amount == null) {
+          return new FygaroTopupHistoryQueryError(
+            `Missing amount on ${row.request_id ?? "<unknown row>"}`,
+          )
+        }
         const cents = Math.round(Number(row.amount) * 100)
         if (!Number.isFinite(cents)) {
           return new FygaroTopupHistoryQueryError(

--- a/src/services/frappe/ErpNext.ts
+++ b/src/services/frappe/ErpNext.ts
@@ -482,7 +482,7 @@ export class ErpNext {
         amount?: number | string | null
       }[]) {
         // Frappe's list API returns null for unset fields, and Number(null)
-        // is 0 — a null amount must fail closed like any other unparseable
+        // is 0 — a null amount must fail closed like any other unparsable
         // row, not silently contribute nothing to the sum.
         if (row.amount == null) {
           return new FygaroTopupHistoryQueryError(

--- a/src/services/frappe/ErpNext.ts
+++ b/src/services/frappe/ErpNext.ts
@@ -15,6 +15,7 @@ import {
   CashoutSubmitError,
   ExchangeRateQueryError,
   FygaroSettingsQueryError,
+  FygaroTopupHistoryQueryError,
   JournalEntryDeleteError,
   SetDocTypeValueError,
   UpgradeRequestCreateError,
@@ -100,6 +101,9 @@ export type FygaroSettingsDoc = {
   auto_credit_limit?: number | string
   minimum_topup?: number | string
   auto_credit_enabled?: number | boolean | string
+  l1_daily_limit?: number | string
+  l2_daily_limit?: number | string
+  l3_daily_limit?: number | string
 }
 
 export class ErpNext {
@@ -405,6 +409,86 @@ export class ErpNext {
         attributes: { "erpnext.exception": responseData?.exception },
       })
       return new FygaroSettingsQueryError(err)
+    }
+  }
+
+  // Sums the GROSS USD cents of one account's Fygaro card top-ups over a
+  // trailing window, for the per-level daily top-up limit gate. Counts every
+  // captured payment (Fiat Received or Completed — i.e. the card was charged,
+  // whether or not it has been credited yet), excludes Cancelled rows, and
+  // excludes the current delivery's own audit row (written before the gate
+  // runs) via excludeRequestId. Any read/shape/parse problem is an error, not
+  // zero — under-counting the window would quietly defeat the cap.
+  async sumFygaroTopupGrossCentsSince({
+    accountId,
+    since,
+    excludeRequestId,
+  }: {
+    accountId: string
+    since: Date
+    excludeRequestId: string
+  }): Promise<number | FygaroTopupHistoryQueryError> {
+    try {
+      const filters = JSON.stringify([
+        [BridgeTransferRequest.doctype, "provider", "=", "Fygaro"],
+        [
+          BridgeTransferRequest.doctype,
+          "transaction_type",
+          "=",
+          BridgeTransferRequestTransactionType.Topup,
+        ],
+        [BridgeTransferRequest.doctype, "account_id", "=", accountId],
+        [
+          BridgeTransferRequest.doctype,
+          "status",
+          "in",
+          [
+            BridgeTransferRequestStatus.FiatReceived,
+            BridgeTransferRequestStatus.Completed,
+          ],
+        ],
+        [
+          BridgeTransferRequest.doctype,
+          "creation",
+          ">=",
+          toFrappeDatetime(since.toISOString()),
+        ],
+        [BridgeTransferRequest.doctype, "request_id", "!=", excludeRequestId],
+      ])
+      const fields = JSON.stringify(["request_id", "amount"])
+      const resp = await axios.get(
+        `${this.url}/api/resource/${encodeURIComponent(BridgeTransferRequest.doctype)}`,
+        {
+          params: { filters, fields, limit_page_length: 0 },
+          headers: this.headers,
+        },
+      )
+      const rows = resp.data?.data
+      if (!Array.isArray(rows)) {
+        return new FygaroTopupHistoryQueryError("No data in top-up history response")
+      }
+      let sumCents = 0
+      for (const row of rows as { request_id?: string; amount?: number | string }[]) {
+        const cents = Math.round(Number(row.amount) * 100)
+        if (!Number.isFinite(cents)) {
+          return new FygaroTopupHistoryQueryError(
+            `Non-numeric amount on ${row.request_id ?? "<unknown row>"}`,
+          )
+        }
+        sumCents += cents
+      }
+      return sumCents
+    } catch (err) {
+      const responseData = isAxiosError(err) ? err.response?.data : undefined
+      baseLogger.error(
+        { err, responseData, accountId },
+        "Error summing Fygaro top-up history from ERPNext",
+      )
+      recordExceptionInCurrentSpan({
+        error: err,
+        attributes: { "erpnext.exception": responseData?.exception },
+      })
+      return new FygaroTopupHistoryQueryError(err)
     }
   }
 

--- a/src/services/frappe/errors.ts
+++ b/src/services/frappe/errors.ts
@@ -14,3 +14,4 @@ export class BankAccountUpdateRequestQueryError extends ErpNextError {}
 export class ExchangeRateQueryError extends ErpNextError {}
 export class BridgeTransferRequestUpsertError extends ErpNextError {}
 export class FygaroSettingsQueryError extends ErpNextError {}
+export class FygaroTopupHistoryQueryError extends ErpNextError {}

--- a/src/services/fygaro/webhook-server/fees.ts
+++ b/src/services/fygaro/webhook-server/fees.ts
@@ -51,12 +51,18 @@ export const computeFygaroFees = ({
 // Why a payment was NOT auto-credited. `credit-disabled` is the deploy-level
 // master gate (FygaroConfig.credit.enabled) and is handled silently; the rest
 // are runtime conditions worth an ops alert because credit IS supposed to be on.
+// `settings-unavailable` and `history-unavailable` are TRANSIENT (an ERPNext
+// blip) — the route answers 500 so the provider retries and the read
+// self-heals; every other reason is deterministic and acks 200.
 export type RecordOnlyReason =
   | "credit-disabled"
   | "settings-unavailable"
   | "auto-credit-disabled"
   | "non-usd"
   | "over-limit"
+  | "no-daily-limit-for-level"
+  | "history-unavailable"
+  | "daily-limit-exceeded"
   | "under-minimum"
   | "non-positive-net"
 
@@ -70,9 +76,17 @@ export type CreditGate =
  *   2. Fygaro Settings available AND auto_credit_enabled
  *   3. currency === "USD"
  *   4. gross <= auto_credit_limit (inclusive upper bound on GROSS)
- *   5. net > 0 (after fees)
- *   6. gross >= minimum_topup (inclusive lower bound on GROSS)
+ *   5. the account level has a configured daily limit, the trailing-24h
+ *      history read succeeded, and gross + prior-24h gross <= that limit
+ *      (inclusive: a payment landing exactly ON the cap still credits)
+ *   6. net > 0 (after fees)
+ *   7. gross >= minimum_topup (inclusive lower bound on GROSS)
  * The first failing gate names the record-only reason.
+ *
+ * The daily-limit gates count GROSS captured fiat (Fiat Received + Completed
+ * rows), not net credits: the cap answers "how much card volume may this user
+ * run per day", and gross is also the only number the client can reproduce
+ * locally to warn before charging the card.
  *
  * `under-minimum` is checked last (after the net gate) on purpose: a payment
  * below the operator minimum is a valid, positive-net, in-limit USD top-up that
@@ -87,11 +101,18 @@ export const evaluateCreditGate = ({
   currency,
   settings,
   grossCents,
+  level,
+  priorDayGrossCents,
 }: {
   creditEnabled: boolean
   currency: string
   settings: FygaroSettings | undefined
   grossCents: number
+  // The recipient account's AccountLevel (0-3).
+  level: number
+  // Gross cents this account was charged over the trailing 24h (excluding the
+  // current payment), or undefined when the history read failed.
+  priorDayGrossCents: number | undefined
 }): CreditGate => {
   if (!creditEnabled) return { credit: false, reason: "credit-disabled" }
   if (!settings) return { credit: false, reason: "settings-unavailable" }
@@ -100,6 +121,19 @@ export const evaluateCreditGate = ({
   if (currency !== "USD") return { credit: false, reason: "non-usd" }
   if (grossCents > Math.round(settings.autoCreditLimit * 100)) {
     return { credit: false, reason: "over-limit" }
+  }
+
+  const dailyLimitUsd = settings.dailyTopupLimits[level]
+  if (dailyLimitUsd === undefined) {
+    // No configured allowance for this level (level 0, or a future level the
+    // settings row does not know) — fail closed to manual review.
+    return { credit: false, reason: "no-daily-limit-for-level" }
+  }
+  if (priorDayGrossCents === undefined) {
+    return { credit: false, reason: "history-unavailable" }
+  }
+  if (grossCents + priorDayGrossCents > Math.round(dailyLimitUsd * 100)) {
+    return { credit: false, reason: "daily-limit-exceeded" }
   }
 
   const fees = computeFygaroFees({ grossCents, settings })

--- a/src/services/fygaro/webhook-server/fygaro-settings.ts
+++ b/src/services/fygaro/webhook-server/fygaro-settings.ts
@@ -24,6 +24,16 @@ export type FygaroSettings = {
   autoCreditLimit: number // USD
   minimumTopup: number // USD
   autoCreditEnabled: boolean
+  // Per-account-level daily top-up caps in GROSS USD, keyed by AccountLevel.
+  // Levels 1-3 are always present (validation rejects the row otherwise);
+  // indexing by an arbitrary level yields `number | undefined`, and levels
+  // absent here (e.g. level 0) have no top-up allowance so they fail the
+  // credit gate.
+  dailyTopupLimits: { [level: number]: number | undefined } & {
+    1: number
+    2: number
+    3: number
+  }
 }
 
 const CACHE_TTL_MS = 60_000
@@ -58,6 +68,9 @@ export const validateFygaroSettings = (
   const flashMarginFixed = toFiniteNumber(doc.flash_margin_fixed)
   const autoCreditLimit = toFiniteNumber(doc.auto_credit_limit)
   const minimumTopup = toFiniteNumber(doc.minimum_topup)
+  const l1DailyLimit = toFiniteNumber(doc.l1_daily_limit)
+  const l2DailyLimit = toFiniteNumber(doc.l2_daily_limit)
+  const l3DailyLimit = toFiniteNumber(doc.l3_daily_limit)
 
   const numbers = [
     processorFeePercent,
@@ -66,8 +79,14 @@ export const validateFygaroSettings = (
     flashMarginFixed,
     autoCreditLimit,
     minimumTopup,
+    l1DailyLimit,
+    l2DailyLimit,
+    l3DailyLimit,
   ]
   // A missing or negative fee/limit is not something we can safely credit off.
+  // The daily limits are equally load-bearing: a doctype row from before the
+  // limit fields existed (ERP not yet migrated/saved) hard-stops auto-credit
+  // rather than crediting uncapped — deploy the ERP fields first.
   if (numbers.some((n) => n === undefined || n < 0)) return undefined
 
   return {
@@ -79,6 +98,11 @@ export const validateFygaroSettings = (
     autoCreditLimit: autoCreditLimit as number,
     minimumTopup: minimumTopup as number,
     autoCreditEnabled: toBoolean(doc.auto_credit_enabled),
+    dailyTopupLimits: {
+      1: l1DailyLimit as number,
+      2: l2DailyLimit as number,
+      3: l3DailyLimit as number,
+    },
   }
 }
 

--- a/src/services/fygaro/webhook-server/routes/payment.ts
+++ b/src/services/fygaro/webhook-server/routes/payment.ts
@@ -29,6 +29,7 @@ import {
   writeFygaroTopupRequest,
   completeFygaroTopup,
   isFygaroTopupCompleted,
+  sumFygaroTopupGrossCentsLast24h,
 } from "@services/frappe/BridgeTransferRequestWriter"
 import { alertBridge, generateDedupKey } from "@services/alerts"
 import { notifyOpsEvent } from "@services/alerts/ops-events"
@@ -67,6 +68,12 @@ const RECORD_ONLY_ALERT_TITLE: Record<
     "Fygaro auto-credit disabled in settings — payment recorded, not auto-credited",
   "non-usd": "Fygaro payment in unexpected currency — not auto-credited",
   "over-limit": "Fygaro payment over the auto-credit limit — not auto-credited",
+  "no-daily-limit-for-level":
+    "Fygaro payment from an account level with no daily top-up limit — not auto-credited",
+  "history-unavailable":
+    "Fygaro top-up history unavailable — payment recorded, not auto-credited",
+  "daily-limit-exceeded":
+    "Fygaro payment exceeds the account's daily top-up limit — not auto-credited",
   "under-minimum": "Fygaro payment below the minimum top-up — not auto-credited",
   "non-positive-net": "Fygaro payment net after fees is not positive — not auto-credited",
 }
@@ -123,16 +130,16 @@ export const paymentHandler = async (req: Request, res: Response) => {
     // Attribution: customReference carries the Flash username. A blank or
     // unknown reference still gets recorded — that IS the failure mode this
     // webhook exists to surface.
-    let accountId: AccountId | undefined
+    let account: Account | undefined
     if (username) {
-      const account = await AccountsRepository().findByUsername(username as Username)
-      if (account instanceof Error) {
+      const found = await AccountsRepository().findByUsername(username as Username)
+      if (found instanceof Error) {
         baseLogger.warn(
           { transactionId, username },
           "Fygaro payment: customReference does not match any account",
         )
       } else {
-        accountId = account.id
+        account = found
       }
     }
 
@@ -140,7 +147,7 @@ export const paymentHandler = async (req: Request, res: Response) => {
       transactionId,
       amount: String(payload.amount),
       currency,
-      accountId,
+      accountId: account?.id,
       createdAt,
       rawPayload: req.body,
     })
@@ -170,7 +177,7 @@ export const paymentHandler = async (req: Request, res: Response) => {
       return res.status(500).json({ error: "Failed to persist audit row" })
     }
 
-    if (!accountId) {
+    if (!account) {
       // Dedupe re-deliveries before emitting: alertBridge is TTL-deduped but
       // the ops feed is not, so a Fygaro retry of an unattributed payment
       // would otherwise spam a feed line per delivery. Taken only after the
@@ -208,6 +215,7 @@ export const paymentHandler = async (req: Request, res: Response) => {
       })
       return res.status(200).json({ status: "recorded", attributed: false })
     }
+    const accountId = account.id
 
     // Fee-aware gate: credit the NET (gross minus processor + Flash fees), and
     // only when every gate holds. The fees/threshold/minimum/toggle live in the
@@ -218,42 +226,76 @@ export const paymentHandler = async (req: Request, res: Response) => {
     const creditEnabled = Boolean(FygaroConfig.credit?.enabled)
     const grossCents = Math.round(grossAmount * 100)
     const settings = creditEnabled ? await getFygaroSettings() : undefined
-    const gate = evaluateCreditGate({ creditEnabled, currency, settings, grossCents })
+
+    // Trailing-24h charged gross for the per-level daily cap, read only when a
+    // credit could actually happen (deploy gate on, settings readable). A
+    // failed read stays `undefined` — never coerced to 0, which would treat a
+    // history outage as a clean slate — and the gate turns it into the
+    // retryable `history-unavailable` stop.
+    let priorDayGrossCents: number | undefined
+    if (creditEnabled && settings) {
+      const priorSum = await sumFygaroTopupGrossCentsLast24h({
+        accountId,
+        excludeTransactionId: transactionId,
+      })
+      if (priorSum instanceof Error) {
+        baseLogger.warn(
+          { error: priorSum, transactionId },
+          "Failed to read Fygaro top-up history; treating as unavailable",
+        )
+      } else {
+        priorDayGrossCents = priorSum
+      }
+    }
+
+    const gate = evaluateCreditGate({
+      creditEnabled,
+      currency,
+      settings,
+      grossCents,
+      level: account.level,
+      priorDayGrossCents,
+    })
 
     if (!gate.credit) {
-      // `settings-unavailable` is TRANSIENT (an ERPNext blip, cached undefined
-      // for up to 60s) — unlike the deterministic reasons below, a retry
-      // seconds later would auto-credit cleanly. Acking 200 (record-only) would
-      // stop Fygaro retrying and permanently downgrade the payment to manual
-      // credit over a momentary outage. Return 500 so Fygaro retries and the
-      // read self-heals once ERPNext recovers; it still never credits off
-      // missing data — the retry simply re-reads settings. Deliberately do NOT
-      // take the non-releasing dedupe lock here (it would make the very next
-      // retry ack 200 "already_processed" and defeat the self-heal), and skip
-      // the ops-feed line (it can't be deduped without that lock, so per-retry
+      // `settings-unavailable` and `history-unavailable` are TRANSIENT (an
+      // ERPNext blip; settings reads are additionally cached-undefined for up
+      // to 60s) — unlike the deterministic reasons below, a retry seconds
+      // later would auto-credit cleanly. Acking 200 (record-only) would stop
+      // Fygaro retrying and permanently downgrade the payment to manual credit
+      // over a momentary outage. Return 500 so Fygaro retries and the read
+      // self-heals once ERPNext recovers; it still never credits off missing
+      // data — the retry simply re-reads. Deliberately do NOT take the
+      // non-releasing dedupe lock here (it would make the very next retry ack
+      // 200 "already_processed" and defeat the self-heal), and skip the
+      // ops-feed line (it can't be deduped without that lock, so per-retry
       // emission would spam the feed during an outage). alertBridge is
       // TTL-deduped, so a genuine sustained outage still pages without spamming.
-      if (gate.reason === "settings-unavailable") {
+      if (
+        gate.reason === "settings-unavailable" ||
+        gate.reason === "history-unavailable"
+      ) {
         baseLogger.warn(
-          { transactionId },
-          "Fygaro Settings unavailable — returning 500 so Fygaro retries and the read self-heals",
+          { transactionId, reason: gate.reason },
+          "Fygaro ERPNext read unavailable — returning 500 so Fygaro retries and the read self-heals",
         )
         alertBridge({
           dedupKey: generateDedupKey.fygaroNotCredited(transactionId),
           source: "fygaro-webhook",
           severity: "warning",
-          title: RECORD_ONLY_ALERT_TITLE["settings-unavailable"],
-          detail: `reason=settings-unavailable currency=${currency} gross=${centsToDollars(grossCents)}`,
+          title: RECORD_ONLY_ALERT_TITLE[gate.reason],
+          detail: `reason=${gate.reason} currency=${currency} gross=${centsToDollars(grossCents)}`,
           context: {
             transaction_id: transactionId,
             amount: String(payload.amount),
             reason: gate.reason,
           },
         })
-        return res.status(500).json({ error: "Fygaro Settings unavailable; will retry" })
+        return res.status(500).json({ error: "ERPNext read unavailable; will retry" })
       }
 
-      // Deterministic record-only path (non-usd, over-limit, under-minimum,
+      // Deterministic record-only path (non-usd, over-limit,
+      // no-daily-limit-for-level, daily-limit-exceeded, under-minimum,
       // non-positive-net, auto-credit-disabled, and the silent credit-disabled
       // master gate): these will never change on retry, so ack 200 and dedupe
       // with a non-releasing timelock. Nothing money-moving happens here. Taken
@@ -276,11 +318,13 @@ export const paymentHandler = async (req: Request, res: Response) => {
           source: "fygaro-webhook",
           severity: "warning",
           title: RECORD_ONLY_ALERT_TITLE[gate.reason],
-          detail: `reason=${gate.reason} currency=${currency} gross=${centsToDollars(grossCents)}`,
+          detail: `reason=${gate.reason} currency=${currency} gross=${centsToDollars(grossCents)} level=${account.level}`,
           context: {
             transaction_id: transactionId,
             amount: String(payload.amount),
             reason: gate.reason,
+            username,
+            account_level: account.level,
           },
         })
       }

--- a/src/services/fygaro/webhook-server/routes/payment.ts
+++ b/src/services/fygaro/webhook-server/routes/payment.ts
@@ -228,12 +228,17 @@ export const paymentHandler = async (req: Request, res: Response) => {
     const settings = creditEnabled ? await getFygaroSettings() : undefined
 
     // Trailing-24h charged gross for the per-level daily cap, read only when a
-    // credit could actually happen (deploy gate on, settings readable). A
-    // failed read stays `undefined` — never coerced to 0, which would treat a
-    // history outage as a clean slate — and the gate turns it into the
-    // retryable `history-unavailable` stop.
+    // credit could actually happen (deploy gate on, settings readable,
+    // auto-credit toggle on, USD). The cheaper deterministic gates come first:
+    // with the operator kill switch off or a non-USD payment, gate ordering
+    // guarantees an `auto-credit-disabled`/`non-usd` stop before the history
+    // gates are ever consulted, so skipping the ERPNext list query here can
+    // never surface a false `history-unavailable`. A failed read stays
+    // `undefined` — never coerced to 0, which would treat a history outage as
+    // a clean slate — and the gate turns it into the retryable
+    // `history-unavailable` stop.
     let priorDayGrossCents: number | undefined
-    if (creditEnabled && settings) {
+    if (creditEnabled && settings?.autoCreditEnabled && currency === "USD") {
       const priorSum = await sumFygaroTopupGrossCentsLast24h({
         accountId,
         excludeTransactionId: transactionId,

--- a/test/flash/unit/graphql/public/root/query/globals.spec.ts
+++ b/test/flash/unit/graphql/public/root/query/globals.spec.ts
@@ -18,6 +18,9 @@ type FygaroTopupField = {
   processorFeeFixed: number
   flashFeePercent: number
   flashFeeFixed: number
+  l1DailyLimit: number
+  l2DailyLimit: number
+  l3DailyLimit: number
 } | null
 
 type GlobalsResult = { fygaroTopup: FygaroTopupField }
@@ -44,6 +47,7 @@ const SETTINGS: FygaroSettings = {
   autoCreditLimit: 500,
   minimumTopup: 10,
   autoCreditEnabled: true,
+  dailyTopupLimits: { 1: 125, 2: 1000, 3: 2500 },
 }
 
 beforeEach(() => {
@@ -70,7 +74,20 @@ describe("globals query — fygaroTopup", () => {
       processorFeeFixed: SETTINGS.processorFeeFixed,
       flashFeePercent: SETTINGS.flashMarginPercent,
       flashFeeFixed: SETTINGS.flashMarginFixed,
+      l1DailyLimit: SETTINGS.dailyTopupLimits[1],
+      l2DailyLimit: SETTINGS.dailyTopupLimits[2],
+      l3DailyLimit: SETTINGS.dailyTopupLimits[3],
     })
+  })
+
+  it("maps each per-level daily limit to its own level (no swaps)", async () => {
+    mockGetFygaroSettings.mockResolvedValue({ ...SETTINGS })
+
+    const fygaroTopup = (await resolveGlobals()).fygaroTopup
+
+    expect(fygaroTopup?.l1DailyLimit).toBe(125)
+    expect(fygaroTopup?.l2DailyLimit).toBe(1000)
+    expect(fygaroTopup?.l3DailyLimit).toBe(2500)
   })
 
   it("does not transpose the processor and flash fixed/percent fees", async () => {

--- a/test/flash/unit/services/frappe/BridgeTransferRequestWriter.spec.ts
+++ b/test/flash/unit/services/frappe/BridgeTransferRequestWriter.spec.ts
@@ -2,6 +2,7 @@ jest.mock("@services/frappe/ErpNext", () => ({
   upsertBridgeTransferRequest: jest.fn(),
   findBridgeTransferRequest: jest.fn(),
   completeBridgeTopupByTxHash: jest.fn(),
+  sumFygaroTopupGrossCentsSince: jest.fn(),
 }))
 
 jest.mock("@services/logger", () => ({
@@ -12,17 +13,20 @@ import ErpNext from "@services/frappe/ErpNext"
 import { baseLogger } from "@services/logger"
 import {
   promoteBridgeDepositForCryptoReceive,
+  sumFygaroTopupGrossCentsLast24h,
   writeBridgeCashoutCompleted,
   writeBridgeCashoutFailed,
   writeBridgeCashoutPending,
   writeBridgeDepositRequest,
   writeIbexCryptoReceiveRequest,
 } from "@services/frappe/BridgeTransferRequestWriter"
+import { FygaroTopupHistoryQueryError } from "@services/frappe/errors"
 import { BridgeTransferRequestStatus } from "@services/frappe/models/BridgeTransferRequest"
 
 const upsert = ErpNext.upsertBridgeTransferRequest as jest.Mock
 const findRow = ErpNext.findBridgeTransferRequest as jest.Mock
 const completeByTxHash = ErpNext.completeBridgeTopupByTxHash as jest.Mock
+const sumSince = ErpNext.sumFygaroTopupGrossCentsSince as jest.Mock
 const lastRequestInput = () => upsert.mock.calls[0][0].input
 
 describe("BridgeTransferRequestWriter", () => {
@@ -348,6 +352,46 @@ describe("BridgeTransferRequestWriter", () => {
         sourceEventType: "bridge.withdrawal.usdt_sent",
       }),
     )
+  })
+
+  describe("sumFygaroTopupGrossCentsLast24h", () => {
+    it("queries the trailing 24h excluding the payment's own fygaro-prefixed audit row", async () => {
+      sumSince.mockResolvedValue(10_000)
+
+      const before = Date.now()
+      const result = await sumFygaroTopupGrossCentsLast24h({
+        accountId: "acct_123" as AccountId,
+        excludeTransactionId: "tx-1",
+      })
+      const after = Date.now()
+
+      expect(result).toBe(10_000)
+      expect(sumSince).toHaveBeenCalledTimes(1)
+      const { accountId, since, excludeRequestId } = sumSince.mock.calls[0][0]
+      expect(accountId).toBe("acct_123")
+      expect(excludeRequestId).toBe("fygaro:tx-1")
+      const dayMs = 24 * 60 * 60 * 1000
+      expect(since).toBeInstanceOf(Date)
+      expect(since.getTime()).toBeGreaterThanOrEqual(before - dayMs)
+      expect(since.getTime()).toBeLessThanOrEqual(after - dayMs)
+    })
+
+    it("fails closed with FygaroTopupHistoryQueryError when the ERPNext client is not configured", async () => {
+      const erpnext = ErpNext as unknown as {
+        sumFygaroTopupGrossCentsSince?: jest.Mock
+      }
+      const original = erpnext.sumFygaroTopupGrossCentsSince
+      delete erpnext.sumFygaroTopupGrossCentsSince
+      try {
+        const result = await sumFygaroTopupGrossCentsLast24h({
+          accountId: "acct_123" as AccountId,
+          excludeTransactionId: "tx-1",
+        })
+        expect(result).toBeInstanceOf(FygaroTopupHistoryQueryError)
+      } finally {
+        erpnext.sumFygaroTopupGrossCentsSince = original
+      }
+    })
   })
 
   it("writes failed Bridge transfers as failed cashout audit requests", async () => {

--- a/test/flash/unit/services/frappe/ErpNext.spec.ts
+++ b/test/flash/unit/services/frappe/ErpNext.spec.ts
@@ -389,3 +389,85 @@ describe("ErpNext.completeBridgeTopupByTxHash", () => {
     expect(result).toBeInstanceOf(Error)
   })
 })
+
+describe("ErpNext.sumFygaroTopupGrossCentsSince", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  const params = {
+    accountId: "account-1",
+    since: new Date("2026-08-13T07:00:00Z"),
+    excludeRequestId: "fygaro:tx-current",
+  }
+
+  it("sums row amounts in integer cents", async () => {
+    mockedAxios.get.mockResolvedValue({
+      data: {
+        data: [
+          { request_id: "fygaro:tx-1", amount: "25.00" },
+          { request_id: "fygaro:tx-2", amount: "10.50" },
+          // ERPNext may return numerics for Currency fields
+          { request_id: "fygaro:tx-3", amount: 0.1 },
+        ],
+      },
+    })
+
+    const result = await client.sumFygaroTopupGrossCentsSince(params)
+
+    expect(result).toBe(3560)
+  })
+
+  it("scopes the query to this account's captured Fygaro top-ups in the window, excluding the current delivery", async () => {
+    mockedAxios.get.mockResolvedValue({ data: { data: [] } })
+
+    await client.sumFygaroTopupGrossCentsSince(params)
+
+    const [url, config] = mockedAxios.get.mock.calls[0]
+    expect(url).toBe("https://erp.example/api/resource/Bridge%20Transfer%20Request")
+    const filters = JSON.parse(config.params.filters)
+    expect(filters).toEqual([
+      ["Bridge Transfer Request", "provider", "=", "Fygaro"],
+      ["Bridge Transfer Request", "transaction_type", "=", "Topup"],
+      ["Bridge Transfer Request", "account_id", "=", "account-1"],
+      ["Bridge Transfer Request", "status", "in", ["Fiat Received", "Completed"]],
+      ["Bridge Transfer Request", "creation", ">=", "2026-08-13 07:00:00"],
+      ["Bridge Transfer Request", "request_id", "!=", "fygaro:tx-current"],
+    ])
+    // limit_page_length 0 = no pagination cap; a truncated window would
+    // under-count and quietly defeat the daily cap.
+    expect(config.params.limit_page_length).toBe(0)
+  })
+
+  it("returns 0 for an empty window", async () => {
+    mockedAxios.get.mockResolvedValue({ data: { data: [] } })
+
+    expect(await client.sumFygaroTopupGrossCentsSince(params)).toBe(0)
+  })
+
+  it("fails closed (error, not zero) when the response has no data array", async () => {
+    mockedAxios.get.mockResolvedValue({ data: {} })
+
+    const result = await client.sumFygaroTopupGrossCentsSince(params)
+
+    expect(result).toBeInstanceOf(Error)
+  })
+
+  it("fails closed on a non-numeric row amount", async () => {
+    mockedAxios.get.mockResolvedValue({
+      data: { data: [{ request_id: "fygaro:tx-1", amount: "N/A" }] },
+    })
+
+    const result = await client.sumFygaroTopupGrossCentsSince(params)
+
+    expect(result).toBeInstanceOf(Error)
+  })
+
+  it("returns an error when the read fails", async () => {
+    mockedAxios.get.mockRejectedValue(new Error("erpnext down"))
+
+    const result = await client.sumFygaroTopupGrossCentsSince(params)
+
+    expect(result).toBeInstanceOf(Error)
+  })
+})

--- a/test/flash/unit/services/frappe/ErpNext.spec.ts
+++ b/test/flash/unit/services/frappe/ErpNext.spec.ts
@@ -430,8 +430,16 @@ describe("ErpNext.sumFygaroTopupGrossCentsSince", () => {
       ["Bridge Transfer Request", "provider", "=", "Fygaro"],
       ["Bridge Transfer Request", "transaction_type", "=", "Topup"],
       ["Bridge Transfer Request", "account_id", "=", "account-1"],
+      // USD only: a non-USD row carries the raw foreign-currency amount, so a
+      // 5,000 JMD payment counted at face value would read as $5,000 of prior
+      // gross and wrongly lock the account out for a day.
+      ["Bridge Transfer Request", "currency", "=", "USD"],
       ["Bridge Transfer Request", "status", "in", ["Fiat Received", "Completed"]],
-      ["Bridge Transfer Request", "creation", ">=", "2026-08-13 07:00:00"],
+      // The window must filter on last_seen_at (written in UTC by this code),
+      // NOT Frappe's `creation`, which is stored naive in the ERP site's
+      // configured time zone — comparing that against a UTC cutoff would
+      // silently shrink the 24h window by the site's UTC offset.
+      ["Bridge Transfer Request", "last_seen_at", ">=", "2026-08-13 07:00:00"],
       ["Bridge Transfer Request", "request_id", "!=", "fygaro:tx-current"],
     ])
     // limit_page_length 0 = no pagination cap; a truncated window would
@@ -456,6 +464,23 @@ describe("ErpNext.sumFygaroTopupGrossCentsSince", () => {
   it("fails closed on a non-numeric row amount", async () => {
     mockedAxios.get.mockResolvedValue({
       data: { data: [{ request_id: "fygaro:tx-1", amount: "N/A" }] },
+    })
+
+    const result = await client.sumFygaroTopupGrossCentsSince(params)
+
+    expect(result).toBeInstanceOf(Error)
+  })
+
+  it("fails closed on a null row amount instead of counting it as zero", async () => {
+    // Frappe's list API returns null for unset fields and Number(null) is 0 —
+    // a null amount must be an error, not a silent zero contribution.
+    mockedAxios.get.mockResolvedValue({
+      data: {
+        data: [
+          { request_id: "fygaro:tx-1", amount: "25.00" },
+          { request_id: "fygaro:tx-2", amount: null },
+        ],
+      },
     })
 
     const result = await client.sumFygaroTopupGrossCentsSince(params)

--- a/test/flash/unit/services/fygaro/webhook-server/fees.spec.ts
+++ b/test/flash/unit/services/fygaro/webhook-server/fees.spec.ts
@@ -13,6 +13,7 @@ const settings = (overrides: Partial<FygaroSettings> = {}): FygaroSettings => ({
   autoCreditLimit: 500,
   minimumTopup: 10,
   autoCreditEnabled: true,
+  dailyTopupLimits: { 1: 125, 2: 1000, 3: 2500 },
   ...overrides,
 })
 
@@ -73,7 +74,13 @@ describe("computeFygaroFees", () => {
 })
 
 describe("evaluateCreditGate", () => {
-  const base = { creditEnabled: true, currency: "USD", grossCents: 1000 }
+  const base = {
+    creditEnabled: true,
+    currency: "USD",
+    grossCents: 1000,
+    level: 1,
+    priorDayGrossCents: 0,
+  }
 
   it("credits with computed fees when every gate holds", () => {
     const gate = evaluateCreditGate({ ...base, settings: settings() })
@@ -117,8 +124,96 @@ describe("evaluateCreditGate", () => {
   })
 
   it("credits exactly at the auto-credit limit (inclusive threshold)", () => {
-    const gate = evaluateCreditGate({ ...base, grossCents: 50000, settings: settings() })
+    // Level 2 so the $1000 daily cap does not shadow the $500 auto-credit limit
+    // this test is pinning.
+    const gate = evaluateCreditGate({
+      ...base,
+      grossCents: 50000,
+      level: 2,
+      settings: settings(),
+    })
     expect(gate.credit).toBe(true)
+  })
+
+  it("record-only: daily-limit-exceeded when gross plus prior 24h gross tops the level cap", () => {
+    // L1 cap $125: $100 charged earlier today + $30 now = $130 > $125.
+    const gate = evaluateCreditGate({
+      ...base,
+      grossCents: 3000,
+      priorDayGrossCents: 10000,
+      settings: settings(),
+    })
+    expect(gate).toEqual({ credit: false, reason: "daily-limit-exceeded" })
+  })
+
+  it("credits a payment landing exactly ON the daily cap (inclusive)", () => {
+    // L1 cap $125: $100 earlier + $25 now = $125 exactly.
+    const gate = evaluateCreditGate({
+      ...base,
+      grossCents: 2500,
+      priorDayGrossCents: 10000,
+      settings: settings(),
+    })
+    expect(gate.credit).toBe(true)
+  })
+
+  it("uses the cap for the account's own level", () => {
+    // $130 total is over the L1 cap but comfortably inside the L2 cap.
+    const l1 = evaluateCreditGate({
+      ...base,
+      grossCents: 3000,
+      priorDayGrossCents: 10000,
+      level: 1,
+      settings: settings(),
+    })
+    const l2 = evaluateCreditGate({
+      ...base,
+      grossCents: 3000,
+      priorDayGrossCents: 10000,
+      level: 2,
+      settings: settings(),
+    })
+    expect(l1).toEqual({ credit: false, reason: "daily-limit-exceeded" })
+    expect(l2.credit).toBe(true)
+  })
+
+  it("record-only: no-daily-limit-for-level for a level with no configured cap", () => {
+    const gate = evaluateCreditGate({ ...base, level: 0, settings: settings() })
+    expect(gate).toEqual({ credit: false, reason: "no-daily-limit-for-level" })
+  })
+
+  it("record-only: history-unavailable when the trailing-24h read failed", () => {
+    const gate = evaluateCreditGate({
+      ...base,
+      priorDayGrossCents: undefined,
+      settings: settings(),
+    })
+    expect(gate).toEqual({ credit: false, reason: "history-unavailable" })
+  })
+
+  it("evaluates gates in order: over-limit wins over the daily-limit gates", () => {
+    // $500.01 gross is over BOTH the auto-credit limit and the L1 daily cap;
+    // over-limit is checked first. Also proves an over-limit payment never
+    // needs the history read (priorDayGrossCents undefined here).
+    const gate = evaluateCreditGate({
+      ...base,
+      grossCents: 50001,
+      priorDayGrossCents: undefined,
+      settings: settings(),
+    })
+    expect(gate).toEqual({ credit: false, reason: "over-limit" })
+  })
+
+  it("evaluates gates in order: daily-limit-exceeded wins over under-minimum", () => {
+    // $5 now with $125 already charged today: below the $10 minimum AND over
+    // the L1 cap — the cap (checked first) names the reason.
+    const gate = evaluateCreditGate({
+      ...base,
+      grossCents: 500,
+      priorDayGrossCents: 12500,
+      settings: settings(),
+    })
+    expect(gate).toEqual({ credit: false, reason: "daily-limit-exceeded" })
   })
 
   it("record-only: under-minimum when a positive-net payment is below the minimum", () => {

--- a/test/flash/unit/services/fygaro/webhook-server/fygaro-settings.spec.ts
+++ b/test/flash/unit/services/fygaro/webhook-server/fygaro-settings.spec.ts
@@ -24,6 +24,9 @@ const GOOD_DOC = {
   auto_credit_limit: 500,
   minimum_topup: 10,
   auto_credit_enabled: 1,
+  l1_daily_limit: 125,
+  l2_daily_limit: 1000,
+  l3_daily_limit: 2500,
 }
 
 let now = 1_000_000
@@ -51,6 +54,7 @@ describe("validateFygaroSettings", () => {
       autoCreditLimit: 500,
       minimumTopup: 10,
       autoCreditEnabled: true,
+      dailyTopupLimits: { 1: 125, 2: 1000, 3: 2500 },
     })
   })
 
@@ -59,9 +63,11 @@ describe("validateFygaroSettings", () => {
       ...GOOD_DOC,
       processor_fee_percent: "2.99",
       auto_credit_limit: "500",
+      l2_daily_limit: "1000",
     })
     expect(result?.processorFeePercent).toBe(2.99)
     expect(result?.autoCreditLimit).toBe(500)
+    expect(result?.dailyTopupLimits[2]).toBe(1000)
   })
 
   it.each([
@@ -81,6 +87,10 @@ describe("validateFygaroSettings", () => {
     ["a non-numeric string", { ...GOOD_DOC, processor_fee_fixed: "abc" }],
     ["a negative fee", { ...GOOD_DOC, flash_margin_percent: -1 }],
     ["a negative limit", { ...GOOD_DOC, auto_credit_limit: -5 }],
+    // A pre-migration doctype row without the daily-limit fields must
+    // hard-stop auto-credit, not credit uncapped.
+    ["a missing daily limit", { ...GOOD_DOC, l1_daily_limit: undefined }],
+    ["a negative daily limit", { ...GOOD_DOC, l3_daily_limit: -100 }],
   ])("returns undefined for %s (garbage)", (_label, doc) => {
     expect(validateFygaroSettings(doc as never)).toBeUndefined()
   })

--- a/test/flash/unit/services/fygaro/webhook-server/payment.spec.ts
+++ b/test/flash/unit/services/fygaro/webhook-server/payment.spec.ts
@@ -578,6 +578,50 @@ describe("fygaro paymentHandler", () => {
       expect(res.status).toHaveBeenCalledWith(500)
     })
 
+    it("does not read top-up history when auto-credit is disabled in settings", async () => {
+      // The operator kill switch fails the gate deterministically before the
+      // history gates, so the ERPNext list query is a wasted read per webhook
+      // — it must be skipped, and skipping it must still record-only on
+      // `auto-credit-disabled`, never a false transient `history-unavailable`.
+      mockGetFygaroSettings.mockResolvedValue({
+        ...DEFAULT_SETTINGS,
+        autoCreditEnabled: false,
+      })
+      const res = makeRes()
+
+      await paymentHandler(makeReq(VALID_BODY), res)
+
+      expect(mockSumFygaroLast24h).not.toHaveBeenCalled()
+      expect(mockCreditFygaroTopup).not.toHaveBeenCalled()
+      expect(mockNotifyOpsEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          phase: "fygaro-recorded",
+          meta: expect.objectContaining({ reason: "auto-credit-disabled" }),
+        }),
+      )
+      expect(res.status).toHaveBeenCalledWith(200)
+      expect(res.json).toHaveBeenCalledWith({ status: "recorded", credited: false })
+    })
+
+    it("does not read top-up history for a non-USD payment", async () => {
+      // Same ordering argument as the kill switch: `non-usd` fails the gate
+      // before the history gates, so the read would never be consumed.
+      const res = makeRes()
+
+      await paymentHandler(makeReq({ ...VALID_BODY, currency: "JMD" }), res)
+
+      expect(mockSumFygaroLast24h).not.toHaveBeenCalled()
+      expect(mockCreditFygaroTopup).not.toHaveBeenCalled()
+      expect(mockNotifyOpsEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          phase: "fygaro-recorded",
+          meta: expect.objectContaining({ reason: "non-usd" }),
+        }),
+      )
+      expect(res.status).toHaveBeenCalledWith(200)
+      expect(res.json).toHaveBeenCalledWith({ status: "recorded", credited: false })
+    })
+
     it("credits a payment sitting exactly at the auto-credit limit", async () => {
       // Level 2 so the $1000 daily cap does not shadow the $500 auto-credit
       // limit this test is pinning.

--- a/test/flash/unit/services/fygaro/webhook-server/payment.spec.ts
+++ b/test/flash/unit/services/fygaro/webhook-server/payment.spec.ts
@@ -34,6 +34,7 @@ jest.mock("@services/frappe/BridgeTransferRequestWriter", () => ({
   writeFygaroTopupRequest: (...args: unknown[]) => mockWriteFygaroTopup(...args),
   completeFygaroTopup: (...args: unknown[]) => mockCompleteFygaroTopup(...args),
   isFygaroTopupCompleted: (...args: unknown[]) => mockIsFygaroTopupCompleted(...args),
+  sumFygaroTopupGrossCentsLast24h: (...args: unknown[]) => mockSumFygaroLast24h(...args),
 }))
 
 jest.mock("@services/alerts", () => ({
@@ -81,6 +82,7 @@ const mockAlertBridge = jest.fn()
 const mockNotifyOpsEvent = jest.fn()
 const mockCreditFygaroTopup = jest.fn()
 const mockGetFygaroSettings = jest.fn()
+const mockSumFygaroLast24h = jest.fn()
 
 // Canonical operator settings: 2.99% + $0.49 processor, 2.0% Flash margin,
 // $500 auto-credit limit, auto-credit on. For a $10.00 top-up this yields a
@@ -94,6 +96,7 @@ const DEFAULT_SETTINGS = {
   autoCreditLimit: 500,
   minimumTopup: 10,
   autoCreditEnabled: true,
+  dailyTopupLimits: { 1: 125, 2: 1000, 3: 2500 },
 }
 
 import { ResourceAttemptsLockServiceError } from "@domain/lock"
@@ -134,8 +137,9 @@ beforeEach(() => {
     async (_key: unknown, fn: () => Promise<unknown>) => fn(),
   )
   mockIsFygaroTopupCompleted.mockResolvedValue(false)
-  mockFindByUsername.mockResolvedValue({ id: ACCOUNT_ID })
+  mockFindByUsername.mockResolvedValue({ id: ACCOUNT_ID, level: 1 })
   mockWriteFygaroTopup.mockResolvedValue(true)
+  mockSumFygaroLast24h.mockResolvedValue(0)
   mockCompleteFygaroTopup.mockResolvedValue(true)
   mockCreditFygaroTopup.mockResolvedValue({ walletId: WALLET_ID, status: "success" })
   mockGetFygaroSettings.mockResolvedValue({ ...DEFAULT_SETTINGS })
@@ -440,6 +444,18 @@ describe("fygaro paymentHandler", () => {
         (body: Record<string, unknown>) => ({ ...body, amount: "0.10" }),
         () => undefined,
       ],
+      [
+        "daily-limit-exceeded",
+        // $30 now on top of $100 already charged today busts the L1 $125 cap.
+        (body: Record<string, unknown>) => ({ ...body, amount: "30.00" }),
+        () => mockSumFygaroLast24h.mockResolvedValue(10000),
+      ],
+      [
+        "no-daily-limit-for-level",
+        // A level-0 account has no configured daily allowance — fail closed.
+        (body: Record<string, unknown>) => body,
+        () => mockFindByUsername.mockResolvedValue({ id: ACCOUNT_ID, level: 0 }),
+      ],
     ])(
       "records-only and alerts %s without crediting",
       async (reason, mutateBody, arrange) => {
@@ -495,13 +511,56 @@ describe("fygaro paymentHandler", () => {
       expect(res.status).toHaveBeenCalledWith(500)
     })
 
-    it("does not read Fygaro Settings when credit is disabled at deploy level", async () => {
+    it("returns 500 for history-unavailable so Fygaro retries (transient), without acking or spamming the feed", async () => {
+      // Same transient contract as settings-unavailable: a failed trailing-24h
+      // read must never be treated as a clean slate NOR permanently downgrade
+      // the payment to manual credit — 500 lets the provider retry re-read it.
+      mockSumFygaroLast24h.mockResolvedValue(new Error("erpnext down"))
+      const res = makeRes()
+
+      await paymentHandler(makeReq(VALID_BODY), res)
+
+      expect(mockCreditFygaroTopup).not.toHaveBeenCalled()
+      expect(mockCompleteFygaroTopup).not.toHaveBeenCalled()
+      expect(mockLockIdempotencyKey).not.toHaveBeenCalled()
+      expect(mockAlertBridge).toHaveBeenCalledWith(
+        expect.objectContaining({
+          severity: "warning",
+          context: expect.objectContaining({ reason: "history-unavailable" }),
+        }),
+      )
+      expect(mockNotifyOpsEvent).not.toHaveBeenCalled()
+      expect(res.status).toHaveBeenCalledWith(500)
+    })
+
+    it("credits a payment landing exactly ON the daily cap and excludes its own audit row from the sum", async () => {
+      // $100 earlier + $25 now = exactly the L1 $125 cap (inclusive).
+      mockSumFygaroLast24h.mockResolvedValue(10000)
+      const res = makeRes()
+
+      await paymentHandler(makeReq({ ...VALID_BODY, amount: "25.00" }), res)
+
+      // The trailing-24h sum must exclude THIS delivery's audit row (written
+      // before the gate) or every payment would double-count itself.
+      expect(mockSumFygaroLast24h).toHaveBeenCalledWith({
+        accountId: ACCOUNT_ID,
+        excludeTransactionId: VALID_BODY.transactionId,
+      })
+      // $25.00 gross -> $1.24 processor + $0.50 flash -> $23.26 (2326¢) net
+      expect(mockCreditFygaroTopup).toHaveBeenCalledWith(
+        expect.objectContaining({ amountCents: 2326 }),
+      )
+      expect(res.json).toHaveBeenCalledWith({ status: "success", credited: true })
+    })
+
+    it("does not read Fygaro Settings or top-up history when credit is disabled at deploy level", async () => {
       mockFygaroConfig.credit = { enabled: false }
       const res = makeRes()
 
       await paymentHandler(makeReq(VALID_BODY), res)
 
       expect(mockGetFygaroSettings).not.toHaveBeenCalled()
+      expect(mockSumFygaroLast24h).not.toHaveBeenCalled()
       expect(mockAlertBridge).not.toHaveBeenCalled()
       expect(mockNotifyOpsEvent).toHaveBeenCalledWith(
         expect.objectContaining({ phase: "fygaro-recorded" }),
@@ -509,7 +568,20 @@ describe("fygaro paymentHandler", () => {
       expect(res.json).toHaveBeenCalledWith({ status: "recorded", credited: false })
     })
 
+    it("does not read top-up history when settings are unavailable", async () => {
+      mockGetFygaroSettings.mockResolvedValue(undefined)
+      const res = makeRes()
+
+      await paymentHandler(makeReq(VALID_BODY), res)
+
+      expect(mockSumFygaroLast24h).not.toHaveBeenCalled()
+      expect(res.status).toHaveBeenCalledWith(500)
+    })
+
     it("credits a payment sitting exactly at the auto-credit limit", async () => {
+      // Level 2 so the $1000 daily cap does not shadow the $500 auto-credit
+      // limit this test is pinning.
+      mockFindByUsername.mockResolvedValue({ id: ACCOUNT_ID, level: 2 })
       const res = makeRes()
 
       await paymentHandler(makeReq({ ...VALID_BODY, amount: "500.00" }), res)


### PR DESCRIPTION
## What

Adds operator-tunable **daily gross caps per account level** to the Fygaro auto-credit gate:

| Level | Daily cap (gross USD, rolling 24h) |
|---|---|
| L1 | $125 |
| L2 | $1,000 |
| L3 (Business) | $2,500 |

- New gate in `evaluateCreditGate`, evaluated after `over-limit`: sums the account's captured Fygaro top-ups (Fiat Received + Completed, Cancelled excluded) over the trailing 24h from the ERPNext audit rows, **excluding the current delivery's own row**, and refuses auto-credit when gross + prior would exceed the level's cap (inclusive at the cap). Over-cap payments record-only with a reason-named ops alert and stay at Fiat Received for manual review.
- Unknown level (0 or future) fails closed: `no-daily-limit-for-level`.
- A failed history read is **transient** like `settings-unavailable`: 500 so Fygaro retries — never coerced to "no history".
- New `ErpNext.sumFygaroTopupGrossCentsSince` (fails closed on bad shape / non-numeric amounts, `limit_page_length: 0` so pagination can't under-count).
- Limits exposed on unauthenticated `globals.fygaroTopup` (`l1DailyLimit`/`l2DailyLimit`/`l3DailyLimit`) so the app can cap the amount BEFORE the card is charged (companion PR in flash-mobile).
- Settings validation now requires the three limit fields — a pre-migration ERPNext row hard-stops auto-credit instead of crediting uncapped.

## Deploy order (matters)

1. **frappe-flash-admin PR first** (adds `l1/l2/l3_daily_limit` to Fygaro Settings + a post-migrate patch seeding the defaults) — deploy via v-tag → `make erp`.
2. Then this PR. If flash deploys first, auto-credit drops to manual-review-only (fail closed, no mis-credits) until the ERP fields exist.

## Tests

- `fees.spec.ts`: cap exceeded / exactly-at-cap inclusive / per-level selection / no-limit-for-level / history-unavailable / gate ordering.
- `payment.spec.ts`: record-only + alert for `daily-limit-exceeded` and `no-daily-limit-for-level`; 500-retry for `history-unavailable`; own-row exclusion; history read skipped when credit disabled or settings unavailable; at-cap credit path.
- `ErpNext.spec.ts`: filter/window/exclusion contract, cents summing, fail-closed paths.
- `fygaro-settings.spec.ts` + `globals.spec.ts`: field validation and exposure.

Full unit suite: 183 suites / 1621 passed. `tsc-check` + eslint clean; public SDL + supergraph snapshots updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nt7JxbX5W9o7viKegnXJPH