### PR TITLE
fix(payments): read every IBEX status field; never invent a settled send

### DIFF
--- a/src/app/offers/ValidOffer.ts
+++ b/src/app/offers/ValidOffer.ts
@@ -9,7 +9,8 @@ import { notifyOpsEvent } from "@services/alerts/ops-events"
 import ErpNext, { CashoutId } from "@services/frappe/ErpNext"
 import { CashoutDraftError, CashoutSubmitError } from "@services/frappe/errors"
 import { baseLogger } from "@services/logger"
-import { IbexError } from "@services/ibex/errors"
+import { FailedIbexPayment, IbexError } from "@services/ibex/errors"
+import { paymentSendStatusOrPending } from "@services/ibex/payment-status"
 import { Cashout } from "@config"
 
 import { CashoutDetails, ValidationInputs } from "./types"
@@ -73,6 +74,35 @@ class ValidOffer extends Offer {
         this.notifyStepFailed("payInvoice", resp)
         return resp
       }
+
+      // A 200 from IBEX is not a settlement. The same payInvoiceV2 body that
+      // carries a successful send also carries a FAILED one, and reading only
+      // `resp instanceof IbexError` here treated both as paid — submitting a
+      // cashout in ERPNext, on the fiat-payout rail, with no lightning payment
+      // behind it. Unlike cash-wallet-cutover, this path has no
+      // balanceVerifier.verifyBalanceMove backstop, so the status field is the
+      // only check there is. See @services/ibex/payment-status.
+      const paymentStatus = paymentSendStatusOrPending(resp)
+      if (paymentStatus === PaymentSendStatus.Failure) {
+        const failure = new FailedIbexPayment(
+          `IBEX reported the cashout payment as FAILED for cashout ${cashoutId}`,
+        )
+        baseLogger.error(
+          { cashoutId, resp },
+          "IBEX reported the cashout payment as failed — not submitting the cashout",
+        )
+        this.notifyStepFailed("payInvoice", failure)
+        return failure
+      }
+      // Pending is submitted deliberately, not by omission. `pending` here means
+      // "IBEX accepted it and has not told us the outcome" — including the
+      // unreadable-response case, which paymentSendStatusOrPending reports as
+      // pending precisely so a same-key retry cannot pay twice. The cashout is
+      // an async, reconciled flow (InitiatedCashout.status is Pending by
+      // construction and ops settle the fiat leg against the draft), so holding
+      // the ERPNext submit on a payment that probably did settle would strand
+      // the user's funds in a draft nobody is watching. Refusing to submit is
+      // reserved for the one answer that is definitively negative, above.
     } else {
       baseLogger.warn({ cashoutId }, "Skipping Ibex payment (skipPayment=true)")
     }

--- a/src/app/payments/send-intraledger.ts
+++ b/src/app/payments/send-intraledger.ts
@@ -12,6 +12,7 @@ import { AccountsRepository, WalletsRepository } from "@services/mongoose"
 
 import Ibex from "@services/ibex/client"
 import { UnexpectedIbexResponse } from "@services/ibex/errors"
+import { paymentSendStatusOrPending } from "@services/ibex/payment-status"
 
 import { withPaymentIdempotency } from "./idempotency"
 
@@ -97,25 +98,11 @@ const intraledgerPaymentSendWalletId = async ({
   })
   if (payResp instanceof Error) return payResp
 
-  // https://docs.ibexmercado.com/reference/flow-1#payment-status
-  let paymentSendStatus: PaymentSendStatus
-  switch (payResp.status) {
-    case 1:
-      paymentSendStatus = PaymentSendStatus.Pending
-      break
-    case 2:
-      paymentSendStatus = PaymentSendStatus.Success
-      break
-    case 3:
-      paymentSendStatus = PaymentSendStatus.Failure
-      break
-    case 0:
-      return new UnexpectedIbexResponse("Invoice already paid")
-    default:
-      return new UnexpectedIbexResponse(
-        `StatusId (${payResp.status}) not in documentation`,
-      )
-  }
+  // Same payInvoiceV2 response, same reader as every other IBEX send path —
+  // this used to be a fourth private dialect of the status switch, and the only
+  // one reading the top-level `status` alone. See @services/ibex/payment-status
+  // for the field precedence and for why 0 is not "invoice already paid".
+  const paymentSendStatus = paymentSendStatusOrPending(payResp)
 
   // flash fork: no longer adding contact on payments
   // if (senderAccount.id !== recipientAccount.id) {

--- a/src/app/payments/send-intraledger.ts
+++ b/src/app/payments/send-intraledger.ts
@@ -102,6 +102,16 @@ const intraledgerPaymentSendWalletId = async ({
   // this used to be a fourth private dialect of the status switch, and the only
   // one reading the top-level `status` alone. See @services/ibex/payment-status
   // for the field precedence and for why 0 is not "invoice already paid".
+  //
+  // CONTRACT CHANGE (deliberate, not incidental): an unreadable payInvoiceV2
+  // response used to return `UnexpectedIbexResponse` here, which
+  // intraledger-usd-payment-send maps to `{ status: "failed" }`. It now reports
+  // `pending`, for the double-pay reason documented on
+  // paymentSendStatusOrPending — an error return is left uncached by
+  // withPaymentIdempotency, so a same-key retry could re-execute the one send
+  // whose outcome we do not know. Until flash-mobile#699 lands, the shipped
+  // client renders PENDING as a completed conversion, so this rail is
+  // fail-open on that one case; the PR body states this and sequences the two.
   const paymentSendStatus = paymentSendStatusOrPending(payResp)
 
   // flash fork: no longer adding contact on payments

--- a/src/graphql/error-map.ts
+++ b/src/graphql/error-map.ts
@@ -518,6 +518,7 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
 
     case "IbexError":
     case "UnexpectedIbexResponse":
+    case "FailedIbexPayment":
       return new IbexError(baseLogger)
     case "OfferNotFound":
       return new NotFoundError({

--- a/src/graphql/public/root/mutation/ln-invoice-payment-send.ts
+++ b/src/graphql/public/root/mutation/ln-invoice-payment-send.ts
@@ -11,6 +11,7 @@ import dedent from "dedent"
 import { PaymentSendStatus } from "@domain/bitcoin/lightning"
 import Ibex from "@services/ibex/client"
 import { IbexError, InsufficientIbexBalance } from "@services/ibex/errors"
+import { paymentSendStatusOrPending } from "@services/ibex/payment-status"
 import { withPaymentIdempotency } from "@app/payments/idempotency"
 
 const LnInvoicePaymentInput = GT.Input({
@@ -99,20 +100,7 @@ const LnInvoicePaymentSendMutation = GT.Field<
           return PayLightningInvoice
         }
 
-        let ibexStatus: PaymentSendStatus = PaymentSendStatus.Pending
-        switch (PayLightningInvoice.transaction?.payment?.status?.id) {
-          case 1:
-            ibexStatus = PaymentSendStatus.Pending
-            break
-          case 2:
-            ibexStatus = PaymentSendStatus.Success
-            break
-          case 3:
-            ibexStatus = PaymentSendStatus.Failure
-            break
-        }
-
-        return ibexStatus
+        return paymentSendStatusOrPending(PayLightningInvoice)
       },
     })
 

--- a/src/graphql/public/root/mutation/ln-noamount-usd-invoice-payment-send.ts
+++ b/src/graphql/public/root/mutation/ln-noamount-usd-invoice-payment-send.ts
@@ -11,13 +11,12 @@ import dedent from "dedent"
 import FractionalCentAmount from "@graphql/public/types/scalar/cent-amount-fraction"
 
 // FLASH FORK: import ibex dependencies
-import { PaymentSendStatus } from "@domain/bitcoin/lightning"
-
 import { usdWalletAmountFromWalletId } from "@app/wallets"
 import { resolveCashWalletMutationWalletIdForAccount } from "@app/cash-wallet-cutover"
 import Ibex from "@services/ibex/client"
 
 import { IbexError } from "@services/ibex/errors"
+import { paymentSendStatusOrPending } from "@services/ibex/payment-status"
 
 const LnNoAmountUsdInvoicePaymentInput = GT.Input({
   name: "LnNoAmountUsdInvoicePaymentInput",
@@ -126,18 +125,7 @@ const LnNoAmountUsdInvoicePaymentSendMutation = GT.Field<
       }
     }
 
-    let status: PaymentSendStatus = PaymentSendStatus.Pending
-    switch (PayLightningInvoice.transaction?.payment?.status?.id) {
-      case 1:
-        status = PaymentSendStatus.Pending
-        break
-      case 2:
-        status = PaymentSendStatus.Success
-        break
-      case 3:
-        status = PaymentSendStatus.Failure
-        break
-    }
+    const status = paymentSendStatusOrPending(PayLightningInvoice)
 
     return {
       errors: [],

--- a/src/graphql/public/root/mutation/lnurl-payment-send.ts
+++ b/src/graphql/public/root/mutation/lnurl-payment-send.ts
@@ -7,7 +7,6 @@ import {
   validateLnurlPayAmountMsat,
 } from "@app/payments/lnurl-pay"
 import { usdWalletAmountFromWalletId } from "@app/wallets"
-import { PaymentSendStatus } from "@domain/bitcoin/lightning"
 import { InvalidLnurlError } from "@domain/errors"
 import { GT } from "@graphql/index"
 import { mapAndParseErrorForGqlResponse } from "@graphql/error-map"
@@ -20,6 +19,7 @@ import WalletId from "@graphql/shared/types/scalar/wallet-id"
 import { DealerPriceService } from "@services/dealer-price"
 import Ibex from "@services/ibex/client"
 import { IbexError } from "@services/ibex/errors"
+import { paymentSendStatusOrPending } from "@services/ibex/payment-status"
 
 type LnurlPayMetadata = {
   callback: string
@@ -76,32 +76,8 @@ const paramsFromMetadata = ({
     tag: "payRequest",
   })
 
-type IbexPaymentStatus = {
-  transaction?: {
-    payment?: {
-      status?: {
-        id?: number
-      }
-      statusId?: number
-    }
-  }
-}
-
-const paymentStatusFromIbex = (payment: IbexPaymentStatus): PaymentSendStatus => {
-  switch (
-    payment.transaction?.payment?.status?.id ??
-    payment.transaction?.payment?.statusId
-  ) {
-    case 1:
-      return PaymentSendStatus.Pending
-    case 2:
-      return PaymentSendStatus.Success
-    case 3:
-      return PaymentSendStatus.Failure
-    default:
-      return PaymentSendStatus.Pending
-  }
-}
+// Status reading (including the "no recognised status" case) is shared with
+// the other IBEX send mutations: @services/ibex/payment-status.
 
 const LnurlPaymentSendMutation = GT.Field<
   null,
@@ -226,7 +202,7 @@ const LnurlPaymentSendMutation = GT.Field<
 
     return {
       errors: [],
-      status: paymentStatusFromIbex(payment).value,
+      status: paymentSendStatusOrPending(payment).value,
     }
   },
 })

--- a/src/graphql/public/root/mutation/lnurl-payment-send.ts
+++ b/src/graphql/public/root/mutation/lnurl-payment-send.ts
@@ -19,7 +19,7 @@ import WalletId from "@graphql/shared/types/scalar/wallet-id"
 import { DealerPriceService } from "@services/dealer-price"
 import Ibex from "@services/ibex/client"
 import { IbexError } from "@services/ibex/errors"
-import { paymentSendStatusOrPending } from "@services/ibex/payment-status"
+import { lnurlPaymentSendStatusOrPending } from "@services/ibex/payment-status"
 
 type LnurlPayMetadata = {
   callback: string
@@ -76,8 +76,10 @@ const paramsFromMetadata = ({
     tag: "payRequest",
   })
 
-// Status reading (including the "no recognised status" case) is shared with
-// the other IBEX send mutations: @services/ibex/payment-status.
+// Status reading (including the "no recognised status" case) lives in
+// @services/ibex/payment-status. payToLnurl gets its own reader there: its 201
+// response carries no top-level `status` and no `transaction.payment.status`
+// object, and reports settlement via `settleDateUtc` instead.
 
 const LnurlPaymentSendMutation = GT.Field<
   null,
@@ -202,7 +204,7 @@ const LnurlPaymentSendMutation = GT.Field<
 
     return {
       errors: [],
-      status: paymentSendStatusOrPending(payment).value,
+      status: lnurlPaymentSendStatusOrPending(payment).value,
     }
   },
 })

--- a/src/services/ibex/errors.ts
+++ b/src/services/ibex/errors.ts
@@ -55,14 +55,49 @@ export class CompletedInvoice extends IbexError {}
  * clients: the send resolvers record it and report the payment as still in
  * flight, the only honest reading of "we don't know yet".
  *
- * `level` is honoured by the recorder in ./payment-status (it passes
- * `level: error.level` through to the span), so a Warn-level instance records
- * at Warn. Keep it that way — a severity argument that the only caller
- * overrides is worse than no argument at all.
+ * SEVERITY: the default is **Warn**, and Warn is the honest level until a real
+ * response from either send endpoint has been captured. Neither `payInvoiceV2`
+ * nor `payToLnurl` has an observed 200/201 in this repo — the committed
+ * fixtures under test/flash/mocks/ibex/ are the vendor's openapi examples — so
+ * an unreadable response may well be a rail's ordinary shape rather than an
+ * incident, and paging on every send of that rail would be an outage, not a
+ * severity. Raise the default (or pass Critical at a specific call site) once a
+ * capture proves the payment-level fields are populated. The level is honoured
+ * by the recorder in ./payment-status, which passes `level: error.level`
+ * straight through to the span.
+ *
+ * `uncorroboratedOutcome` names a terminal outcome IBEX *claimed* in the
+ * top-level `status` field and this codebase refused to honour uncorroborated.
+ * It is what tells that same recorder how loud to be: a response that reported
+ * nothing at all is an ordinary in-flight payment and gets a span event, while
+ * one carrying an unhonoured SUCCEEDED/FAILED is a genuine field-level
+ * disagreement and gets a recorded exception (which sets the span status to
+ * ERROR). See the doc block on `recordUnconfirmed` in ./payment-status.
  */
 export class UnconfirmedIbexPayment extends IbexError {
-  constructor(message: string, level: ErrorLevel = ErrorLevel.Critical) {
+  readonly uncorroboratedOutcome?: "SUCCEEDED" | "FAILED"
+
+  constructor(
+    message: string,
+    level: ErrorLevel = ErrorLevel.Warn,
+    uncorroboratedOutcome?: "SUCCEEDED" | "FAILED",
+  ) {
     super(new UnexpectedResponseError(message), level)
+    this.uncorroboratedOutcome = uncorroboratedOutcome
+  }
+}
+
+/**
+ * IBEX answered 200/201 and the response says the payment FAILED — a definite,
+ * corroborated negative, not an unreadable one. Distinct from
+ * `UnconfirmedIbexPayment` ("we cannot tell") and from the generic `IbexError`
+ * ("the call itself errored"): this is the shape that sails through any caller
+ * which only checks `resp instanceof IbexError`, letting downstream side
+ * effects fire behind a lightning payment that never settled.
+ */
+export class FailedIbexPayment extends IbexError {
+  constructor(message: string, level: ErrorLevel = ErrorLevel.Warn) {
+    super(new IbexClientError(message), level)
   }
 }
 

--- a/src/services/ibex/errors.ts
+++ b/src/services/ibex/errors.ts
@@ -54,6 +54,11 @@ export class CompletedInvoice extends IbexError {}
  * user's wallet — is greppable and alertable on its own. Never returned to
  * clients: the send resolvers record it and report the payment as still in
  * flight, the only honest reading of "we don't know yet".
+ *
+ * `level` is honoured by the recorder in ./payment-status (it passes
+ * `level: error.level` through to the span), so a Warn-level instance records
+ * at Warn. Keep it that way — a severity argument that the only caller
+ * overrides is worse than no argument at all.
  */
 export class UnconfirmedIbexPayment extends IbexError {
   constructor(message: string, level: ErrorLevel = ErrorLevel.Critical) {

--- a/src/services/ibex/errors.ts
+++ b/src/services/ibex/errors.ts
@@ -48,6 +48,20 @@ export class InsufficientIbexBalance extends IbexError {
 export class CompletedInvoice extends IbexError {}
 
 /**
+ * IBEX accepted the request but the response carries no recognisable payment
+ * status, so we cannot say whether funds moved. Distinct from the generic
+ * UnexpectedIbexResponse so this condition — money may or may not have left a
+ * user's wallet — is greppable and alertable on its own. Never returned to
+ * clients: the send resolvers record it and report the payment as still in
+ * flight, the only honest reading of "we don't know yet".
+ */
+export class UnconfirmedIbexPayment extends IbexError {
+  constructor(message: string, level: ErrorLevel = ErrorLevel.Critical) {
+    super(new UnexpectedResponseError(message), level)
+  }
+}
+
+/**
  * Best-effort extraction of the IBEX error text from a failed call.
  * Shapes handled:
  *  - ibex-client > 3.2.0 (lnflash/ibex-client#6): ApiError carries the parsed

--- a/src/services/ibex/payment-status.ts
+++ b/src/services/ibex/payment-status.ts
@@ -70,11 +70,18 @@ export type IbexPaymentStatusResponse = {
  * The `payToLnurl` (201) shape is NOT the same dialect: per the generated
  * schema it carries no top-level `status` and no `transaction.payment.status`
  * object — only `transaction.payment.statusId`, whose documented example is 0,
- * alongside a top-level `settleDateUtc` (example 1668544241) and `hash`. Two of
- * the three fields the payInvoiceV2 reader looks at are structurally absent
- * here, so this endpoint gets its own reader below.
+ * alongside a top-level `settleDateUtc` (example 1668544241, a creation-time
+ * echo — see the reader) and `hash`. Two of the three fields the payInvoiceV2
+ * reader looks at are structurally absent here, so this endpoint gets its own
+ * reader below.
  */
 export type IbexLnurlPayStatusResponse = {
+  /**
+   * Declared because it is on the wire, NOT because it is read: the vendor's
+   * documented example populates it with the transaction's creation time on a
+   * payment that has not settled. See the reader below — it is settlement
+   * evidence for nothing.
+   */
   settleDateUtc?: unknown
   hash?: unknown
   transaction?: {
@@ -107,40 +114,43 @@ const statusFromField = (value: unknown): PaymentSendStatus | undefined => {
 }
 
 /**
- * Populated only when IBEX has actually settled the payment.
+ * Whether IBEX stamped a real settlement date on the payment.
+ *
+ * Presence is the entire question — no caller needs the instant — so this
+ * returns a boolean rather than a timestamp. The two accepted serialisations
+ * normalise to different UNITS (the integer form is epoch seconds, the ISO
+ * string parses to milliseconds), and handing that back from a helper whose
+ * name promises a timestamp is a trap for the next caller who actually uses
+ * the number.
  *
  * Two serialisations have to be accepted. The payToLnurl 201 declares the
  * top-level `settleDateUtc` as an integer epoch (example 1668544241) whose
- * `default: 0` means "not settled"; the payment-level `settleDateUtc` has no
- * declared type at all, and every payment-level date field this vendor DOES
- * declare is an ISO string (`creationDateUtc`:
- * "2023-07-06T14:51:59.389565Z"). Accepting numbers only would leave the
- * payment-level fallback dead for the string form — and, if the top-level
- * field also arrives as a string, would report every LNURL send as pending
- * forever with a Warn span per send.
+ * `default: 0` means "not settled"; the payment-level `settleDateUtc` — the
+ * only one this module reads, see the reader below — has no declared type at
+ * all, and every payment-level date field this vendor DOES declare is an ISO
+ * string (`creationDateUtc`: "2023-07-06T14:51:59.389565Z"). Accepting numbers
+ * only would leave the payment-level read dead for the string form.
  *
- * Both forms are normalised to an epoch and required to be > 0, which also
- * rejects this vendor's zero-date sentinel "0001-01-01T00:00:00Z" (it parses
- * to a large NEGATIVE epoch) the same way the integer 0 is rejected.
+ * Both forms are required to resolve to an epoch > 0, which also rejects this
+ * vendor's zero-date sentinel "0001-01-01T00:00:00Z" (it parses to a large
+ * NEGATIVE epoch) the same way the integer 0 is rejected.
  */
-const settledAt = (value: unknown): number | undefined => {
-  if (typeof value === "number")
-    return Number.isFinite(value) && value > 0 ? value : undefined
-  if (typeof value === "string" && value.trim() !== "") {
-    const trimmed = value.trim()
-    // An all-digit string is a stringified epoch, NOT a date to parse. Handing
-    // one to Date.parse inverts the check in both directions: Date.parse("0")
-    // is 946713600000 (V8 reads a bare "0" as the year 2000), so the unset
-    // sentinel would read as settled, while a real epoch like "1668544241"
-    // parses as a year and is rejected. Coerce numerically first.
-    if (/^[+-]?\d+$/.test(trimmed)) {
-      const epoch = Number(trimmed)
-      return Number.isFinite(epoch) && epoch > 0 ? epoch : undefined
-    }
-    const parsed = Date.parse(trimmed)
-    return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined
+const hasSettleDate = (value: unknown): boolean => {
+  if (typeof value === "number") return Number.isFinite(value) && value > 0
+  if (typeof value !== "string") return false
+  const trimmed = value.trim()
+  if (trimmed === "") return false
+  // An all-digit string is a stringified epoch, NOT a date to parse. Handing
+  // one to Date.parse inverts the check in both directions: Date.parse("0")
+  // is 946713600000 (V8 reads a bare "0" as the year 2000), so the unset
+  // sentinel would read as settled, while a real epoch like "1668544241"
+  // parses as a year and is rejected. Coerce numerically first.
+  if (/^[+-]?\d+$/.test(trimmed)) {
+    const epoch = Number(trimmed)
+    return Number.isFinite(epoch) && epoch > 0
   }
-  return undefined
+  const parsed = Date.parse(trimmed)
+  return Number.isFinite(parsed) && parsed > 0
 }
 
 /**
@@ -148,10 +158,27 @@ const settledAt = (value: unknown): number | undefined => {
  * payment) default to 0 — "no failure". A code above 0 is IBEX naming a reason
  * the payment failed, and is the only corroboration available for a top-level
  * `status: 3`.
+ *
+ * The declared type admits strings as well as numbers, and a string reason can
+ * be NAMED rather than numeric ("NO_ROUTE"). A named reason is IBEX naming a
+ * failure exactly as much as an integer code is, so it must not be coerced
+ * through `Number()` into a NaN that reads as "no corroboration" — that would
+ * report a definitively failed send as `pending`, which `withPaymentIdempotency`
+ * then caches for 24h under the same key.
+ *
+ * Only an explicit zero says "no failure": "", "0", "0.0", "-0". A string that
+ * parses as a number is held to the same finite-and-`> 0` rule as the number
+ * branch — a negative or infinite code is malformed, not a named reason, and
+ * malformed input must never corroborate a top-level FAILED.
  */
 const reportsFailureCode = (value: unknown): boolean => {
-  const code = typeof value === "string" ? Number(value) : value
-  return typeof code === "number" && Number.isFinite(code) && code > 0
+  if (typeof value === "string") {
+    const trimmed = value.trim()
+    if (trimmed === "") return false
+    const numeric = Number(trimmed)
+    return Number.isNaN(numeric) ? true : Number.isFinite(numeric) && numeric > 0
+  }
+  return typeof value === "number" && Number.isFinite(value) && value > 0
 }
 
 const identityAttributes = (
@@ -197,6 +224,18 @@ const identityAttributes = (
  *
  * Returns `UnconfirmedIbexPayment` when no field can settle the question, so
  * callers can record the anomaly instead of silently inventing an outcome.
+ *
+ * SEVERITY: Warn, not Critical — and deliberately the same level the LNURL
+ * reader uses, because the evidence behind both is the same: no real
+ * payInvoiceV2 200 has been captured on TEST either. The committed fixture
+ * (test/flash/mocks/ibex/pay-invoice.ts) is the vendor's openapi example copied
+ * verbatim, not an observation, and the pre-PR intraledger code read the
+ * TOP-LEVEL `status` field alone — with a `{ status: 2 }` test fixture modelling
+ * exactly that — which is direct evidence that at least one rail may populate
+ * only the field this reader treats as uncorroborated. Paging on every
+ * flash-to-flash send until a capture proves otherwise is not a severity, it is
+ * an outage. Capture one 200 on TEST, commit it as a fixture, confirm the
+ * payment-level fields are populated, then raise this to Critical.
  */
 export const paymentSendStatusFromIbex = (
   response: IbexPaymentStatusResponse | null | undefined,
@@ -225,30 +264,44 @@ export const paymentSendStatusFromIbex = (
         : `No recognised payment status in IBEX response (candidates: ${JSON.stringify(
             candidates,
           )})`,
+    ErrorLevel.Warn,
   )
 }
 
 /**
  * Map an IBEX `payToLnurl` (201) response to a payment status.
  *
- * Same payment-level precedence, but this endpoint reports settlement with a
- * `settleDateUtc` timestamp rather than a status enum — its documented
- * `statusId` example is 0 — so a populated settle date is read as settlement
- * once the status fields have come up empty. That is an explicit signal from
- * IBEX, not an inference from silence.
+ * Same payment-level precedence, and settlement is read ONLY from
+ * payment-level evidence: a recognised `transaction.payment.status.id` /
+ * `statusId`, or failing those a populated `transaction.payment.settleDateUtc`.
  *
- * `settledAt` accepts both the integer epoch the top-level field declares and
- * the ISO string every payment-level date field on this vendor is serialised
- * as, because settlement-on-settle-date is now the ONLY route by which an LNURL
- * send can report success and a type mismatch here would silently return the
- * pre-fix always-pending behaviour with a Warn span attached to every send.
+ * The TOP-LEVEL `settleDateUtc` is deliberately not read. The vendor's own
+ * documented 201 example — the only evidence anyone has for this endpoint —
+ * sets it to 1668544241, which is `transaction.createdAt`
+ * ("2022-11-15T20:30:41.960887Z") floored to the second, while every
+ * payment-level field in the SAME example says the payment has not settled:
+ * `statusId: 0`, `payment.settleDateUtc: null`, `paidMsat: 0`,
+ * `payment.hash: null`. `Ibex.payToLnurl` also registers an async settlement
+ * webhook (see client.ts), so a 201 is an acceptance, not a settlement.
+ * Reading that field would report EVERY LNURL send as `success` regardless of
+ * outcome — the "conversion successful while no funds moved" bug this module
+ * exists to close, reintroduced on the one rail whose real response has never
+ * been observed, and with the Warn-level record suppressed on that path by
+ * design. The example is committed at test/flash/mocks/ibex/pay-to-lnurl.ts
+ * and pinned by a test.
+ *
+ * The payment-level date survives because the same example corroborates it in
+ * the other direction: it is `null` on a payment that has not settled, which is
+ * what a settlement marker looks like. `hasSettleDate` accepts both the integer
+ * epoch and the ISO string every payment-level date on this vendor is
+ * serialised as, since that field has no declared type at all.
  *
  * OPEN: no real payToLnurl response has been captured on TEST yet, so the
- * field's actual runtime type is still schema-derived rather than observed.
- * Until one is captured the residual "no status, no settle date" case is raised
- * at Warn rather than Critical — we do not page on what may well be this
- * endpoint's happy path. Capture a response, confirm the type, then raise this
- * to Critical.
+ * settle-date rule is still schema-derived rather than observed and the
+ * residual "no status, no settle date" case — the documented example's own
+ * shape — is raised at Warn rather than Critical: we do not page on what may
+ * well be this endpoint's happy path. Capture a response, commit it beside the
+ * example fixture, then confirm both the rule and the severity.
  */
 export const paymentSendStatusFromIbexLnurlPay = (
   response: IbexLnurlPayStatusResponse | null | undefined,
@@ -258,13 +311,11 @@ export const paymentSendStatusFromIbexLnurlPay = (
     statusFromField(payment?.status?.id) ?? statusFromField(payment?.statusId)
   if (paymentLevel !== undefined) return paymentLevel
 
-  const settleDateUtc =
-    settledAt(response?.settleDateUtc) ?? settledAt(payment?.settleDateUtc)
-  if (settleDateUtc !== undefined) return PaymentSendStatus.Success
+  if (hasSettleDate(payment?.settleDateUtc)) return PaymentSendStatus.Success
 
   return new UnconfirmedIbexPayment(
-    `No recognised payment status and no settle date in IBEX payToLnurl response (candidates: ${JSON.stringify(
-      [payment?.status?.id, payment?.statusId, response?.settleDateUtc],
+    `No recognised payment status and no payment-level settle date in IBEX payToLnurl response (candidates: ${JSON.stringify(
+      [payment?.status?.id, payment?.statusId, payment?.settleDateUtc],
     )})`,
     ErrorLevel.Warn,
   )
@@ -276,9 +327,11 @@ const recordUnconfirmed = (
 ): void => {
   recordExceptionInCurrentSpan({
     error,
-    // The error carries its own severity — the payInvoiceV2 reader raises
-    // Critical, the LNURL one Warn. Hardcoding a level here would make that
-    // constructor argument silently dead.
+    // The error carries its own severity. Both readers currently raise Warn —
+    // neither endpoint has a captured response to justify paging on an
+    // unreadable one — but the level travels on the error so raising either
+    // reader (once a capture lands) needs no change here. Hardcoding a level
+    // would make that constructor argument silently dead.
     level: error.level,
     fallbackMsg: "IBEX payment response carried no recognised status",
     // Without these an operator woken by "money may or may not have moved" has

--- a/src/services/ibex/payment-status.ts
+++ b/src/services/ibex/payment-status.ts
@@ -127,7 +127,17 @@ const settledAt = (value: unknown): number | undefined => {
   if (typeof value === "number")
     return Number.isFinite(value) && value > 0 ? value : undefined
   if (typeof value === "string" && value.trim() !== "") {
-    const parsed = Date.parse(value)
+    const trimmed = value.trim()
+    // An all-digit string is a stringified epoch, NOT a date to parse. Handing
+    // one to Date.parse inverts the check in both directions: Date.parse("0")
+    // is 946713600000 (V8 reads a bare "0" as the year 2000), so the unset
+    // sentinel would read as settled, while a real epoch like "1668544241"
+    // parses as a year and is rejected. Coerce numerically first.
+    if (/^[+-]?\d+$/.test(trimmed)) {
+      const epoch = Number(trimmed)
+      return Number.isFinite(epoch) && epoch > 0 ? epoch : undefined
+    }
+    const parsed = Date.parse(trimmed)
     return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined
   }
   return undefined

--- a/src/services/ibex/payment-status.ts
+++ b/src/services/ibex/payment-status.ts
@@ -4,50 +4,86 @@ import { recordExceptionInCurrentSpan } from "@services/tracing"
 
 import { UnconfirmedIbexPayment } from "./errors"
 
-// IBEX's pay-invoice response reports the payment state in up to three places
-// (see the generated schema for `PayInvoiceV2`): a top-level `status`, and on
-// the transaction's payment both `statusId` and a nested `status.id`. Which
-// ones are populated varies by response, and unset integer fields arrive as 0
-// rather than being omitted — so we take the first RECOGNISED id rather than
-// the first present one. Reading only `status.id`, or `??`-chaining fields
-// that can legitimately be 0, can miss a status IBEX did report.
+/**
+ * IBEX's payment status ids, from the vendor's own table:
+ *   https://docs.poweredbyibex.io/reference/flow-1#payment-status
+ *   (was docs.ibexmercado.com/reference/flow-1#payment-status before the 301)
+ *
+ *   0  UNKNOWN    "Unknown state"
+ *   1  IN_FLIGHT  "Payment is still in flight."
+ *   2  SUCCEEDED  "Payment completed successfully."
+ *   3  FAILED     "Payment failed to settle"
+ *
+ * 0 is a real, documented id — but it reports no outcome, and it is anyway
+ * indistinguishable from an unset field: every integer in the generated IBEX
+ * schema declares `default: 0`, so an omitted status deserialises to 0 too.
+ * Either way 0 says nothing about whether money moved, which is why it is
+ * deliberately absent from `RECOGNISED_IDS`: a 0 in the first field we look at
+ * must not mask a real status reported further down the same response.
+ *
+ * (An earlier reading in send-intraledger mapped 0 to "Invoice already paid".
+ * That was wrong against the table above and has been removed — do not
+ * reintroduce it without a vendor doc change to cite.)
+ */
+export const IbexPaymentStatusId = {
+  Unknown: 0,
+  InFlight: 1,
+  Succeeded: 2,
+  Failed: 3,
+} as const
+
+const RECOGNISED_IDS: number[] = [
+  IbexPaymentStatusId.InFlight,
+  IbexPaymentStatusId.Succeeded,
+  IbexPaymentStatusId.Failed,
+]
+
+/**
+ * The `payInvoiceV2` shape: the payment state is reported in up to three
+ * places — a top-level `status`, and on the transaction's payment both
+ * `statusId` and a nested `status.id`. Which ones are populated varies by
+ * response, so we read them in precedence order rather than `??`-chaining
+ * fields that can legitimately be 0.
+ */
 export type IbexPaymentStatusResponse = {
   status?: number | null
   transaction?: {
+    id?: unknown
+    accountId?: unknown
     payment?: {
+      hash?: unknown
       statusId?: number | null
       status?: { id?: number | null } | null
     } | null
   } | null
 }
 
-export const IbexPaymentStatusId = {
-  InFlight: 1,
-  Succeeded: 2,
-  Failed: 3,
-} as const
-
-const recognised: number[] = Object.values(IbexPaymentStatusId)
-
 /**
- * Map an IBEX pay-invoice response to a payment status.
- *
- * Returns `UnconfirmedIbexPayment` when the response carries no recognised
- * status, so callers can record the anomaly instead of silently inventing an
- * outcome. Note what this deliberately never returns: `Success`. Only an
- * explicit "succeeded" id is reported as a settled payment.
+ * The `payToLnurl` (201) shape is NOT the same dialect: per the generated
+ * schema it carries no top-level `status` and no `transaction.payment.status`
+ * object — only `transaction.payment.statusId`, whose documented example is 0,
+ * alongside a top-level `settleDateUtc` (example 1668544241) and `hash`. Two of
+ * the three fields the payInvoiceV2 reader looks at are structurally absent
+ * here, so this endpoint gets its own reader below.
  */
-export const paymentSendStatusFromIbex = (
-  response: IbexPaymentStatusResponse | null | undefined,
-): PaymentSendStatus | UnconfirmedIbexPayment => {
-  const payment = response?.transaction?.payment
-  const candidates = [payment?.status?.id, payment?.statusId, response?.status]
+export type IbexLnurlPayStatusResponse = {
+  settleDateUtc?: unknown
+  hash?: unknown
+  transaction?: {
+    id?: unknown
+    accountId?: unknown
+    payment?: {
+      hash?: unknown
+      settleDateUtc?: unknown
+      statusId?: number | null
+      status?: { id?: number | null } | null
+    } | null
+  } | null
+}
 
-  const statusId = candidates.find(
-    (id): id is number => typeof id === "number" && recognised.includes(id),
-  )
-
-  switch (statusId) {
+const statusFromField = (value: unknown): PaymentSendStatus | undefined => {
+  if (typeof value !== "number" || !RECOGNISED_IDS.includes(value)) return undefined
+  switch (value) {
     case IbexPaymentStatusId.InFlight:
       return PaymentSendStatus.Pending
     case IbexPaymentStatusId.Succeeded:
@@ -55,19 +91,126 @@ export const paymentSendStatusFromIbex = (
     case IbexPaymentStatusId.Failed:
       return PaymentSendStatus.Failure
     default:
-      return new UnconfirmedIbexPayment(
-        `No recognised payment status in IBEX response (candidates: ${JSON.stringify(
-          candidates,
-        )})`,
-      )
+      return undefined
+  }
+}
+
+// Populated only when IBEX has actually settled the payment (the schema's
+// `default: 0` means "not settled" arrives as 0, and the field is null on an
+// in-flight payInvoiceV2 response).
+const settledAt = (value: unknown): number | undefined =>
+  typeof value === "number" && value > 0 ? value : undefined
+
+const identityAttributes = (
+  response: IbexPaymentStatusResponse | IbexLnurlPayStatusResponse | null | undefined,
+) => {
+  const asString = (value: unknown) =>
+    typeof value === "string" && value ? value : undefined
+  return {
+    "ibex.transaction.id": asString(response?.transaction?.id),
+    "ibex.payment.hash": asString(response?.transaction?.payment?.hash),
+    "ibex.account.id": asString(response?.transaction?.accountId),
   }
 }
 
 /**
- * What the send resolvers call: the mapping above, with an unreadable response
- * recorded and reported as still in flight.
+ * Map an IBEX `payInvoiceV2` response to a payment status.
  *
- * "Pending" is what the previous inline switch produced for these responses
+ * Precedence: the payment-level fields (`transaction.payment.status.id`, then
+ * `transaction.payment.statusId`) decide the outcome whenever either reports a
+ * recognised id. Only if BOTH are unreadable do we fall back to the top-level
+ * `status` — and then for Pending/Failure only. Settlement is never taken from
+ * the top-level field: it is the least corroborated of the three (the only one
+ * with no sibling `name` in the schema to confirm its enum), and the context it
+ * would fire in — both payment-level fields unreadable — is the worst possible
+ * one in which to upgrade a payment to "settled".
+ *
+ * Returns `UnconfirmedIbexPayment` when no field can settle the question, so
+ * callers can record the anomaly instead of silently inventing an outcome.
+ * Note what this deliberately never returns from a lone top-level 2: `Success`.
+ */
+export const paymentSendStatusFromIbex = (
+  response: IbexPaymentStatusResponse | null | undefined,
+): PaymentSendStatus | UnconfirmedIbexPayment => {
+  const payment = response?.transaction?.payment
+  const paymentLevel =
+    statusFromField(payment?.status?.id) ?? statusFromField(payment?.statusId)
+  if (paymentLevel !== undefined) return paymentLevel
+
+  const topLevel = statusFromField(response?.status)
+  if (topLevel === PaymentSendStatus.Pending || topLevel === PaymentSendStatus.Failure) {
+    return topLevel
+  }
+
+  const candidates = [payment?.status?.id, payment?.statusId, response?.status]
+  return new UnconfirmedIbexPayment(
+    topLevel === PaymentSendStatus.Success
+      ? `IBEX reported SUCCEEDED only in the top-level status field, with no payment-level corroboration (candidates: ${JSON.stringify(
+          candidates,
+        )})`
+      : `No recognised payment status in IBEX response (candidates: ${JSON.stringify(
+          candidates,
+        )})`,
+  )
+}
+
+/**
+ * Map an IBEX `payToLnurl` (201) response to a payment status.
+ *
+ * Same payment-level precedence, but this endpoint reports settlement with a
+ * `settleDateUtc` timestamp rather than a status enum — its documented
+ * `statusId` example is 0 — so a populated settle date is read as settlement
+ * once the status fields have come up empty. That is an explicit signal from
+ * IBEX, not an inference from silence.
+ *
+ * The residual "no status, no settle date" case is raised at Warn rather than
+ * Critical: no real payToLnurl response has been captured on TEST yet, so we do
+ * not page on what may well be this endpoint's happy path. Raise it to Critical
+ * once a captured response proves the field is populated in normal operation.
+ */
+export const paymentSendStatusFromIbexLnurlPay = (
+  response: IbexLnurlPayStatusResponse | null | undefined,
+): PaymentSendStatus | UnconfirmedIbexPayment => {
+  const payment = response?.transaction?.payment
+  const paymentLevel =
+    statusFromField(payment?.status?.id) ?? statusFromField(payment?.statusId)
+  if (paymentLevel !== undefined) return paymentLevel
+
+  const settleDateUtc =
+    settledAt(response?.settleDateUtc) ?? settledAt(payment?.settleDateUtc)
+  if (settleDateUtc !== undefined) return PaymentSendStatus.Success
+
+  return new UnconfirmedIbexPayment(
+    `No recognised payment status and no settle date in IBEX payToLnurl response (candidates: ${JSON.stringify(
+      [payment?.status?.id, payment?.statusId, response?.settleDateUtc],
+    )})`,
+    ErrorLevel.Warn,
+  )
+}
+
+const recordUnconfirmed = (
+  error: UnconfirmedIbexPayment,
+  response: IbexPaymentStatusResponse | IbexLnurlPayStatusResponse | null | undefined,
+): void => {
+  recordExceptionInCurrentSpan({
+    error,
+    // The error carries its own severity — the payInvoiceV2 reader raises
+    // Critical, the LNURL one Warn. Hardcoding a level here would make that
+    // constructor argument silently dead.
+    level: error.level,
+    fallbackMsg: "IBEX payment response carried no recognised status",
+    // Without these an operator woken by "money may or may not have moved" has
+    // to trace-hop to the child ibex-client span before they can even name the
+    // payment.
+    attributes: identityAttributes(response),
+  })
+}
+
+/**
+ * What the `payInvoiceV2` send resolvers call: the mapping above, with an
+ * unreadable response recorded and reported as still in flight.
+ *
+ * "Pending" is what the previous inline switches produced for these responses
  * too, and it is kept deliberately: `withPaymentIdempotency` caches only a
  * definitive PaymentSendStatus, so returning an error here would leave the one
  * case where we do not know whether funds moved as the one case a same-key
@@ -80,11 +223,19 @@ export const paymentSendStatusOrPending = (
 ): PaymentSendStatus => {
   const status = paymentSendStatusFromIbex(response)
   if (status instanceof UnconfirmedIbexPayment) {
-    recordExceptionInCurrentSpan({
-      error: status,
-      level: ErrorLevel.Critical,
-      fallbackMsg: "IBEX payment response carried no recognised status",
-    })
+    recordUnconfirmed(status, response)
+    return PaymentSendStatus.Pending
+  }
+  return status
+}
+
+/** The `payToLnurl` counterpart of `paymentSendStatusOrPending`. */
+export const lnurlPaymentSendStatusOrPending = (
+  response: IbexLnurlPayStatusResponse | null | undefined,
+): PaymentSendStatus => {
+  const status = paymentSendStatusFromIbexLnurlPay(response)
+  if (status instanceof UnconfirmedIbexPayment) {
+    recordUnconfirmed(status, response)
     return PaymentSendStatus.Pending
   }
   return status

--- a/src/services/ibex/payment-status.ts
+++ b/src/services/ibex/payment-status.ts
@@ -44,15 +44,23 @@ const RECOGNISED_IDS: number[] = [
  * `statusId` and a nested `status.id`. Which ones are populated varies by
  * response, so we read them in precedence order rather than `??`-chaining
  * fields that can legitimately be 0.
+ *
+ * The 200 also carries two failure codes — a top-level `failureReason` and
+ * `transaction.payment.failureId`, both integers defaulting to 0. They are the
+ * only corroboration available for a top-level `status: 3`, and that is exactly
+ * what they are used for below.
  */
 export type IbexPaymentStatusResponse = {
   status?: number | null
+  failureReason?: number | string | null
+  hash?: unknown
   transaction?: {
     id?: unknown
     accountId?: unknown
     payment?: {
       hash?: unknown
       statusId?: number | null
+      failureId?: number | string | null
       status?: { id?: number | null } | null
     } | null
   } | null
@@ -76,6 +84,9 @@ export type IbexLnurlPayStatusResponse = {
       hash?: unknown
       settleDateUtc?: unknown
       statusId?: number | null
+      // No `failureId` here on purpose: the payToLnurl 201 declares it with an
+      // EMPTY schema (it deserialises as `unknown`), so it can corroborate
+      // nothing. This reader has no top-level `status` to corroborate anyway.
       status?: { id?: number | null } | null
     } | null
   } | null
@@ -95,11 +106,43 @@ const statusFromField = (value: unknown): PaymentSendStatus | undefined => {
   }
 }
 
-// Populated only when IBEX has actually settled the payment (the schema's
-// `default: 0` means "not settled" arrives as 0, and the field is null on an
-// in-flight payInvoiceV2 response).
-const settledAt = (value: unknown): number | undefined =>
-  typeof value === "number" && value > 0 ? value : undefined
+/**
+ * Populated only when IBEX has actually settled the payment.
+ *
+ * Two serialisations have to be accepted. The payToLnurl 201 declares the
+ * top-level `settleDateUtc` as an integer epoch (example 1668544241) whose
+ * `default: 0` means "not settled"; the payment-level `settleDateUtc` has no
+ * declared type at all, and every payment-level date field this vendor DOES
+ * declare is an ISO string (`creationDateUtc`:
+ * "2023-07-06T14:51:59.389565Z"). Accepting numbers only would leave the
+ * payment-level fallback dead for the string form — and, if the top-level
+ * field also arrives as a string, would report every LNURL send as pending
+ * forever with a Warn span per send.
+ *
+ * Both forms are normalised to an epoch and required to be > 0, which also
+ * rejects this vendor's zero-date sentinel "0001-01-01T00:00:00Z" (it parses
+ * to a large NEGATIVE epoch) the same way the integer 0 is rejected.
+ */
+const settledAt = (value: unknown): number | undefined => {
+  if (typeof value === "number")
+    return Number.isFinite(value) && value > 0 ? value : undefined
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Date.parse(value)
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined
+  }
+  return undefined
+}
+
+/**
+ * IBEX's failure codes (`failureReason` at the top level, `failureId` on the
+ * payment) default to 0 — "no failure". A code above 0 is IBEX naming a reason
+ * the payment failed, and is the only corroboration available for a top-level
+ * `status: 3`.
+ */
+const reportsFailureCode = (value: unknown): boolean => {
+  const code = typeof value === "string" ? Number(value) : value
+  return typeof code === "number" && Number.isFinite(code) && code > 0
+}
 
 const identityAttributes = (
   response: IbexPaymentStatusResponse | IbexLnurlPayStatusResponse | null | undefined,
@@ -108,7 +151,13 @@ const identityAttributes = (
     typeof value === "string" && value ? value : undefined
   return {
     "ibex.transaction.id": asString(response?.transaction?.id),
-    "ibex.payment.hash": asString(response?.transaction?.payment?.hash),
+    // payInvoiceV2 puts the payment hash on `transaction.payment.hash`;
+    // payToLnurl leaves that field's schema empty and carries the hash at the
+    // TOP level instead. Reading only the first shape hands an operator paged
+    // on an unreadable LNURL response every identifier EXCEPT the one that
+    // names the payment.
+    "ibex.payment.hash":
+      asString(response?.transaction?.payment?.hash) ?? asString(response?.hash),
     "ibex.account.id": asString(response?.transaction?.accountId),
   }
 }
@@ -119,15 +168,25 @@ const identityAttributes = (
  * Precedence: the payment-level fields (`transaction.payment.status.id`, then
  * `transaction.payment.statusId`) decide the outcome whenever either reports a
  * recognised id. Only if BOTH are unreadable do we fall back to the top-level
- * `status` — and then for Pending/Failure only. Settlement is never taken from
- * the top-level field: it is the least corroborated of the three (the only one
- * with no sibling `name` in the schema to confirm its enum), and the context it
- * would fire in — both payment-level fields unreadable — is the worst possible
- * one in which to upgrade a payment to "settled".
+ * `status`, which is the least corroborated of the three (the only one with no
+ * sibling `name` in the schema to confirm its enum) and is only ever read in
+ * the anomalous context where the payment-level fields said nothing. That is
+ * the worst possible place to invent a terminal outcome, in EITHER direction:
+ *
+ *  - Never `Success` from a lone top-level 2. Inventing a settled send is the
+ *    headline bug this module exists to close.
+ *  - Never `Failure` from a lone top-level 3 either. Telling a user "failed"
+ *    for a payment IBEX may in fact have made sends them back to retry with a
+ *    fresh idempotency key — the double-pay hole `withPaymentIdempotency`
+ *    (#478) exists to close, and the same hazard the Pending choice in
+ *    `paymentSendStatusOrPending` is argued from. A top-level 3 is therefore
+ *    accepted only when IBEX also names a failure code (`failureReason` or
+ *    `transaction.payment.failureId` > 0); uncorroborated, it is unconfirmed.
+ *  - Pending needs no gate: it is the same outcome the unconfirmed path
+ *    reports anyway, so reading it commits to nothing.
  *
  * Returns `UnconfirmedIbexPayment` when no field can settle the question, so
  * callers can record the anomaly instead of silently inventing an outcome.
- * Note what this deliberately never returns from a lone top-level 2: `Success`.
  */
 export const paymentSendStatusFromIbex = (
   response: IbexPaymentStatusResponse | null | undefined,
@@ -138,19 +197,24 @@ export const paymentSendStatusFromIbex = (
   if (paymentLevel !== undefined) return paymentLevel
 
   const topLevel = statusFromField(response?.status)
-  if (topLevel === PaymentSendStatus.Pending || topLevel === PaymentSendStatus.Failure) {
-    return topLevel
-  }
+  if (topLevel === PaymentSendStatus.Pending) return topLevel
+  const corroboratedFailure =
+    reportsFailureCode(response?.failureReason) || reportsFailureCode(payment?.failureId)
+  if (topLevel === PaymentSendStatus.Failure && corroboratedFailure) return topLevel
 
   const candidates = [payment?.status?.id, payment?.statusId, response?.status]
+  const uncorroborated = (outcome: string) =>
+    `IBEX reported ${outcome} only in the top-level status field, with no payment-level corroboration (candidates: ${JSON.stringify(
+      candidates,
+    )})`
   return new UnconfirmedIbexPayment(
     topLevel === PaymentSendStatus.Success
-      ? `IBEX reported SUCCEEDED only in the top-level status field, with no payment-level corroboration (candidates: ${JSON.stringify(
-          candidates,
-        )})`
-      : `No recognised payment status in IBEX response (candidates: ${JSON.stringify(
-          candidates,
-        )})`,
+      ? uncorroborated("SUCCEEDED")
+      : topLevel === PaymentSendStatus.Failure
+        ? uncorroborated("FAILED")
+        : `No recognised payment status in IBEX response (candidates: ${JSON.stringify(
+            candidates,
+          )})`,
   )
 }
 
@@ -163,10 +227,18 @@ export const paymentSendStatusFromIbex = (
  * once the status fields have come up empty. That is an explicit signal from
  * IBEX, not an inference from silence.
  *
- * The residual "no status, no settle date" case is raised at Warn rather than
- * Critical: no real payToLnurl response has been captured on TEST yet, so we do
- * not page on what may well be this endpoint's happy path. Raise it to Critical
- * once a captured response proves the field is populated in normal operation.
+ * `settledAt` accepts both the integer epoch the top-level field declares and
+ * the ISO string every payment-level date field on this vendor is serialised
+ * as, because settlement-on-settle-date is now the ONLY route by which an LNURL
+ * send can report success and a type mismatch here would silently return the
+ * pre-fix always-pending behaviour with a Warn span attached to every send.
+ *
+ * OPEN: no real payToLnurl response has been captured on TEST yet, so the
+ * field's actual runtime type is still schema-derived rather than observed.
+ * Until one is captured the residual "no status, no settle date" case is raised
+ * at Warn rather than Critical — we do not page on what may well be this
+ * endpoint's happy path. Capture a response, confirm the type, then raise this
+ * to Critical.
  */
 export const paymentSendStatusFromIbexLnurlPay = (
   response: IbexLnurlPayStatusResponse | null | undefined,
@@ -210,13 +282,21 @@ const recordUnconfirmed = (
  * What the `payInvoiceV2` send resolvers call: the mapping above, with an
  * unreadable response recorded and reported as still in flight.
  *
- * "Pending" is what the previous inline switches produced for these responses
- * too, and it is kept deliberately: `withPaymentIdempotency` caches only a
- * definitive PaymentSendStatus, so returning an error here would leave the one
- * case where we do not know whether funds moved as the one case a same-key
- * retry could pay twice. What changes is that the anomaly is no longer
- * invisible, and that a status IBEX *did* report can no longer be missed —
- * see paymentSendStatusFromIbex.
+ * Pending is what the LN resolvers' inline switches produced for these
+ * responses; intraledger previously returned an `UnexpectedIbexResponse` here
+ * — a GraphQL error, rendered as "failed" — and now reports Pending. That is a
+ * deliberate, user-visible contract change on the flash-to-flash rail, called
+ * out in the PR body and sequenced behind the client fix (flash-mobile#699)
+ * that makes the app render `pending` honestly instead of as a completed
+ * conversion. Do not treat it as an incidental side effect of the refactor.
+ *
+ * Pending is the choice for all four call sites because
+ * `withPaymentIdempotency` caches only a definitive PaymentSendStatus:
+ * returning an error here would leave the one case where we do not know
+ * whether funds moved as the one case a same-key retry could pay twice. What
+ * changes for the LN rails is that the anomaly is no longer invisible, and
+ * that a status IBEX *did* report can no longer be missed — see
+ * paymentSendStatusFromIbex.
  */
 export const paymentSendStatusOrPending = (
   response: IbexPaymentStatusResponse | null | undefined,

--- a/src/services/ibex/payment-status.ts
+++ b/src/services/ibex/payment-status.ts
@@ -1,6 +1,10 @@
 import { PaymentSendStatus } from "@domain/bitcoin/lightning"
 import { ErrorLevel } from "@domain/shared"
-import { recordExceptionInCurrentSpan } from "@services/tracing"
+import {
+  addAttributesToCurrentSpan,
+  addEventToCurrentSpan,
+  recordExceptionInCurrentSpan,
+} from "@services/tracing"
 
 import { UnconfirmedIbexPayment } from "./errors"
 
@@ -225,17 +229,23 @@ const identityAttributes = (
  * Returns `UnconfirmedIbexPayment` when no field can settle the question, so
  * callers can record the anomaly instead of silently inventing an outcome.
  *
- * SEVERITY: Warn, not Critical — and deliberately the same level the LNURL
- * reader uses, because the evidence behind both is the same: no real
- * payInvoiceV2 200 has been captured on TEST either. The committed fixture
- * (test/flash/mocks/ibex/pay-invoice.ts) is the vendor's openapi example copied
- * verbatim, not an observation, and the pre-PR intraledger code read the
- * TOP-LEVEL `status` field alone — with a `{ status: 2 }` test fixture modelling
- * exactly that — which is direct evidence that at least one rail may populate
- * only the field this reader treats as uncorroborated. Paging on every
- * flash-to-flash send until a capture proves otherwise is not a severity, it is
- * an outage. Capture one 200 on TEST, commit it as a fixture, confirm the
- * payment-level fields are populated, then raise this to Critical.
+ * SEVERITY: Warn — the class default (see UnconfirmedIbexPayment), passed
+ * explicitly here only so the argument sits next to the reasoning, and
+ * deliberately the same level the LNURL reader uses, because the evidence
+ * behind both is the same: no real payInvoiceV2 200 has been captured on TEST
+ * either. The committed fixture (test/flash/mocks/ibex/pay-invoice.ts) is the
+ * vendor's openapi example copied verbatim, not an observation, and the pre-PR
+ * intraledger code read the TOP-LEVEL `status` field alone — with a
+ * `{ status: 2 }` test fixture modelling exactly that — which is direct
+ * evidence that at least one rail may populate only the field this reader
+ * treats as uncorroborated. Paging on every flash-to-flash send until a capture
+ * proves otherwise is not a severity, it is an outage. Capture one 200 on TEST,
+ * commit it as a fixture, confirm the payment-level fields are populated, then
+ * raise this to Critical.
+ *
+ * VOLUME is a separate axis from severity and is decided by the third
+ * constructor argument, not by the level — see `recordUnconfirmed` below for
+ * why `level` alone cannot keep a span green.
  */
 export const paymentSendStatusFromIbex = (
   response: IbexPaymentStatusResponse | null | undefined,
@@ -256,14 +266,23 @@ export const paymentSendStatusFromIbex = (
     `IBEX reported ${outcome} only in the top-level status field, with no payment-level corroboration (candidates: ${JSON.stringify(
       candidates,
     )})`
+  // The third argument is the volume dial, not a severity: it says IBEX made a
+  // terminal claim this reader refused to honour, which is a genuine field-level
+  // disagreement and worth a red span. A response that claimed nothing at all is
+  // an ordinary in-flight payment and must not be. See `recordUnconfirmed`.
+  if (topLevel === PaymentSendStatus.Success)
+    return new UnconfirmedIbexPayment(
+      uncorroborated("SUCCEEDED"),
+      ErrorLevel.Warn,
+      "SUCCEEDED",
+    )
+  if (topLevel === PaymentSendStatus.Failure)
+    return new UnconfirmedIbexPayment(uncorroborated("FAILED"), ErrorLevel.Warn, "FAILED")
+
   return new UnconfirmedIbexPayment(
-    topLevel === PaymentSendStatus.Success
-      ? uncorroborated("SUCCEEDED")
-      : topLevel === PaymentSendStatus.Failure
-        ? uncorroborated("FAILED")
-        : `No recognised payment status in IBEX response (candidates: ${JSON.stringify(
-            candidates,
-          )})`,
+    `No recognised payment status in IBEX response (candidates: ${JSON.stringify(
+      candidates,
+    )})`,
     ErrorLevel.Warn,
   )
 }
@@ -281,20 +300,37 @@ export const paymentSendStatusFromIbex = (
  * ("2022-11-15T20:30:41.960887Z") floored to the second, while every
  * payment-level field in the SAME example says the payment has not settled:
  * `statusId: 0`, `payment.settleDateUtc: null`, `paidMsat: 0`,
- * `payment.hash: null`. `Ibex.payToLnurl` also registers an async settlement
- * webhook (see client.ts), so a 201 is an acceptance, not a settlement.
- * Reading that field would report EVERY LNURL send as `success` regardless of
- * outcome — the "conversion successful while no funds moved" bug this module
- * exists to close, reintroduced on the one rail whose real response has never
- * been observed, and with the Warn-level record suppressed on that path by
- * design. The example is committed at test/flash/mocks/ibex/pay-to-lnurl.ts
- * and pinned by a test.
+ * `payment.hash: null`. On the example's own evidence, then, a 201 is an
+ * acceptance rather than a settlement. Reading that field would report EVERY
+ * LNURL send as `success` regardless of outcome — the "conversion successful
+ * while no funds moved" bug this module exists to close, reintroduced on the
+ * one rail whose real response has never been observed, and with the Warn-level
+ * record suppressed on that path by design. The example is committed at
+ * test/flash/mocks/ibex/pay-to-lnurl.ts and pinned by a test.
  *
  * The payment-level date survives because the same example corroborates it in
  * the other direction: it is `null` on a payment that has not settled, which is
  * what a settlement marker looks like. `hasSettleDate` accepts both the integer
  * epoch and the ISO string every payment-level date on this vendor is
  * serialised as, since that field has no declared type at all.
+ *
+ * GAP — NOTHING RESOLVES A PENDING LNURL SEND SERVER-SIDE. An earlier revision
+ * of this block justified the acceptance reading with "payToLnurl also
+ * registers an async settlement webhook". That was wrong and is corrected here:
+ * `Ibex.payToLnurl` does pass a `webhookUrl` (client.ts), but the value it
+ * passes is `ibexWebhookEndpoints.onPay.lnurl`, which resolves to
+ * `<uri>/pay/lnurl/:username` — the express ROUTE TEMPLATE from
+ * webhook-config.ts, `:username` never substituted. The only route this repo
+ * mounts at that path is the public **GET** LNURL-pay callback for INBOUND
+ * payments (webhook-server/routes/on-pay.ts); there is no POST handler for it,
+ * and the two POST webhook routes that do exist (`/pay/invoice`, `/pay/onchain`)
+ * are `resp.status(200).end()` stubs. So an LNURL send this reader reports as
+ * `pending` stays pending: no webhook, no poller, no reconciliation job moves
+ * it, and `withPaymentIdempotency` replays that same `pending` for 24h under
+ * the same key. Whoever wires a real POST handler (at a substituted path) or a
+ * reconciler must update this block and
+ * test/flash/unit/services/ibex/webhook-server/on-pay-lnurl-gap.spec.ts, which
+ * pins the absence.
  *
  * OPEN: no real payToLnurl response has been captured on TEST yet, so the
  * settle-date rule is still schema-derived rather than observed and the
@@ -321,10 +357,68 @@ export const paymentSendStatusFromIbexLnurlPay = (
   )
 }
 
+/** Span attribute + event name for the quiet path. Exported for the tests. */
+export const UNCONFIRMED_SPAN_EVENT = "ibex.payment.unconfirmed"
+
+/**
+ * Record an unreadable response on the current span — at one of two volumes.
+ *
+ * `ErrorLevel` does NOT control volume. `recordExceptionInCurrentSpan` ends in
+ * `span.setStatus({ code: SpanStatusCode.ERROR })` UNCONDITIONALLY
+ * (services/tracing.ts `recordException`); the level only decides which
+ * `error.*` attributes win the ranking in `updateErrorForSpan`. So a Warn-level
+ * `recordException` still paints the span red, and any dashboard or trigger
+ * keyed on span status rather than on the `error.level` attribute fires on it.
+ *
+ * That matters because one of the two unreadable cases is expected to be a
+ * rail's ORDINARY shape, not an incident:
+ *
+ *  - **Quiet** — the response reported no outcome anywhere (`uncorroboratedOutcome`
+ *    unset). This is exactly the vendor's documented payToLnurl 201: an
+ *    acceptance with `statusId: 0` and a null payment-level settle date, on a
+ *    payment that is genuinely still in flight. `pending` is the correct,
+ *    unremarkable answer, and marking 100% of that rail's spans ERROR would
+ *    bury the real ones. Recorded as span attributes plus a span event, which
+ *    stay fully queryable (`name = ibex.payment.unconfirmed`) without touching
+ *    span status.
+ *  - **Loud** — IBEX claimed SUCCEEDED or FAILED in the top-level `status` and
+ *    the corroboration rules refused it (`uncorroboratedOutcome` set). Here the
+ *    payload disagrees with itself and the `pending` we report may well be
+ *    wrong in a direction that moved money, so the exception — and the ERROR
+ *    span status that comes with it — is earned. Only the payInvoiceV2 reader
+ *    can produce this; the payToLnurl dialect has no top-level `status` field.
+ *
+ * If alerting is later confirmed to key on the `error.level` attribute rather
+ * than span status, collapsing this back to a single `recordException` call is
+ * a safe simplification. Until then this split is what keeps the LN/LNURL rails
+ * from going permanently red on their happy path.
+ */
 const recordUnconfirmed = (
   error: UnconfirmedIbexPayment,
   response: IbexPaymentStatusResponse | IbexLnurlPayStatusResponse | null | undefined,
 ): void => {
+  // Without these an operator looking at "money may or may not have moved" has
+  // to trace-hop to the child ibex-client span before they can even name the
+  // payment. They go on the span on BOTH paths.
+  const attributes = identityAttributes(response)
+
+  if (error.uncorroboratedOutcome === undefined) {
+    addAttributesToCurrentSpan({
+      ...attributes,
+      "ibex.payment.unconfirmed": true,
+      // Namespaced deliberately: writing the bare `error.level` attribute here
+      // would bypass updateErrorForSpan's ranking and could DOWNGRADE a real
+      // error already recorded on the same span.
+      "ibex.payment.unconfirmed.level": error.level,
+      "ibex.payment.unconfirmed.reason": error.message,
+    })
+    addEventToCurrentSpan(UNCONFIRMED_SPAN_EVENT, {
+      "ibex.payment.unconfirmed.level": error.level,
+      "ibex.payment.unconfirmed.reason": error.message,
+    })
+    return
+  }
+
   recordExceptionInCurrentSpan({
     error,
     // The error carries its own severity. Both readers currently raise Warn —
@@ -334,10 +428,10 @@ const recordUnconfirmed = (
     // would make that constructor argument silently dead.
     level: error.level,
     fallbackMsg: "IBEX payment response carried no recognised status",
-    // Without these an operator woken by "money may or may not have moved" has
-    // to trace-hop to the child ibex-client span before they can even name the
-    // payment.
-    attributes: identityAttributes(response),
+    attributes: {
+      ...attributes,
+      "ibex.payment.uncorroborated_outcome": error.uncorroboratedOutcome,
+    },
   })
 }
 
@@ -372,7 +466,15 @@ export const paymentSendStatusOrPending = (
   return status
 }
 
-/** The `payToLnurl` counterpart of `paymentSendStatusOrPending`. */
+/**
+ * The `payToLnurl` counterpart of `paymentSendStatusOrPending`.
+ *
+ * NOTE the asymmetry: a `pending` from this reader is terminal in practice.
+ * Nothing in this repo resolves it — payToLnurl is handed a webhook URL that
+ * has no POST handler mounted behind it — so the value here is replayed by
+ * `withPaymentIdempotency` for 24h and never transitions. See the GAP paragraph
+ * on `paymentSendStatusFromIbexLnurlPay`.
+ */
 export const lnurlPaymentSendStatusOrPending = (
   response: IbexLnurlPayStatusResponse | null | undefined,
 ): PaymentSendStatus => {

--- a/src/services/ibex/payment-status.ts
+++ b/src/services/ibex/payment-status.ts
@@ -1,0 +1,91 @@
+import { PaymentSendStatus } from "@domain/bitcoin/lightning"
+import { ErrorLevel } from "@domain/shared"
+import { recordExceptionInCurrentSpan } from "@services/tracing"
+
+import { UnconfirmedIbexPayment } from "./errors"
+
+// IBEX's pay-invoice response reports the payment state in up to three places
+// (see the generated schema for `PayInvoiceV2`): a top-level `status`, and on
+// the transaction's payment both `statusId` and a nested `status.id`. Which
+// ones are populated varies by response, and unset integer fields arrive as 0
+// rather than being omitted — so we take the first RECOGNISED id rather than
+// the first present one. Reading only `status.id`, or `??`-chaining fields
+// that can legitimately be 0, can miss a status IBEX did report.
+export type IbexPaymentStatusResponse = {
+  status?: number | null
+  transaction?: {
+    payment?: {
+      statusId?: number | null
+      status?: { id?: number | null } | null
+    } | null
+  } | null
+}
+
+export const IbexPaymentStatusId = {
+  InFlight: 1,
+  Succeeded: 2,
+  Failed: 3,
+} as const
+
+const recognised: number[] = Object.values(IbexPaymentStatusId)
+
+/**
+ * Map an IBEX pay-invoice response to a payment status.
+ *
+ * Returns `UnconfirmedIbexPayment` when the response carries no recognised
+ * status, so callers can record the anomaly instead of silently inventing an
+ * outcome. Note what this deliberately never returns: `Success`. Only an
+ * explicit "succeeded" id is reported as a settled payment.
+ */
+export const paymentSendStatusFromIbex = (
+  response: IbexPaymentStatusResponse | null | undefined,
+): PaymentSendStatus | UnconfirmedIbexPayment => {
+  const payment = response?.transaction?.payment
+  const candidates = [payment?.status?.id, payment?.statusId, response?.status]
+
+  const statusId = candidates.find(
+    (id): id is number => typeof id === "number" && recognised.includes(id),
+  )
+
+  switch (statusId) {
+    case IbexPaymentStatusId.InFlight:
+      return PaymentSendStatus.Pending
+    case IbexPaymentStatusId.Succeeded:
+      return PaymentSendStatus.Success
+    case IbexPaymentStatusId.Failed:
+      return PaymentSendStatus.Failure
+    default:
+      return new UnconfirmedIbexPayment(
+        `No recognised payment status in IBEX response (candidates: ${JSON.stringify(
+          candidates,
+        )})`,
+      )
+  }
+}
+
+/**
+ * What the send resolvers call: the mapping above, with an unreadable response
+ * recorded and reported as still in flight.
+ *
+ * "Pending" is what the previous inline switch produced for these responses
+ * too, and it is kept deliberately: `withPaymentIdempotency` caches only a
+ * definitive PaymentSendStatus, so returning an error here would leave the one
+ * case where we do not know whether funds moved as the one case a same-key
+ * retry could pay twice. What changes is that the anomaly is no longer
+ * invisible, and that a status IBEX *did* report can no longer be missed —
+ * see paymentSendStatusFromIbex.
+ */
+export const paymentSendStatusOrPending = (
+  response: IbexPaymentStatusResponse | null | undefined,
+): PaymentSendStatus => {
+  const status = paymentSendStatusFromIbex(response)
+  if (status instanceof UnconfirmedIbexPayment) {
+    recordExceptionInCurrentSpan({
+      error: status,
+      level: ErrorLevel.Critical,
+      fallbackMsg: "IBEX payment response carried no recognised status",
+    })
+    return PaymentSendStatus.Pending
+  }
+  return status
+}

--- a/test/flash/mocks/ibex/index.ts
+++ b/test/flash/mocks/ibex/index.ts
@@ -8,3 +8,4 @@ export * as signIn from "./sign-in"
 // export const getAccountDetails = () => {
 //   return account
 // }
+export * from "./transaction-details-captured"

--- a/test/flash/mocks/ibex/index.ts
+++ b/test/flash/mocks/ibex/index.ts
@@ -1,6 +1,7 @@
 export * as account from "./account"
 export * as addInvoice from "./add-invoice"
 export * as payInvoiceV2 from "./pay-invoice"
+export * as payToLnurl from "./pay-to-lnurl"
 export * as sendToAddressV2 from "./send-to-address-v2"
 export * as signIn from "./sign-in"
 

--- a/test/flash/mocks/ibex/pay-invoice.ts
+++ b/test/flash/mocks/ibex/pay-invoice.ts
@@ -1,3 +1,15 @@
+/**
+ * IBEX `payInvoiceV2` — the 200 body.
+ *
+ * PROVENANCE: the vendor's documented example, copied verbatim from the
+ * generated client's openapi document. NOT a live capture. It happens to
+ * populate all three status fields (`status: 1`, `payment.statusId: 1`,
+ * `payment.status.id: 1` — IN_FLIGHT), but nothing has confirmed that a real
+ * 200 does the same: the pre-#483 intraledger code read the TOP-LEVEL `status`
+ * alone and its fixture modelled exactly that. That is why the unreadable case
+ * in src/services/ibex/payment-status.ts records at Warn rather than paging.
+ * Capture a real 200 on TEST, commit it beside this file, then raise it.
+ */
 const response = {
   settleAtUtc: 0,
   hash: "",

--- a/test/flash/mocks/ibex/pay-to-lnurl.ts
+++ b/test/flash/mocks/ibex/pay-to-lnurl.ts
@@ -1,0 +1,56 @@
+/**
+ * IBEX `POST /v2/lnurl/pay/send` — the 201 body.
+ *
+ * PROVENANCE: this is the vendor's own documented example, copied verbatim from
+ * the generated client's openapi document
+ * (`ibex-client/dist/.api/apis/sing-in/openapi.json`, operation
+ * `pay-to-a-lnurl-pay`, response 201, example "Result"). It is NOT a live
+ * capture — no real payToLnurl response has been observed on TEST yet — and it
+ * is committed precisely so the readers are asserted against the only evidence
+ * that exists rather than against a shape we imagined.
+ *
+ * Read it carefully before treating any field as settlement:
+ *   - top-level `settleDateUtc: 1668544241` is 2022-11-15T20:30:41Z, i.e.
+ *     `transaction.createdAt` ("2022-11-15T20:30:41.960887Z") floored to the
+ *     second — a creation-time echo, not a settlement stamp;
+ *   - meanwhile `payment.statusId` is 0, `payment.settleDateUtc` is null,
+ *     `paidMsat` is 0 and `payment.hash` is null: nothing has settled.
+ * `Ibex.payToLnurl` also registers an async settlement webhook, so the 201 is
+ * an acceptance. `paymentSendStatusFromIbexLnurlPay` must therefore report this
+ * body as unconfirmed (→ pending), never as success.
+ *
+ * When a real 201 is captured on TEST, commit it beside this file rather than
+ * overwriting it, and revisit both the settle-date rule and the Warn severity
+ * in src/services/ibex/payment-status.ts.
+ */
+const response = {
+  settleDateUtc: 1668544241,
+  amountMsat: 1000,
+  feesMsat: 0,
+  hash: "19b7ff42e048d14791180d63592099b3394fc9ea7e3243906e810362124c29fd",
+  transaction: {
+    id: "dfeec8bd-b4e7-46f1-aa4a-cf4e4569df02",
+    createdAt: "2022-11-15T20:30:41.960887Z",
+    accountId: "eeba6152-9432-448e-b7d2-4205e5099924",
+    amount: 0.00325496699508991,
+    networkFee: 0,
+    exchangeRateCurrencySats: 307.53,
+    currencyId: 5,
+    transactionTypeId: 2,
+    payment: {
+      bolt11: "",
+      hash: null,
+      preImage: null,
+      memo: null,
+      amountMsat: 1000,
+      feeMsat: 0,
+      paidMsat: 0,
+      creationDateUtc: "0001-01-01T00:00:00Z",
+      settleDateUtc: null,
+      statusId: 0,
+      failureId: null,
+    },
+  },
+}
+
+export { response }

--- a/test/flash/mocks/ibex/transaction-details-captured.ts
+++ b/test/flash/mocks/ibex/transaction-details-captured.ts
@@ -1,0 +1,57 @@
+/**
+ * A REAL IBEX response, not an openapi example.
+ *
+ * Captured 2026-08-16 from the sandbox hub (which settles on mainnet):
+ *   GET https://ibexhub-api.sandbox.poweredbyibex.io
+ *       /v2/transaction/3ba8081c-0e69-4218-9219-84486042fa5b
+ * — a settled Lightning send (transactionTypeId 2) from the TEST cash wallet.
+ * Amounts and identifiers are as returned; the bolt11/preimage are from a
+ * sandbox transaction of ~$1.10 that has already settled.
+ *
+ * Why it is here: every other status assertion in this module was derived from
+ * the generated openapi *examples*, which are illustrative. This capture is the
+ * evidence for three things the readers depend on:
+ *
+ *  1. A real settled payment populates BOTH payment-level status fields —
+ *     `payment.statusId: 2` and `payment.status.id: 2` (name "SUCCEEDED") — so
+ *     the payment-level precedence in paymentSendStatusFromIbex is reading
+ *     fields IBEX actually fills, and the "no recognised status" case is a
+ *     genuine anomaly rather than this vendor's normal shape.
+ *  2. `payment.failureId` is 0 on success, confirming 0 = "no failure" for the
+ *     corroboration rule.
+ *  3. `payment.settleDateUtc` arrives as an ISO STRING
+ *     ("2026-08-15T05:33:17.554653Z"), not the integer epoch the payToLnurl
+ *     example declares — which is why hasSettleDate must accept both forms.
+ *
+ * Note the transaction-level `status` here is the STRING "completed", a
+ * different field from the integer `status` on the payInvoiceV2 send response.
+ * Do not feed this whole object to a status reader as if it were one.
+ */
+export const capturedSettledLightningSend = {
+  id: "3ba8081c-0e69-4218-9219-84486042fa5b",
+  createdAt: "2026-08-15T05:33:12.081277Z",
+  settledAt: "2026-08-15T05:33:17.600375Z",
+  accountId: "e0eee682-2631-4081-a51e-9ebcada3b24b",
+  amount: 1.10237620493,
+  networkFee: 0.001423690928,
+  onChainSendFee: 0,
+  exchangeRateCurrencySats: 1574.78,
+  currencyId: 29,
+  transactionTypeId: 2,
+  status: "completed",
+  payment: {
+    bolt11:
+      "lnbc17350n1p48l7sspp5nccxp9x373c9lum267m0mms9w2v72974w2c59hcdyakausn5yxxshp5t4z8k9lpmw54z30pvn8eqyufkseznkydu3ggwvalpftg35vwn0jscqzzsxqzp6sp5ufxzxky24ffd4dwqzgazral8jf7370nhr8lxh9p5pxy47kwzfztq9qxpqysgqkmmd2qp7vs4led2rtep58hw4smk22k9lq9jmyhv76mvan3v9stf5h7qh8rh9cm2tzeqt7s2dq3z7alxz2v5l5587fpq0g3k8sgnnvwgq5udlk4",
+    hash: "9e306094d1f4705ff36ad7b6fdee057299e517d572b142df0d276dde4274218d",
+    preImage: "83120d0a91461bc5cdad08aaa0b72d42e6ded08bf8ffdfc00fa2247dcc0a5709",
+    memo: null,
+    amountMsat: 1735000,
+    feeMsat: 2242,
+    paidMsat: 1735000,
+    creationDateUtc: "2026-08-15T05:33:12.073746Z",
+    settleDateUtc: "2026-08-15T05:33:17.554653Z",
+    statusId: 2,
+    failureId: 0,
+    status: { id: 2, name: "SUCCEEDED", description: null },
+  },
+} as const

--- a/test/flash/unit/app/offers/ops-events-valid-offer.spec.ts
+++ b/test/flash/unit/app/offers/ops-events-valid-offer.spec.ts
@@ -16,6 +16,12 @@ jest.mock("@services/logger", () => ({
   baseLogger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
 }))
 
+jest.mock("@services/tracing", () => ({
+  addAttributesToCurrentSpan: jest.fn(),
+  addEventToCurrentSpan: jest.fn(),
+  recordExceptionInCurrentSpan: jest.fn(),
+}))
+
 jest.mock("@services/mongoose", () => ({
   AccountsRepository: jest.fn(() => ({
     findById: (...args: unknown[]) => mockFindAccountById(...args),
@@ -44,7 +50,7 @@ jest.mock("@app/offers/Validator", () => ({
 
 import ValidOffer, { InitiatedCashout } from "@app/offers/ValidOffer"
 import { CashoutDraftError, CashoutSubmitError } from "@services/frappe/errors"
-import { IbexError } from "@services/ibex/errors"
+import { FailedIbexPayment, IbexError } from "@services/ibex/errors"
 import { USDAmount } from "@domain/shared"
 import { notifyOpsEvent } from "@services/alerts/ops-events"
 
@@ -82,7 +88,12 @@ describe("ops events — ValidOffer.execute step failures", () => {
     mockFindWalletById.mockResolvedValue({ id: walletId, accountId })
     mockFindAccountById.mockResolvedValue({ id: accountId })
     mockDraftCashout.mockResolvedValue(cashoutId)
-    mockPayInvoice.mockResolvedValue({ status: 2 })
+    // A payment-level SUCCEEDED — what a settled payInvoiceV2 200 looks like.
+    // (A lone top-level `{ status: 2 }` is deliberately NOT settlement; see
+    // @services/ibex/payment-status.)
+    mockPayInvoice.mockResolvedValue({
+      transaction: { payment: { status: { id: 2 } } },
+    })
     mockSubmitCashout.mockResolvedValue(true)
   })
 
@@ -133,6 +144,79 @@ describe("ops events — ValidOffer.execute step failures", () => {
         status: "failed",
       }),
     )
+  })
+
+  // The headline defect of lnflash/flash#483, on the one rail it had not
+  // reached: this path only ever checked `resp instanceof IbexError`, so a 200
+  // carrying a FAILED payment read as paid and Flash submitted a cashout in
+  // ERPNext — on the fiat-payout rail — with no lightning payment behind it.
+  // Unlike cash-wallet-cutover's send path there is no
+  // balanceVerifier.verifyBalanceMove backstop here, so the status field is the
+  // only check there is.
+  describe("IBEX reports the payment as FAILED in a 200 body", () => {
+    const failedResponses = [
+      { transaction: { payment: { status: { id: 3 } } } },
+      { transaction: { payment: { statusId: 3 } } },
+      { status: 3, failureReason: "NO_ROUTE", transaction: { payment: { statusId: 0 } } },
+    ]
+
+    it("never submits the cashout", async () => {
+      for (const resp of failedResponses) {
+        jest.clearAllMocks()
+        mockPayInvoice.mockResolvedValue(resp)
+        const offer = await makeOffer()
+
+        const result = await offer.execute()
+
+        expect(result).toBeInstanceOf(FailedIbexPayment)
+        expect(mockSubmitCashout).not.toHaveBeenCalled()
+      }
+    })
+
+    it("reports the payInvoice step to ops", async () => {
+      mockPayInvoice.mockResolvedValue(failedResponses[0])
+      const offer = await makeOffer()
+
+      await offer.execute()
+
+      expect(notifyOpsEvent).toHaveBeenCalledTimes(1)
+      expect(notifyOpsEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          step: "payInvoice",
+          error: "FailedIbexPayment",
+          status: "failed",
+        }),
+      )
+    })
+  })
+
+  describe("IBEX has not reported an outcome yet", () => {
+    // Pending — including the unreadable-response case, which
+    // paymentSendStatusOrPending reports as pending so a same-key retry cannot
+    // pay twice — is submitted deliberately. The cashout is an async, reconciled
+    // flow (InitiatedCashout.status is Pending by construction); holding the
+    // ERPNext submit on a payment that probably did settle would strand the
+    // user's funds in a draft nobody is watching. Only a definitive FAILED
+    // stops the submit.
+    it("still submits the cashout on an in-flight payment", async () => {
+      mockPayInvoice.mockResolvedValue({ transaction: { payment: { statusId: 1 } } })
+      const offer = await makeOffer()
+
+      const result = await offer.execute()
+
+      expect(result).toBeInstanceOf(InitiatedCashout)
+      expect(mockSubmitCashout).toHaveBeenCalledTimes(1)
+    })
+
+    it("still submits the cashout on an unreadable response", async () => {
+      mockPayInvoice.mockResolvedValue({ transaction: { payment: {} } })
+      const offer = await makeOffer()
+
+      const result = await offer.execute()
+
+      expect(result).toBeInstanceOf(InitiatedCashout)
+      expect(mockSubmitCashout).toHaveBeenCalledTimes(1)
+    })
   })
 
   it("reports the submitCashout step when submit fails after the retry", async () => {

--- a/test/flash/unit/app/payments/send-intraledger.spec.ts
+++ b/test/flash/unit/app/payments/send-intraledger.spec.ts
@@ -163,6 +163,23 @@ const wallet = ({
     currency,
   }) as unknown as Wallet
 
+// A payInvoiceV2 response shaped the way IBEX actually returns one: the status
+// is reported at the payment level as well as at the top level (see
+// test/flash/mocks/ibex/pay-invoice.ts). Intraledger used to read the top-level
+// field alone, which is why a payment-level-only status went unseen.
+const ibexPayResponse = (statusId: number) => ({
+  status: statusId,
+  transaction: {
+    id: "dfeec8bd-b4e7-46f1-aa4a-cf4e4569df02",
+    accountId: "37fe77d13",
+    payment: {
+      hash: "19b7ff42e048d147",
+      statusId,
+      status: { id: statusId },
+    },
+  },
+})
+
 describe("intraledgerPaymentSendWalletIdForUsdWallet", () => {
   beforeEach(() => {
     jest.clearAllMocks()
@@ -171,7 +188,7 @@ describe("intraledgerPaymentSendWalletIdForUsdWallet", () => {
       activeAccount(accountId as string),
     )
     mockAddInvoice.mockResolvedValue({ invoice: { bolt11: "lnbc1recipient" } })
-    mockPayInvoice.mockResolvedValue({ status: 2 })
+    mockPayInvoice.mockResolvedValue(ibexPayResponse(2))
   })
 
   it("keeps USD to USD using cent amount semantics", async () => {
@@ -305,6 +322,78 @@ describe("intraledgerPaymentSendWalletIdForUsdWallet", () => {
   })
 })
 
+describe("intraledger IBEX status reading", () => {
+  // Intraledger consumes the same payInvoiceV2 response as the LN send
+  // resolvers, and used to read the top-level `status` alone — a fourth private
+  // dialect of the switch this module now shares.
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    mockFindAccountById.mockImplementation(async (accountId: AccountId) =>
+      activeAccount(accountId as string),
+    )
+    mockAddInvoice.mockResolvedValue({ invoice: { bolt11: "lnbc1recipient" } })
+    mockFindWalletById.mockImplementation(async (walletId: WalletId) =>
+      wallet({
+        id: walletId,
+        accountId:
+          walletId === senderUsdWalletId ? "sender-account" : "recipient-account",
+        currency: WalletCurrency.Usd,
+      }),
+    )
+  })
+
+  const sendArgs = {
+    senderWalletId: senderUsdWalletId,
+    recipientWalletId: recipientUsdWalletId,
+    amount: 100,
+    memo: "status reading",
+  }
+
+  it("settles on a payment-level SUCCEEDED even when the top-level status is 0", async () => {
+    // The exact shape that used to return UnexpectedIbexResponse("Invoice
+    // already paid") for a payment that settled: IBEX populated
+    // transaction.payment.status.id = 2 and left the top-level status at 0
+    // (0 is UNKNOWN in IBEX's table, never "already paid").
+    mockPayInvoice.mockResolvedValue({
+      status: 0,
+      transaction: { payment: { statusId: 0, status: { id: 2 } } },
+    })
+
+    const result = await intraledgerPaymentSendWalletIdForUsdWallet(sendArgs)
+
+    expect(result).toEqual({ value: "success" })
+  })
+
+  it("reports a payment-level FAILED even when the top-level status is 0", async () => {
+    mockPayInvoice.mockResolvedValue({
+      status: 0,
+      transaction: { payment: { statusId: 3 } },
+    })
+
+    const result = await intraledgerPaymentSendWalletIdForUsdWallet(sendArgs)
+
+    expect(result).toEqual({ value: "failed" })
+  })
+
+  it("reports an unreadable response as pending instead of erroring or inventing a settlement", async () => {
+    mockPayInvoice.mockResolvedValue({ status: 0, transaction: { payment: {} } })
+
+    const result = await intraledgerPaymentSendWalletIdForUsdWallet(sendArgs)
+
+    expect(result).toEqual({ value: "pending" })
+    expect(result).not.toBeInstanceOf(Error)
+  })
+
+  it("does not settle on a top-level SUCCEEDED with no payment-level corroboration", async () => {
+    mockPayInvoice.mockResolvedValue({ status: 2, transaction: { payment: {} } })
+
+    const result = await intraledgerPaymentSendWalletIdForUsdWallet(sendArgs)
+
+    expect(result).toEqual({ value: "pending" })
+  })
+})
+
 describe("intraledger send ops events", () => {
   beforeEach(() => {
     jest.clearAllMocks()
@@ -313,7 +402,7 @@ describe("intraledger send ops events", () => {
       activeAccount(accountId as string),
     )
     mockAddInvoice.mockResolvedValue({ invoice: { bolt11: "lnbc1recipient" } })
-    mockPayInvoice.mockResolvedValue({ status: 2 })
+    mockPayInvoice.mockResolvedValue(ibexPayResponse(2))
     mockFindWalletById.mockImplementation(async (walletId: WalletId) =>
       wallet({
         id: walletId,
@@ -405,7 +494,7 @@ describe("intraledger send ops events", () => {
   })
 
   it("distinguishes an Ibex status failure from an error return", async () => {
-    mockPayInvoice.mockResolvedValue({ status: 3 })
+    mockPayInvoice.mockResolvedValue(ibexPayResponse(3))
 
     await intraledgerPaymentSendWalletIdForUsdWallet(sendArgs)
 
@@ -421,7 +510,7 @@ describe("intraledger send ops events", () => {
   })
 
   it("notifies a pending transfer event when Ibex reports pending", async () => {
-    mockPayInvoice.mockResolvedValue({ status: 1 })
+    mockPayInvoice.mockResolvedValue(ibexPayResponse(1))
 
     await intraledgerPaymentSendWalletIdForUsdWallet(sendArgs)
 
@@ -451,7 +540,7 @@ describe("intraledger idempotency (ENG-530)", () => {
       activeAccount(accountId as string),
     )
     mockAddInvoice.mockResolvedValue({ invoice: { bolt11: "lnbc1recipient" } })
-    mockPayInvoice.mockResolvedValue({ status: 2 })
+    mockPayInvoice.mockResolvedValue(ibexPayResponse(2))
     mockFindWalletById.mockImplementation(async (walletId: WalletId) => {
       const isUsdt = walletId === senderUsdtWalletId || walletId === recipientUsdtWalletId
       const isSender = walletId === senderUsdWalletId || walletId === senderUsdtWalletId
@@ -510,7 +599,7 @@ describe("intraledger idempotency (ENG-530)", () => {
     expect(second).toBeInstanceOf(Error)
     expect(mockAddInvoice).toHaveBeenCalledTimes(1)
 
-    releasePay({ status: 2 })
+    releasePay(ibexPayResponse(2))
     const first = await firstPromise
 
     expect(first).toEqual({ value: "success" })

--- a/test/flash/unit/app/payments/send-intraledger.spec.ts
+++ b/test/flash/unit/app/payments/send-intraledger.spec.ts
@@ -16,6 +16,7 @@ jest.mock("@config", () => ({
 
 jest.mock("@services/tracing", () => ({
   addAttributesToCurrentSpan: jest.fn(),
+  addEventToCurrentSpan: jest.fn(),
   recordExceptionInCurrentSpan: jest.fn(),
 }))
 
@@ -135,6 +136,7 @@ import {
 } from "@domain/errors"
 import { USDAmount, USDTAmount, WalletCurrency } from "@domain/shared"
 import { notifyOpsEvent } from "@services/alerts/ops-events"
+import { addEventToCurrentSpan, recordExceptionInCurrentSpan } from "@services/tracing"
 
 const senderUsdWalletId = "11111111-1111-4111-8111-111111111111" as WalletId
 const senderUsdtWalletId = "22222222-2222-4222-8222-222222222222" as WalletId
@@ -421,6 +423,41 @@ describe("intraledger IBEX status reading", () => {
     const result = await intraledgerPaymentSendWalletIdForUsdWallet(sendArgs)
 
     expect(result).toEqual({ value: "pending" })
+  })
+
+  describe("span volume on the flash-to-flash rail", () => {
+    // recordExceptionInCurrentSpan sets the span status to ERROR
+    // unconditionally (services/tracing.ts) — ErrorLevel only picks which
+    // `error.*` attributes win. So if this rail's ordinary response shape were
+    // routed through it, every intraledger send would emit a red span and any
+    // trigger keyed on span status rather than the error.level attribute would
+    // fire on 100% of the rail. Only a response that CLAIMS a terminal outcome
+    // we refuse to honour earns that.
+    it("stays green when IBEX reported nothing at all", async () => {
+      mockPayInvoice.mockResolvedValue({ status: 0, transaction: { payment: {} } })
+
+      await intraledgerPaymentSendWalletIdForUsdWallet(sendArgs)
+
+      expect(recordExceptionInCurrentSpan).not.toHaveBeenCalled()
+      expect(addEventToCurrentSpan).toHaveBeenCalledTimes(1)
+      expect((addEventToCurrentSpan as jest.Mock).mock.calls[0][0]).toBe(
+        "ibex.payment.unconfirmed",
+      )
+    })
+
+    it("goes red when IBEX claimed a terminal outcome we refused to honour", async () => {
+      mockPayInvoice.mockResolvedValue({ status: 2, transaction: { payment: {} } })
+
+      await intraledgerPaymentSendWalletIdForUsdWallet(sendArgs)
+
+      expect(addEventToCurrentSpan).not.toHaveBeenCalled()
+      expect(recordExceptionInCurrentSpan).toHaveBeenCalledTimes(1)
+      expect(
+        (recordExceptionInCurrentSpan as jest.Mock).mock.calls[0][0].attributes[
+          "ibex.payment.uncorroborated_outcome"
+        ],
+      ).toBe("SUCCEEDED")
+    })
   })
 })
 

--- a/test/flash/unit/app/payments/send-intraledger.spec.ts
+++ b/test/flash/unit/app/payments/send-intraledger.spec.ts
@@ -377,12 +377,42 @@ describe("intraledger IBEX status reading", () => {
   })
 
   it("reports an unreadable response as pending instead of erroring or inventing a settlement", async () => {
+    // CONTRACT CHANGE, pinned here deliberately: this case previously returned
+    // an UnexpectedIbexResponse, which intraledger-usd-payment-send maps to
+    // `{ status: "failed" }`. It now reports pending — an error return is left
+    // uncached by withPaymentIdempotency, so a same-key retry could re-execute
+    // the one send whose outcome we do not know. Until flash-mobile#699 lands,
+    // the shipped client renders PENDING as a completed conversion, so this
+    // rail is fail-open on this one case; see the PR body and the doc block on
+    // paymentSendStatusOrPending.
     mockPayInvoice.mockResolvedValue({ status: 0, transaction: { payment: {} } })
 
     const result = await intraledgerPaymentSendWalletIdForUsdWallet(sendArgs)
 
     expect(result).toEqual({ value: "pending" })
     expect(result).not.toBeInstanceOf(Error)
+  })
+
+  it("does not report a bare top-level FAILED as a failed send", async () => {
+    // The mirror of "never invent a settled send": a fabricated "failed" sends
+    // the user back to retry with a fresh idempotency key against a send IBEX
+    // may in fact have made. A top-level 3 counts only when IBEX also names a
+    // failure code.
+    mockPayInvoice.mockResolvedValue({ status: 3, transaction: { payment: {} } })
+
+    expect(await intraledgerPaymentSendWalletIdForUsdWallet(sendArgs)).toEqual({
+      value: "pending",
+    })
+
+    mockPayInvoice.mockResolvedValue({
+      status: 3,
+      failureReason: 2,
+      transaction: { payment: {} },
+    })
+
+    expect(await intraledgerPaymentSendWalletIdForUsdWallet(sendArgs)).toEqual({
+      value: "failed",
+    })
   })
 
   it("does not settle on a top-level SUCCEEDED with no payment-level corroboration", async () => {

--- a/test/flash/unit/graphql/ln-invoice-payment-send.spec.ts
+++ b/test/flash/unit/graphql/ln-invoice-payment-send.spec.ts
@@ -1,4 +1,11 @@
 const mockPayInvoice = jest.fn()
+const mockRecordExceptionInCurrentSpan = jest.fn()
+
+jest.mock("@services/tracing", () => ({
+  addAttributesToCurrentSpan: jest.fn(),
+  recordExceptionInCurrentSpan: (...args: unknown[]) =>
+    mockRecordExceptionInCurrentSpan(...args),
+}))
 
 jest.mock("@services/ibex/client", () => ({
   __esModule: true,
@@ -13,7 +20,11 @@ jest.mock("@app/payments/idempotency", () => ({
 
 import { ErrorLevel } from "@domain/shared"
 import LnInvoicePaymentSendMutation from "@graphql/public/root/mutation/ln-invoice-payment-send"
-import { IbexError, InsufficientIbexBalance } from "@services/ibex/errors"
+import {
+  IbexError,
+  InsufficientIbexBalance,
+  UnconfirmedIbexPayment,
+} from "@services/ibex/errors"
 
 const insufficientDetail =
   "insufficient balance. Current Balance: 5.000000. Estimated Fee: 0.001109. invoice amount: 5.042164. account: 39c6e986-979b-40ab-9e7b-df18a9277a84"
@@ -86,5 +97,75 @@ describe("lnInvoicePaymentSend IBEX error surfacing (issue #93)", () => {
 
     expect(result.status).toBe("success")
     expect(result.errors).toEqual([])
+  })
+})
+
+// The two IBEX status readers are structurally interchangeable at the type
+// level — `lnurlPaymentSendStatusOrPending` accepts a payInvoiceV2 response
+// without complaint — so nothing but an assertion at the call site proves this
+// resolver is wired to the payInvoiceV2 one. Wrong-reader-on-wrong-endpoint is
+// exactly the bug class that had shipped on the LNURL rail, and the one thing
+// the reader's own exhaustive unit suite cannot see.
+describe("lnInvoicePaymentSend IBEX status reader wiring", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("settles on a payment-level SUCCEEDED even when the top-level status is 0", async () => {
+    mockPayInvoice.mockResolvedValue({
+      status: 0,
+      transaction: { payment: { status: { id: 2 } } },
+    })
+
+    const result = await resolvePayment()
+
+    expect(result).toEqual({ errors: [], status: "success" })
+  })
+
+  it("reports a corroborated top-level failure — a reading only the payInvoiceV2 reader makes", async () => {
+    // payToLnurl's dialect has no top-level `status` at all, so its reader
+    // would report this exact response as pending.
+    mockPayInvoice.mockResolvedValue({
+      status: 3,
+      failureReason: 2,
+      transaction: { payment: { statusId: 0 } },
+    })
+
+    const result = await resolvePayment()
+
+    expect(result).toEqual({ errors: [], status: "failed" })
+  })
+
+  it("reports an unreadable response as pending and records it at Critical", async () => {
+    // Critical is the payInvoiceV2 reader's severity for this condition; the
+    // LNURL reader raises the same one at Warn. This is the assertion that
+    // catches the two readers being swapped.
+    mockPayInvoice.mockResolvedValue({ status: 0, transaction: { payment: {} } })
+
+    const result = await resolvePayment()
+
+    expect(result).toEqual({ errors: [], status: "pending" })
+    expect(mockRecordExceptionInCurrentSpan).toHaveBeenCalledTimes(1)
+    const [{ error, level }] = mockRecordExceptionInCurrentSpan.mock.calls[0]
+    expect(error).toBeInstanceOf(UnconfirmedIbexPayment)
+    expect(level).toBe(ErrorLevel.Critical)
+  })
+
+  it("never reports success from a top-level status alone", async () => {
+    mockPayInvoice.mockResolvedValue({ status: 2, transaction: { payment: {} } })
+
+    const result = await resolvePayment()
+
+    expect(result).toEqual({ errors: [], status: "pending" })
+  })
+
+  it("never reports failure from a top-level status alone", async () => {
+    // A fabricated "failed" sends the user back to retry with a fresh
+    // idempotency key against a send that may already have paid.
+    mockPayInvoice.mockResolvedValue({ status: 3, transaction: { payment: {} } })
+
+    const result = await resolvePayment()
+
+    expect(result).toEqual({ errors: [], status: "pending" })
   })
 })

--- a/test/flash/unit/graphql/ln-invoice-payment-send.spec.ts
+++ b/test/flash/unit/graphql/ln-invoice-payment-send.spec.ts
@@ -136,10 +136,12 @@ describe("lnInvoicePaymentSend IBEX status reader wiring", () => {
     expect(result).toEqual({ errors: [], status: "failed" })
   })
 
-  it("reports an unreadable response as pending and records it at Critical", async () => {
-    // Critical is the payInvoiceV2 reader's severity for this condition; the
-    // LNURL reader raises the same one at Warn. This is the assertion that
-    // catches the two readers being swapped.
+  it("reports an unreadable response as pending and records it in the payInvoiceV2 reader's own words", async () => {
+    // Both readers record at Warn (neither endpoint has a captured response to
+    // justify paging), so severity alone no longer tells them apart — the
+    // message does: the LNURL reader names payToLnurl and its payment-level
+    // settle date. This is the assertion that catches the two readers being
+    // swapped.
     mockPayInvoice.mockResolvedValue({ status: 0, transaction: { payment: {} } })
 
     const result = await resolvePayment()
@@ -148,7 +150,11 @@ describe("lnInvoicePaymentSend IBEX status reader wiring", () => {
     expect(mockRecordExceptionInCurrentSpan).toHaveBeenCalledTimes(1)
     const [{ error, level }] = mockRecordExceptionInCurrentSpan.mock.calls[0]
     expect(error).toBeInstanceOf(UnconfirmedIbexPayment)
-    expect(level).toBe(ErrorLevel.Critical)
+    expect(level).toBe(ErrorLevel.Warn)
+    expect((error as UnconfirmedIbexPayment).message).toMatch(
+      /No recognised payment status in IBEX response/,
+    )
+    expect((error as UnconfirmedIbexPayment).message).not.toMatch(/payToLnurl/)
   })
 
   it("never reports success from a top-level status alone", async () => {

--- a/test/flash/unit/graphql/ln-invoice-payment-send.spec.ts
+++ b/test/flash/unit/graphql/ln-invoice-payment-send.spec.ts
@@ -1,8 +1,10 @@
 const mockPayInvoice = jest.fn()
 const mockRecordExceptionInCurrentSpan = jest.fn()
+const mockAddEventToCurrentSpan = jest.fn()
 
 jest.mock("@services/tracing", () => ({
   addAttributesToCurrentSpan: jest.fn(),
+  addEventToCurrentSpan: (...args: unknown[]) => mockAddEventToCurrentSpan(...args),
   recordExceptionInCurrentSpan: (...args: unknown[]) =>
     mockRecordExceptionInCurrentSpan(...args),
 }))
@@ -142,19 +144,25 @@ describe("lnInvoicePaymentSend IBEX status reader wiring", () => {
     // message does: the LNURL reader names payToLnurl and its payment-level
     // settle date. This is the assertion that catches the two readers being
     // swapped.
+    //
+    // The channel matters as much as the message: a response that claimed
+    // NOTHING is recorded as a span event, not a recorded exception, because
+    // recordExceptionInCurrentSpan sets the span status to ERROR
+    // unconditionally and this shape may be a rail's ordinary answer.
     mockPayInvoice.mockResolvedValue({ status: 0, transaction: { payment: {} } })
 
     const result = await resolvePayment()
 
     expect(result).toEqual({ errors: [], status: "pending" })
-    expect(mockRecordExceptionInCurrentSpan).toHaveBeenCalledTimes(1)
-    const [{ error, level }] = mockRecordExceptionInCurrentSpan.mock.calls[0]
-    expect(error).toBeInstanceOf(UnconfirmedIbexPayment)
-    expect(level).toBe(ErrorLevel.Warn)
-    expect((error as UnconfirmedIbexPayment).message).toMatch(
+    expect(mockRecordExceptionInCurrentSpan).not.toHaveBeenCalled()
+    expect(mockAddEventToCurrentSpan).toHaveBeenCalledTimes(1)
+    const [eventName, eventAttributes] = mockAddEventToCurrentSpan.mock.calls[0]
+    expect(eventName).toBe("ibex.payment.unconfirmed")
+    expect(eventAttributes["ibex.payment.unconfirmed.level"]).toBe(ErrorLevel.Warn)
+    expect(eventAttributes["ibex.payment.unconfirmed.reason"]).toMatch(
       /No recognised payment status in IBEX response/,
     )
-    expect((error as UnconfirmedIbexPayment).message).not.toMatch(/payToLnurl/)
+    expect(eventAttributes["ibex.payment.unconfirmed.reason"]).not.toMatch(/payToLnurl/)
   })
 
   it("never reports success from a top-level status alone", async () => {
@@ -163,6 +171,15 @@ describe("lnInvoicePaymentSend IBEX status reader wiring", () => {
     const result = await resolvePayment()
 
     expect(result).toEqual({ errors: [], status: "pending" })
+    // An unhonoured terminal claim IS worth a red span — the payload disagrees
+    // with itself and our `pending` may be wrong in a direction that moved
+    // money.
+    expect(mockAddEventToCurrentSpan).not.toHaveBeenCalled()
+    expect(mockRecordExceptionInCurrentSpan).toHaveBeenCalledTimes(1)
+    const [{ error, level }] = mockRecordExceptionInCurrentSpan.mock.calls[0]
+    expect(error).toBeInstanceOf(UnconfirmedIbexPayment)
+    expect(level).toBe(ErrorLevel.Warn)
+    expect((error as UnconfirmedIbexPayment).uncorroboratedOutcome).toBe("SUCCEEDED")
   })
 
   it("never reports failure from a top-level status alone", async () => {

--- a/test/flash/unit/graphql/public/root/mutation/ln-noamount-usd-invoice-payment-send.spec.ts
+++ b/test/flash/unit/graphql/public/root/mutation/ln-noamount-usd-invoice-payment-send.spec.ts
@@ -2,9 +2,11 @@ const mockPayInvoice = jest.fn()
 const mockResolveCashWalletMutationWalletIdForAccount = jest.fn()
 const mockUsdWalletAmountFromWalletId = jest.fn()
 const mockRecordExceptionInCurrentSpan = jest.fn()
+const mockAddEventToCurrentSpan = jest.fn()
 
 jest.mock("@services/tracing", () => ({
   addAttributesToCurrentSpan: jest.fn(),
+  addEventToCurrentSpan: (...args: unknown[]) => mockAddEventToCurrentSpan(...args),
   recordExceptionInCurrentSpan: (...args: unknown[]) =>
     mockRecordExceptionInCurrentSpan(...args),
 }))
@@ -123,19 +125,25 @@ describe("LnNoAmountUsdInvoicePaymentSendMutation", () => {
       // message does: the LNURL reader names payToLnurl and its
       // payment-level settle date. This is the assertion that catches the two
       // readers being swapped.
+      //
+      // The channel matters as much as the message: a response that claimed
+      // NOTHING is recorded as a span event, not a recorded exception, because
+      // recordExceptionInCurrentSpan sets the span status to ERROR
+      // unconditionally and this shape may be a rail's ordinary answer.
       mockPayInvoice.mockResolvedValue({ status: 0, transaction: { payment: {} } })
 
       const result = await resolveMutation()
 
       expect(result).toEqual({ errors: [], status: "pending" })
-      expect(mockRecordExceptionInCurrentSpan).toHaveBeenCalledTimes(1)
-      const [{ error, level }] = mockRecordExceptionInCurrentSpan.mock.calls[0]
-      expect(error).toBeInstanceOf(UnconfirmedIbexPayment)
-      expect(level).toBe(ErrorLevel.Warn)
-      expect((error as UnconfirmedIbexPayment).message).toMatch(
+      expect(mockRecordExceptionInCurrentSpan).not.toHaveBeenCalled()
+      expect(mockAddEventToCurrentSpan).toHaveBeenCalledTimes(1)
+      const [eventName, eventAttributes] = mockAddEventToCurrentSpan.mock.calls[0]
+      expect(eventName).toBe("ibex.payment.unconfirmed")
+      expect(eventAttributes["ibex.payment.unconfirmed.level"]).toBe(ErrorLevel.Warn)
+      expect(eventAttributes["ibex.payment.unconfirmed.reason"]).toMatch(
         /No recognised payment status in IBEX response/,
       )
-      expect((error as UnconfirmedIbexPayment).message).not.toMatch(/payToLnurl/)
+      expect(eventAttributes["ibex.payment.unconfirmed.reason"]).not.toMatch(/payToLnurl/)
     })
 
     it("never reports success from a top-level status alone", async () => {
@@ -144,6 +152,14 @@ describe("LnNoAmountUsdInvoicePaymentSendMutation", () => {
       const result = await resolveMutation()
 
       expect(result).toEqual({ errors: [], status: "pending" })
+      // An unhonoured terminal claim IS worth a red span — the payload
+      // disagrees with itself and our `pending` may be wrong in a direction
+      // that moved money.
+      expect(mockAddEventToCurrentSpan).not.toHaveBeenCalled()
+      expect(mockRecordExceptionInCurrentSpan).toHaveBeenCalledTimes(1)
+      const [{ error }] = mockRecordExceptionInCurrentSpan.mock.calls[0]
+      expect(error).toBeInstanceOf(UnconfirmedIbexPayment)
+      expect((error as UnconfirmedIbexPayment).uncorroboratedOutcome).toBe("SUCCEEDED")
     })
 
     it("never reports failure from a top-level status alone", async () => {

--- a/test/flash/unit/graphql/public/root/mutation/ln-noamount-usd-invoice-payment-send.spec.ts
+++ b/test/flash/unit/graphql/public/root/mutation/ln-noamount-usd-invoice-payment-send.spec.ts
@@ -117,10 +117,12 @@ describe("LnNoAmountUsdInvoicePaymentSendMutation", () => {
       expect(result).toEqual({ errors: [], status: "failed" })
     })
 
-    it("reports an unreadable response as pending and records it at Critical", async () => {
-      // Critical is the payInvoiceV2 reader's severity for this condition; the
-      // LNURL reader raises the same one at Warn. This is the assertion that
-      // catches the two readers being swapped.
+    it("reports an unreadable response as pending and records it in the payInvoiceV2 reader's own words", async () => {
+      // Both readers record at Warn (neither endpoint has a captured response
+      // to justify paging), so severity alone no longer tells them apart — the
+      // message does: the LNURL reader names payToLnurl and its
+      // payment-level settle date. This is the assertion that catches the two
+      // readers being swapped.
       mockPayInvoice.mockResolvedValue({ status: 0, transaction: { payment: {} } })
 
       const result = await resolveMutation()
@@ -129,7 +131,11 @@ describe("LnNoAmountUsdInvoicePaymentSendMutation", () => {
       expect(mockRecordExceptionInCurrentSpan).toHaveBeenCalledTimes(1)
       const [{ error, level }] = mockRecordExceptionInCurrentSpan.mock.calls[0]
       expect(error).toBeInstanceOf(UnconfirmedIbexPayment)
-      expect(level).toBe(ErrorLevel.Critical)
+      expect(level).toBe(ErrorLevel.Warn)
+      expect((error as UnconfirmedIbexPayment).message).toMatch(
+        /No recognised payment status in IBEX response/,
+      )
+      expect((error as UnconfirmedIbexPayment).message).not.toMatch(/payToLnurl/)
     })
 
     it("never reports success from a top-level status alone", async () => {

--- a/test/flash/unit/graphql/public/root/mutation/ln-noamount-usd-invoice-payment-send.spec.ts
+++ b/test/flash/unit/graphql/public/root/mutation/ln-noamount-usd-invoice-payment-send.spec.ts
@@ -1,0 +1,163 @@
+const mockPayInvoice = jest.fn()
+const mockResolveCashWalletMutationWalletIdForAccount = jest.fn()
+const mockUsdWalletAmountFromWalletId = jest.fn()
+const mockRecordExceptionInCurrentSpan = jest.fn()
+
+jest.mock("@services/tracing", () => ({
+  addAttributesToCurrentSpan: jest.fn(),
+  recordExceptionInCurrentSpan: (...args: unknown[]) =>
+    mockRecordExceptionInCurrentSpan(...args),
+}))
+
+jest.mock("@services/ibex/client", () => ({
+  __esModule: true,
+  default: { payInvoice: (...args: unknown[]) => mockPayInvoice(...args) },
+}))
+
+jest.mock("@app/cash-wallet-cutover", () => ({
+  resolveCashWalletMutationWalletIdForAccount: (
+    ...args: Parameters<typeof mockResolveCashWalletMutationWalletIdForAccount>
+  ) => mockResolveCashWalletMutationWalletIdForAccount(...args),
+}))
+
+jest.mock("@app/wallets", () => ({
+  usdWalletAmountFromWalletId: (
+    ...args: Parameters<typeof mockUsdWalletAmountFromWalletId>
+  ) => mockUsdWalletAmountFromWalletId(...args),
+}))
+
+import { ErrorLevel, USDTAmount } from "@domain/shared"
+import LnNoAmountUsdInvoicePaymentSendMutation from "@graphql/public/root/mutation/ln-noamount-usd-invoice-payment-send"
+import { IbexError, UnconfirmedIbexPayment } from "@services/ibex/errors"
+
+const walletId = "11111111-1111-4111-8111-111111111111" as WalletId
+const routedWalletId = "22222222-2222-4222-8222-222222222222" as WalletId
+const domainAccount = { id: "account-id" } as Account
+const client = {
+  cashWalletPresentation: "usdt",
+  hasUsdtCashWalletSupport: true,
+} as const
+
+type MutationResult = {
+  status?: string
+  errors: { message: string }[]
+}
+
+const resolveMutation = (overrides: Record<string, unknown> = {}) =>
+  LnNoAmountUsdInvoicePaymentSendMutation.resolve?.(
+    null,
+    {
+      input: {
+        walletId,
+        paymentRequest: "lnbc1noamount",
+        amount: 1234 as FractionalCentAmount,
+        memo: "memo" as Memo,
+        ...overrides,
+      },
+    },
+    {
+      domainAccount,
+      cashWalletClientCapabilities: client,
+    } as GraphQLPublicContextAuth,
+    {} as never,
+  ) as Promise<MutationResult>
+
+describe("LnNoAmountUsdInvoicePaymentSendMutation", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockResolveCashWalletMutationWalletIdForAccount.mockResolvedValue(routedWalletId)
+    mockUsdWalletAmountFromWalletId.mockResolvedValue(
+      USDTAmount.usdCents("1234") as USDTAmount,
+    )
+    mockPayInvoice.mockResolvedValue({
+      status: 0,
+      transaction: { payment: { status: { id: 2 } } },
+    })
+  })
+
+  it("pays the routed wallet with the resolved cent amount", async () => {
+    const result = await resolveMutation()
+
+    expect(mockResolveCashWalletMutationWalletIdForAccount).toHaveBeenCalledWith({
+      account: domainAccount,
+      walletId,
+      client,
+    })
+    expect(mockPayInvoice).toHaveBeenCalledWith(
+      expect.objectContaining({
+        invoice: "lnbc1noamount",
+        accountId: routedWalletId,
+      }),
+    )
+    expect(result).toEqual({ errors: [], status: "success" })
+  })
+
+  // The two IBEX status readers are structurally interchangeable at the type
+  // level — `lnurlPaymentSendStatusOrPending` accepts a payInvoiceV2 response
+  // without complaint — so nothing but an assertion at the call site proves this
+  // resolver is wired to the payInvoiceV2 one. Wrong-reader-on-wrong-endpoint is
+  // exactly the bug class that had shipped on the LNURL rail, and the one thing
+  // the reader's own exhaustive unit suite cannot see.
+  describe("IBEX status reader wiring", () => {
+    it("settles on a payment-level SUCCEEDED even when the top-level status is 0", async () => {
+      const result = await resolveMutation()
+
+      expect(result).toEqual({ errors: [], status: "success" })
+    })
+
+    it("reports a corroborated top-level failure — a reading only the payInvoiceV2 reader makes", async () => {
+      mockPayInvoice.mockResolvedValue({
+        status: 3,
+        failureReason: 2,
+        transaction: { payment: { statusId: 0 } },
+      })
+
+      const result = await resolveMutation()
+
+      expect(result).toEqual({ errors: [], status: "failed" })
+    })
+
+    it("reports an unreadable response as pending and records it at Critical", async () => {
+      // Critical is the payInvoiceV2 reader's severity for this condition; the
+      // LNURL reader raises the same one at Warn. This is the assertion that
+      // catches the two readers being swapped.
+      mockPayInvoice.mockResolvedValue({ status: 0, transaction: { payment: {} } })
+
+      const result = await resolveMutation()
+
+      expect(result).toEqual({ errors: [], status: "pending" })
+      expect(mockRecordExceptionInCurrentSpan).toHaveBeenCalledTimes(1)
+      const [{ error, level }] = mockRecordExceptionInCurrentSpan.mock.calls[0]
+      expect(error).toBeInstanceOf(UnconfirmedIbexPayment)
+      expect(level).toBe(ErrorLevel.Critical)
+    })
+
+    it("never reports success from a top-level status alone", async () => {
+      mockPayInvoice.mockResolvedValue({ status: 2, transaction: { payment: {} } })
+
+      const result = await resolveMutation()
+
+      expect(result).toEqual({ errors: [], status: "pending" })
+    })
+
+    it("never reports failure from a top-level status alone", async () => {
+      // A fabricated "failed" sends the user back to retry with a fresh
+      // idempotency key against a send that may already have paid.
+      mockPayInvoice.mockResolvedValue({ status: 3, transaction: { payment: {} } })
+
+      const result = await resolveMutation()
+
+      expect(result).toEqual({ errors: [], status: "pending" })
+    })
+  })
+
+  it("maps IBEX pay failures into payload errors", async () => {
+    mockPayInvoice.mockResolvedValue(new IbexError(new Error("ibex failed")))
+
+    const result = await resolveMutation()
+
+    expect(result.status).toBe("failed")
+    expect(result.errors[0].message).toBeTruthy()
+    expect(mockRecordExceptionInCurrentSpan).not.toHaveBeenCalled()
+  })
+})

--- a/test/flash/unit/graphql/public/root/mutation/lnurl-payment-send.spec.ts
+++ b/test/flash/unit/graphql/public/root/mutation/lnurl-payment-send.spec.ts
@@ -42,6 +42,10 @@ import LnurlPaymentSendMutation from "@graphql/public/root/mutation/lnurl-paymen
 import { paymentAmountFromNumber, USDTAmount, WalletCurrency } from "@domain/shared"
 import { IbexError } from "@services/ibex/errors"
 
+// The vendor's documented 201 body, committed verbatim — the only evidence
+// this endpoint's shape has. See test/flash/mocks/ibex/pay-to-lnurl.ts.
+import * as payToLnurlMock from "test/flash/mocks/ibex/pay-to-lnurl"
+
 const walletId = "11111111-1111-4111-8111-111111111111" as WalletId
 const routedWalletId = "22222222-2222-4222-8222-222222222222" as WalletId
 const domainAccount = { id: "account-id" } as Account
@@ -160,18 +164,31 @@ describe("LnurlPaymentSendMutation", () => {
     expect(result?.errors[0].message).toMatch(/minSendable|maxSendable/i)
   })
 
-  it("reports success on the documented payToLnurl 201 shape (statusId 0 + settleDateUtc)", async () => {
-    // Per the generated schema this endpoint has no top-level `status` and no
-    // `transaction.payment.status` object — its documented statusId example is
-    // 0 next to a populated settleDateUtc. Reading it with the payInvoiceV2
-    // reader would have reported every LNURL send as pending and paged on it.
+  it("reports pending — never success — on the vendor's documented payToLnurl 201 example", async () => {
+    // The committed fixture is the vendor's own example: a top-level
+    // settleDateUtc of 1668544241 that is `transaction.createdAt` floored to
+    // the second, next to `statusId: 0`, `payment.settleDateUtc: null`,
+    // `paidMsat: 0` and `payment.hash: null`. payToLnurl also registers an
+    // async settlement webhook, so the 201 is an acceptance. Reading that
+    // top-level echo reported every LNURL send as a completed conversion —
+    // the exact bug this PR opens by condemning.
+    mockPayToLnurl.mockResolvedValueOnce(payToLnurlMock.response)
+
+    const result = await resolveMutation()
+
+    expect(result).toEqual({ errors: [], status: "pending" })
+  })
+
+  it("reports success on a payment-level settle date — a reading only the LNURL reader makes", async () => {
+    // The payInvoiceV2 reader has no settle-date rule at all and would report
+    // this as pending, so this is the assertion that catches the two readers
+    // being swapped on this rail.
     mockPayToLnurl.mockResolvedValueOnce({
-      settleDateUtc: 1668544241,
       hash: "19b7ff42e048d14791180d63592099b3394fc9ea7e3243906e810362124c29fd",
       transaction: {
         id: "dfeec8bd-b4e7-46f1-aa4a-cf4e4569df02",
         accountId: "eeba6152-9432-448e-b7d2-4205e5099924",
-        payment: { statusId: 0 },
+        payment: { statusId: 0, settleDateUtc: "2022-11-15T20:30:41.960887Z" },
       },
     })
 

--- a/test/flash/unit/graphql/public/root/mutation/lnurl-payment-send.spec.ts
+++ b/test/flash/unit/graphql/public/root/mutation/lnurl-payment-send.spec.ts
@@ -160,6 +160,34 @@ describe("LnurlPaymentSendMutation", () => {
     expect(result?.errors[0].message).toMatch(/minSendable|maxSendable/i)
   })
 
+  it("reports success on the documented payToLnurl 201 shape (statusId 0 + settleDateUtc)", async () => {
+    // Per the generated schema this endpoint has no top-level `status` and no
+    // `transaction.payment.status` object — its documented statusId example is
+    // 0 next to a populated settleDateUtc. Reading it with the payInvoiceV2
+    // reader would have reported every LNURL send as pending and paged on it.
+    mockPayToLnurl.mockResolvedValueOnce({
+      settleDateUtc: 1668544241,
+      hash: "19b7ff42e048d14791180d63592099b3394fc9ea7e3243906e810362124c29fd",
+      transaction: {
+        id: "dfeec8bd-b4e7-46f1-aa4a-cf4e4569df02",
+        accountId: "eeba6152-9432-448e-b7d2-4205e5099924",
+        payment: { statusId: 0 },
+      },
+    })
+
+    const result = await resolveMutation()
+
+    expect(result).toEqual({ errors: [], status: "success" })
+  })
+
+  it("reports pending — never success — when the payToLnurl response carries neither status nor settle date", async () => {
+    mockPayToLnurl.mockResolvedValueOnce({ transaction: { payment: { statusId: 0 } } })
+
+    const result = await resolveMutation()
+
+    expect(result).toEqual({ errors: [], status: "pending" })
+  })
+
   it("maps IBEX pay failures into payload errors", async () => {
     mockPayToLnurl.mockResolvedValueOnce(new IbexError(new Error("ibex failed")))
 

--- a/test/flash/unit/services/ibex/errors.spec.ts
+++ b/test/flash/unit/services/ibex/errors.spec.ts
@@ -4,9 +4,11 @@ import { ApiError, AuthenticationError, MAX_IBEX_MESSAGE_LENGTH } from "ibex-cli
 import {
   CompletedInvoice,
   errorHandler,
+  FailedIbexPayment,
   IbexError,
   ibexErrorDetail,
   InsufficientIbexBalance,
+  UnconfirmedIbexPayment,
 } from "@services/ibex/errors"
 
 const insufficientDetail =
@@ -286,5 +288,47 @@ describe("errorHandler", () => {
   it("passes successful responses through untouched", () => {
     const response = { transaction: { id: "t-1" } }
     expect(errorHandler(response)).toBe(response)
+  })
+})
+
+describe("UnconfirmedIbexPayment", () => {
+  it("defaults to Warn, the level every construction site actually wants", () => {
+    // The default used to be Critical while both readers in
+    // @services/ibex/payment-status passed Warn explicitly — an unreachable
+    // default that would silently page the next caller who omitted the
+    // argument, on rails whose responses have never been captured. Warn is the
+    // documented, evidence-backed level until a capture justifies raising it.
+    expect(new UnconfirmedIbexPayment("nothing readable").level).toBe(ErrorLevel.Warn)
+  })
+
+  it("still honours an explicit level", () => {
+    expect(
+      new UnconfirmedIbexPayment("nothing readable", ErrorLevel.Critical).level,
+    ).toBe(ErrorLevel.Critical)
+  })
+
+  it("carries no uncorroborated outcome unless one is named", () => {
+    // The flag drives span VOLUME in payment-status.recordUnconfirmed (event vs
+    // recorded exception), so an accidental default of "set" would put every
+    // unreadable response back on the red-span path.
+    expect(new UnconfirmedIbexPayment("nothing readable").uncorroboratedOutcome).toBe(
+      undefined,
+    )
+    expect(
+      new UnconfirmedIbexPayment("top-level only", ErrorLevel.Warn, "SUCCEEDED")
+        .uncorroboratedOutcome,
+    ).toBe("SUCCEEDED")
+  })
+})
+
+describe("FailedIbexPayment", () => {
+  it("is an IbexError so existing `instanceof IbexError` guards still catch it", () => {
+    const failure = new FailedIbexPayment("IBEX reported the payment as FAILED")
+
+    expect(failure).toBeInstanceOf(IbexError)
+    expect(failure.level).toBe(ErrorLevel.Warn)
+    // error-map keys on `name`; a class whose name is not in the switch falls
+    // through to the unknown-error path.
+    expect(failure.name).toBe("FailedIbexPayment")
   })
 })

--- a/test/flash/unit/services/ibex/payment-status.spec.ts
+++ b/test/flash/unit/services/ibex/payment-status.spec.ts
@@ -1,17 +1,30 @@
+jest.mock("@services/tracing", () => ({
+  recordExceptionInCurrentSpan: jest.fn(),
+}))
+
 import { PaymentSendStatus } from "@domain/bitcoin/lightning"
+import { ErrorLevel } from "@domain/shared"
 import { UnconfirmedIbexPayment } from "@services/ibex/errors"
 import {
+  lnurlPaymentSendStatusOrPending,
   paymentSendStatusFromIbex,
+  paymentSendStatusFromIbexLnurlPay,
   paymentSendStatusOrPending,
 } from "@services/ibex/payment-status"
+import { recordExceptionInCurrentSpan } from "@services/tracing"
+
+const recordMock = recordExceptionInCurrentSpan as jest.Mock
 
 const withNestedStatus = (id: number) => ({
   transaction: { payment: { status: { id } } },
 })
 
+// Responses payInvoiceV2 callers cannot read an outcome from. Note `{ status: 2 }`:
+// a lone top-level SUCCEEDED is NOT settlement — see the precedence tests below.
 const unreadableResponses = [
   {},
   { status: 0 },
+  { status: 2 },
   { status: 7 },
   { transaction: {} },
   { transaction: { payment: {} } },
@@ -20,6 +33,10 @@ const unreadableResponses = [
   null,
   undefined,
 ]
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
 
 describe("paymentSendStatusFromIbex", () => {
   it("maps the recognised IBEX status ids", () => {
@@ -34,26 +51,93 @@ describe("paymentSendStatusFromIbex", () => {
     )
   })
 
-  it("falls back to the top-level status field", () => {
+  it("falls back to the top-level status field for pending and failure", () => {
+    expect(paymentSendStatusFromIbex({ status: 1 })).toBe(PaymentSendStatus.Pending)
     expect(paymentSendStatusFromIbex({ status: 3 })).toBe(PaymentSendStatus.Failure)
   })
 
   it("skips unset (0) fields rather than reading them as unknown", () => {
-    // IBEX omits nothing: unset integers come back as 0, so a 0 in the first
+    // 0 is IBEX's UNKNOWN (docs.poweredbyibex.io/reference/flow-1#payment-status)
+    // and is also what an unset integer deserialises to, so a 0 in the first
     // position must not mask a real status further down the response. This is
     // what the previous `status?.id ?? statusId` chain got wrong.
-    const response = {
-      status: 2,
-      transaction: { payment: { statusId: 0, status: { id: 0 } } },
-    }
+    const response = { transaction: { payment: { statusId: 2, status: { id: 0 } } } }
 
     expect(paymentSendStatusFromIbex(response)).toBe(PaymentSendStatus.Success)
+  })
+
+  it("never settles a payment on the top-level status field alone", () => {
+    // The top-level `status` is the least corroborated of the three fields (no
+    // sibling `name` in the schema to confirm its enum) and the only context it
+    // is ever read in is the anomalous one — both payment-level fields
+    // unreadable. That is the worst possible place to upgrade a send to
+    // "settled", so a lone top-level 2 is reported as unconfirmed.
+    const unconfirmed = paymentSendStatusFromIbex({ status: 2 })
+
+    expect(unconfirmed).toBeInstanceOf(UnconfirmedIbexPayment)
+    expect((unconfirmed as UnconfirmedIbexPayment).message).toMatch(
+      /top-level status field/i,
+    )
+    expect(
+      paymentSendStatusFromIbex({
+        status: 2,
+        transaction: { payment: { statusId: 0, status: { id: 0 } } },
+      }),
+    ).toBeInstanceOf(UnconfirmedIbexPayment)
+  })
+
+  describe("field precedence when two recognised fields disagree", () => {
+    it("prefers the payment-level nested status over the top-level status", () => {
+      expect(
+        paymentSendStatusFromIbex({
+          status: 2,
+          transaction: { payment: { status: { id: 3 } } },
+        }),
+      ).toBe(PaymentSendStatus.Failure)
+    })
+
+    it("prefers the payment-level nested status over the top-level status (mirror)", () => {
+      expect(
+        paymentSendStatusFromIbex({
+          status: 3,
+          transaction: { payment: { status: { id: 2 } } },
+        }),
+      ).toBe(PaymentSendStatus.Success)
+    })
+
+    it("prefers the nested status object over the flat statusId", () => {
+      expect(
+        paymentSendStatusFromIbex({
+          transaction: { payment: { statusId: 2, status: { id: 3 } } },
+        }),
+      ).toBe(PaymentSendStatus.Failure)
+      expect(
+        paymentSendStatusFromIbex({
+          transaction: { payment: { statusId: 3, status: { id: 2 } } },
+        }),
+      ).toBe(PaymentSendStatus.Success)
+    })
+
+    it("prefers the flat statusId over the top-level status", () => {
+      expect(
+        paymentSendStatusFromIbex({
+          status: 2,
+          transaction: { payment: { statusId: 3 } },
+        }),
+      ).toBe(PaymentSendStatus.Failure)
+    })
   })
 
   it("returns UnconfirmedIbexPayment when no recognised status is present", () => {
     for (const response of unreadableResponses) {
       expect(paymentSendStatusFromIbex(response)).toBeInstanceOf(UnconfirmedIbexPayment)
     }
+  })
+
+  it("raises the unreadable payInvoiceV2 case at Critical", () => {
+    const unconfirmed = paymentSendStatusFromIbex({}) as UnconfirmedIbexPayment
+
+    expect(unconfirmed.level).toBe(ErrorLevel.Critical)
   })
 
   it("never reports success without an explicit success id", () => {
@@ -82,5 +166,122 @@ describe("paymentSendStatusOrPending", () => {
       expect(status).toBe(PaymentSendStatus.Pending)
       expect(status).not.toBe(PaymentSendStatus.Success)
     }
+  })
+
+  it("records the anomaly exactly once, as a Critical UnconfirmedIbexPayment", () => {
+    for (const response of unreadableResponses) {
+      recordMock.mockClear()
+
+      paymentSendStatusOrPending(response)
+
+      expect(recordMock).toHaveBeenCalledTimes(1)
+      const [{ error, level }] = recordMock.mock.calls[0]
+      expect(error).toBeInstanceOf(UnconfirmedIbexPayment)
+      expect(level).toBe(ErrorLevel.Critical)
+    }
+  })
+
+  it("records the identifying fields so the payment is nameable from the alert", () => {
+    // Without these an operator woken by "money may or may not have moved" has
+    // to trace-hop to the child ibex-client span before they can name it.
+    paymentSendStatusOrPending({
+      status: 0,
+      transaction: {
+        id: "dfeec8bd-b4e7-46f1-aa4a-cf4e4569df02",
+        accountId: "eeba6152-9432-448e-b7d2-4205e5099924",
+        payment: { hash: "19b7ff42e048d147", statusId: 0 },
+      },
+    })
+
+    expect(recordMock).toHaveBeenCalledTimes(1)
+    expect(recordMock.mock.calls[0][0].attributes).toEqual({
+      "ibex.transaction.id": "dfeec8bd-b4e7-46f1-aa4a-cf4e4569df02",
+      "ibex.payment.hash": "19b7ff42e048d147",
+      "ibex.account.id": "eeba6152-9432-448e-b7d2-4205e5099924",
+    })
+  })
+
+  it("does not record anything for a recognised status", () => {
+    paymentSendStatusOrPending(withNestedStatus(1))
+    paymentSendStatusOrPending(withNestedStatus(2))
+    paymentSendStatusOrPending(withNestedStatus(3))
+    paymentSendStatusOrPending({ status: 3 })
+
+    expect(recordMock).not.toHaveBeenCalled()
+  })
+})
+
+describe("paymentSendStatusFromIbexLnurlPay", () => {
+  // payToLnurl's 201 has no top-level `status` and no
+  // `transaction.payment.status` object — only `transaction.payment.statusId`
+  // (documented example: 0) next to a populated top-level `settleDateUtc`.
+  const settledLnurlResponse = {
+    settleDateUtc: 1668544241,
+    hash: "19b7ff42e048d14791180d63592099b3394fc9ea7e3243906e810362124c29fd",
+    transaction: {
+      id: "dfeec8bd-b4e7-46f1-aa4a-cf4e4569df02",
+      accountId: "eeba6152-9432-448e-b7d2-4205e5099924",
+      payment: { statusId: 0 },
+    },
+  }
+
+  it("reads a recognised payment-level status when the endpoint reports one", () => {
+    expect(paymentSendStatusFromIbexLnurlPay(withNestedStatus(2))).toBe(
+      PaymentSendStatus.Success,
+    )
+    expect(
+      paymentSendStatusFromIbexLnurlPay({ transaction: { payment: { statusId: 3 } } }),
+    ).toBe(PaymentSendStatus.Failure)
+  })
+
+  it("treats a populated settleDateUtc as settlement when statusId is 0", () => {
+    expect(paymentSendStatusFromIbexLnurlPay(settledLnurlResponse)).toBe(
+      PaymentSendStatus.Success,
+    )
+  })
+
+  it("does not page on the happy path", () => {
+    lnurlPaymentSendStatusOrPending(settledLnurlResponse)
+
+    expect(recordMock).not.toHaveBeenCalled()
+  })
+
+  it("lets a recognised status override the settle date", () => {
+    expect(
+      paymentSendStatusFromIbexLnurlPay({
+        ...settledLnurlResponse,
+        transaction: { payment: { statusId: 3 } },
+      }),
+    ).toBe(PaymentSendStatus.Failure)
+  })
+
+  it("treats an unset (0) settle date as no settlement", () => {
+    expect(
+      paymentSendStatusFromIbexLnurlPay({
+        settleDateUtc: 0,
+        transaction: { payment: { statusId: 0 } },
+      }),
+    ).toBeInstanceOf(UnconfirmedIbexPayment)
+  })
+
+  it("raises the unreadable LNURL case at Warn, not Critical", () => {
+    // No real payToLnurl response has been captured on TEST yet, so an
+    // unreadable one must not page — it may be this endpoint's happy path.
+    const unconfirmed = paymentSendStatusFromIbexLnurlPay({}) as UnconfirmedIbexPayment
+
+    expect(unconfirmed).toBeInstanceOf(UnconfirmedIbexPayment)
+    expect(unconfirmed.level).toBe(ErrorLevel.Warn)
+  })
+})
+
+describe("lnurlPaymentSendStatusOrPending", () => {
+  it("reports an unreadable response as pending and records it at the error's own level", () => {
+    const status = lnurlPaymentSendStatusOrPending({ transaction: { payment: {} } })
+
+    expect(status).toBe(PaymentSendStatus.Pending)
+    expect(recordMock).toHaveBeenCalledTimes(1)
+    const [{ error, level }] = recordMock.mock.calls[0]
+    expect(error).toBeInstanceOf(UnconfirmedIbexPayment)
+    expect(level).toBe(ErrorLevel.Warn)
   })
 })

--- a/test/flash/unit/services/ibex/payment-status.spec.ts
+++ b/test/flash/unit/services/ibex/payment-status.spec.ts
@@ -1,4 +1,6 @@
 jest.mock("@services/tracing", () => ({
+  addAttributesToCurrentSpan: jest.fn(),
+  addEventToCurrentSpan: jest.fn(),
   recordExceptionInCurrentSpan: jest.fn(),
 }))
 
@@ -6,12 +8,17 @@ import { PaymentSendStatus } from "@domain/bitcoin/lightning"
 import { ErrorLevel } from "@domain/shared"
 import { UnconfirmedIbexPayment } from "@services/ibex/errors"
 import {
+  UNCONFIRMED_SPAN_EVENT,
   lnurlPaymentSendStatusOrPending,
   paymentSendStatusFromIbex,
   paymentSendStatusFromIbexLnurlPay,
   paymentSendStatusOrPending,
 } from "@services/ibex/payment-status"
-import { recordExceptionInCurrentSpan } from "@services/tracing"
+import {
+  addAttributesToCurrentSpan,
+  addEventToCurrentSpan,
+  recordExceptionInCurrentSpan,
+} from "@services/tracing"
 
 // The vendor's own documented response bodies, committed verbatim. Neither is a
 // live capture — that is the point: these are the only evidence either reader
@@ -21,10 +28,46 @@ import * as payInvoiceMock from "test/flash/mocks/ibex/pay-invoice"
 import * as payToLnurlMock from "test/flash/mocks/ibex/pay-to-lnurl"
 
 const recordMock = recordExceptionInCurrentSpan as jest.Mock
+const attrMock = addAttributesToCurrentSpan as jest.Mock
+const eventMock = addEventToCurrentSpan as jest.Mock
 
 const withNestedStatus = (id: number) => ({
   transaction: { payment: { status: { id } } },
 })
+
+/**
+ * An unreadable response is recorded on exactly one of two channels, never
+ * both and never neither — see recordUnconfirmed. `recordExceptionInCurrentSpan`
+ * ends in an unconditional `span.setStatus({ code: ERROR })`, so the channel,
+ * not the ErrorLevel, is what decides whether the span goes red. This helper
+ * asserts the "exactly one" invariant and hands back which channel fired so the
+ * tests below can pin the choice per response shape.
+ */
+const soleRecord = () => {
+  expect(recordMock.mock.calls.length + eventMock.mock.calls.length).toBe(1)
+
+  if (recordMock.mock.calls.length === 1) {
+    const [payload] = recordMock.mock.calls[0]
+    return {
+      loud: true as const,
+      level: payload.level as ErrorLevel,
+      error: payload.error as UnconfirmedIbexPayment,
+      reason: (payload.error as UnconfirmedIbexPayment).message,
+      attributes: payload.attributes as Record<string, unknown>,
+    }
+  }
+
+  const [name, eventAttributes] = eventMock.mock.calls[0]
+  expect(name).toBe(UNCONFIRMED_SPAN_EVENT)
+  const spanAttributes = Object.assign({}, ...attrMock.mock.calls.map(([a]) => a))
+  return {
+    loud: false as const,
+    level: eventAttributes["ibex.payment.unconfirmed.level"] as ErrorLevel,
+    error: undefined,
+    reason: eventAttributes["ibex.payment.unconfirmed.reason"] as string,
+    attributes: spanAttributes as Record<string, unknown>,
+  }
+}
 
 // Responses payInvoiceV2 callers cannot read an outcome from. Note `{ status: 2 }`
 // and `{ status: 3 }`: a lone top-level SUCCEEDED is not settlement and a lone
@@ -300,36 +343,113 @@ describe("paymentSendStatusOrPending", () => {
   })
 
   it("records the anomaly exactly once, at the error's own level", () => {
+    // soleRecord() asserts the "exactly once, on exactly one channel" half.
+    // Collect the levels and check them after the loop so every assertion is
+    // unconditional.
+    const recordedLevels: ErrorLevel[] = []
+    const errorOwnLevels: ErrorLevel[] = []
+
     for (const response of unreadableResponses) {
-      recordMock.mockClear()
+      jest.clearAllMocks()
 
       paymentSendStatusOrPending(response)
 
-      expect(recordMock).toHaveBeenCalledTimes(1)
-      const [{ error, level }] = recordMock.mock.calls[0]
-      expect(error).toBeInstanceOf(UnconfirmedIbexPayment)
-      expect(level).toBe(ErrorLevel.Warn)
-      expect(level).toBe((error as UnconfirmedIbexPayment).level)
+      const recorded = soleRecord()
+      recordedLevels.push(recorded.level)
+      // Present only on the loud channel; the level must be the error's own
+      // rather than a hardcoded one, so that raising a reader's severity needs
+      // no change in recordUnconfirmed.
+      if (recorded.error) errorOwnLevels.push(recorded.error.level)
     }
+
+    expect(recordedLevels).toEqual(unreadableResponses.map(() => ErrorLevel.Warn))
+    expect(errorOwnLevels.length).toBeGreaterThan(0)
+    expect(errorOwnLevels).toEqual(errorOwnLevels.map(() => ErrorLevel.Warn))
+  })
+
+  describe("span volume — which channel each unreadable shape earns", () => {
+    // ErrorLevel does NOT decide this: recordExceptionInCurrentSpan ends in an
+    // unconditional span.setStatus({ code: ERROR }) (services/tracing.ts), so a
+    // Warn-level recordException still paints the span red and any trigger keyed
+    // on span status rather than the error.level attribute fires on it. Marking
+    // 100% of a rail's spans ERROR because its ordinary acceptance shape is
+    // unreadable would bury the anomalies that matter.
+    it("stays quiet — attributes + span event, no exception — when IBEX claimed nothing", () => {
+      for (const response of [
+        {},
+        { status: 0 },
+        { status: 7 },
+        { transaction: { payment: {} } },
+        { transaction: { payment: { statusId: 0, status: { id: 0 } } } },
+        null,
+        undefined,
+      ]) {
+        jest.clearAllMocks()
+
+        expect(paymentSendStatusOrPending(response)).toBe(PaymentSendStatus.Pending)
+
+        const recorded = soleRecord()
+        expect(recorded.loud).toBe(false)
+        expect(recorded.attributes["ibex.payment.unconfirmed"]).toBe(true)
+        expect(recordMock).not.toHaveBeenCalled()
+      }
+    })
+
+    it("goes loud — a recorded exception — when IBEX claimed a terminal outcome we refused", () => {
+      // Here the payload disagrees with itself: a top-level SUCCEEDED/FAILED
+      // that the corroboration rules would not honour. The `pending` we report
+      // may be wrong in a direction that moved money, so the ERROR span status
+      // that comes with recordException is earned.
+      for (const [response, outcome] of [
+        [{ status: 2 }, "SUCCEEDED"],
+        [{ status: 3 }, "FAILED"],
+        [
+          { status: 3, failureReason: 0, transaction: { payment: { failureId: 0 } } },
+          "FAILED",
+        ],
+        [{ status: 2, transaction: { payment: { statusId: 0 } } }, "SUCCEEDED"],
+      ] as const) {
+        jest.clearAllMocks()
+
+        expect(paymentSendStatusOrPending(response)).toBe(PaymentSendStatus.Pending)
+
+        const recorded = soleRecord()
+        if (!recorded.loud) throw new Error("expected a recorded exception, got an event")
+        expect(recorded.attributes["ibex.payment.uncorroborated_outcome"]).toBe(outcome)
+        expect(recorded.error.uncorroboratedOutcome).toBe(outcome)
+        expect(eventMock).not.toHaveBeenCalled()
+      }
+    })
   })
 
   it("records the identifying fields so the payment is nameable from the alert", () => {
-    // Without these an operator woken by "money may or may not have moved" has
-    // to trace-hop to the child ibex-client span before they can name it.
-    paymentSendStatusOrPending({
-      status: 0,
-      transaction: {
-        id: "dfeec8bd-b4e7-46f1-aa4a-cf4e4569df02",
-        accountId: "eeba6152-9432-448e-b7d2-4205e5099924",
-        payment: { hash: "19b7ff42e048d147", statusId: 0 },
-      },
-    })
-
-    expect(recordMock).toHaveBeenCalledTimes(1)
-    expect(recordMock.mock.calls[0][0].attributes).toEqual({
+    // Without these an operator looking at "money may or may not have moved"
+    // has to trace-hop to the child ibex-client span before they can name it.
+    // They must land on BOTH channels — a quiet record that cannot name the
+    // payment is not a record.
+    const identity = {
       "ibex.transaction.id": "dfeec8bd-b4e7-46f1-aa4a-cf4e4569df02",
       "ibex.payment.hash": "19b7ff42e048d147",
       "ibex.account.id": "eeba6152-9432-448e-b7d2-4205e5099924",
+    }
+    const transaction = {
+      id: identity["ibex.transaction.id"],
+      accountId: identity["ibex.account.id"],
+      payment: { hash: identity["ibex.payment.hash"], statusId: 0 },
+    }
+
+    paymentSendStatusOrPending({ status: 0, transaction })
+    expect(soleRecord()).toMatchObject({
+      loud: false,
+      attributes: expect.objectContaining(identity),
+    })
+
+    jest.clearAllMocks()
+
+    paymentSendStatusOrPending({ status: 2, transaction })
+    expect(soleRecord()).toMatchObject({
+      loud: true,
+      attributes: expect.objectContaining(identity),
     })
   })
 
@@ -341,6 +461,8 @@ describe("paymentSendStatusOrPending", () => {
     paymentSendStatusOrPending({ status: 3, failureReason: 2 })
 
     expect(recordMock).not.toHaveBeenCalled()
+    expect(eventMock).not.toHaveBeenCalled()
+    expect(attrMock).not.toHaveBeenCalled()
   })
 
   it("reports an uncorroborated top-level FAILED as pending, not as failed", () => {
@@ -387,6 +509,7 @@ describe("paymentSendStatusFromIbexLnurlPay", () => {
     lnurlPaymentSendStatusOrPending(settledLnurlResponse)
 
     expect(recordMock).not.toHaveBeenCalled()
+    expect(eventMock).not.toHaveBeenCalled()
   })
 
   it("lets a recognised status override the settle date", () => {
@@ -419,7 +542,16 @@ describe("paymentSendStatusFromIbexLnurlPay", () => {
       expect(lnurlPaymentSendStatusOrPending(payToLnurlMock.response)).toBe(
         PaymentSendStatus.Pending,
       )
-      expect(recordMock).toHaveBeenCalledTimes(1)
+
+      // Recorded, but QUIETLY: this shape is the vendor's own documented
+      // acceptance, i.e. plausibly this rail's every-send happy path. A
+      // recorded exception would set the span status to ERROR (tracing.ts
+      // does it unconditionally, regardless of ErrorLevel) and turn 100% of
+      // the LNURL rail red.
+      const recorded = soleRecord()
+      expect(recorded.loud).toBe(false)
+      expect(recorded.level).toBe(ErrorLevel.Warn)
+      expect(recordMock).not.toHaveBeenCalled()
     })
 
     it("ignores a top-level settle date in every serialisation", () => {
@@ -530,10 +662,33 @@ describe("lnurlPaymentSendStatusOrPending", () => {
     const status = lnurlPaymentSendStatusOrPending({ transaction: { payment: {} } })
 
     expect(status).toBe(PaymentSendStatus.Pending)
-    expect(recordMock).toHaveBeenCalledTimes(1)
-    const [{ error, level }] = recordMock.mock.calls[0]
-    expect(error).toBeInstanceOf(UnconfirmedIbexPayment)
-    expect(level).toBe(ErrorLevel.Warn)
+    const recorded = soleRecord()
+    expect(recorded.level).toBe(ErrorLevel.Warn)
+  })
+
+  it("never records an exception on this rail — the dialect cannot produce one", () => {
+    // The payToLnurl 201 has no top-level `status` field at all, so this reader
+    // can never be in the "IBEX claimed a terminal outcome we refused" case
+    // that earns a red span. Every unreadable payToLnurl response is therefore
+    // quiet, which is the whole point: this rail's documented acceptance shape
+    // IS unreadable, and it must not paint every send ERROR.
+    for (const response of [
+      {},
+      null,
+      undefined,
+      { transaction: {} },
+      { transaction: { payment: {} } },
+      { transaction: { payment: { statusId: 0 } } },
+      { transaction: { payment: { statusId: 0, settleDateUtc: 0 } } },
+      payToLnurlMock.response,
+    ]) {
+      jest.clearAllMocks()
+
+      expect(lnurlPaymentSendStatusOrPending(response)).toBe(PaymentSendStatus.Pending)
+
+      expect(recordMock).not.toHaveBeenCalled()
+      expect(soleRecord().loud).toBe(false)
+    }
   })
 
   it("records the payment hash from the top level, where payToLnurl puts it", () => {
@@ -551,8 +706,7 @@ describe("lnurlPaymentSendStatusOrPending", () => {
       },
     })
 
-    expect(recordMock).toHaveBeenCalledTimes(1)
-    expect(recordMock.mock.calls[0][0].attributes).toEqual({
+    expect(soleRecord().attributes).toMatchObject({
       "ibex.transaction.id": "dfeec8bd-b4e7-46f1-aa4a-cf4e4569df02",
       "ibex.payment.hash":
         "19b7ff42e048d14791180d63592099b3394fc9ea7e3243906e810362124c29fd",
@@ -566,8 +720,6 @@ describe("lnurlPaymentSendStatusOrPending", () => {
       transaction: { payment: { hash: "payment-level-hash", statusId: 0 } },
     })
 
-    expect(recordMock.mock.calls[0][0].attributes["ibex.payment.hash"]).toBe(
-      "payment-level-hash",
-    )
+    expect(soleRecord().attributes["ibex.payment.hash"]).toBe("payment-level-hash")
   })
 })

--- a/test/flash/unit/services/ibex/payment-status.spec.ts
+++ b/test/flash/unit/services/ibex/payment-status.spec.ts
@@ -26,6 +26,7 @@ import {
 // imagined.
 import * as payInvoiceMock from "test/flash/mocks/ibex/pay-invoice"
 import * as payToLnurlMock from "test/flash/mocks/ibex/pay-to-lnurl"
+import { capturedSettledLightningSend } from "test/flash/mocks/ibex/transaction-details-captured"
 
 const recordMock = recordExceptionInCurrentSpan as jest.Mock
 const attrMock = addAttributesToCurrentSpan as jest.Mock
@@ -721,5 +722,40 @@ describe("lnurlPaymentSendStatusOrPending", () => {
     })
 
     expect(soleRecord().attributes["ibex.payment.hash"]).toBe("payment-level-hash")
+  })
+})
+
+describe("against a REAL captured IBEX response", () => {
+  // test/flash/mocks/ibex/transaction-details-captured.ts — a settled Lightning
+  // send pulled from the sandbox hub on 2026-08-16, not an openapi example.
+  // Everything else in this suite is derived from the generated examples; this
+  // is the one place the readers are held against a shape IBEX actually sent.
+  const { payment } = capturedSettledLightningSend
+
+  it("populates BOTH payment-level status fields on a settled send", () => {
+    // The precedence rule reads payment-level fields first and only falls back
+    // to the top-level status. If IBEX left these empty in practice, that
+    // fallback — and the Critical severity on the unreadable case — would be
+    // firing on the happy path instead of on a genuine anomaly.
+    expect(payment.statusId).toBe(2)
+    expect(payment.status.id).toBe(2)
+    expect(payment.status.name).toBe("SUCCEEDED")
+  })
+
+  it("reads the captured payment as a settled send", () => {
+    expect(paymentSendStatusFromIbex({ transaction: { payment } })).toBe(
+      PaymentSendStatus.Success,
+    )
+  })
+
+  it("reports no failure code on a successful payment", () => {
+    expect(payment.failureId).toBe(0)
+  })
+
+  it("returns an ISO-string settleDateUtc, not the integer epoch of the example", () => {
+    // hasSettleDate must accept both serialisations: the payToLnurl example
+    // declares an integer epoch, but a real payment-level settle date is ISO.
+    expect(typeof payment.settleDateUtc).toBe("string")
+    expect(Number.isNaN(Date.parse(payment.settleDateUtc))).toBe(false)
   })
 })

--- a/test/flash/unit/services/ibex/payment-status.spec.ts
+++ b/test/flash/unit/services/ibex/payment-status.spec.ts
@@ -19,12 +19,15 @@ const withNestedStatus = (id: number) => ({
   transaction: { payment: { status: { id } } },
 })
 
-// Responses payInvoiceV2 callers cannot read an outcome from. Note `{ status: 2 }`:
-// a lone top-level SUCCEEDED is NOT settlement — see the precedence tests below.
+// Responses payInvoiceV2 callers cannot read an outcome from. Note `{ status: 2 }`
+// and `{ status: 3 }`: a lone top-level SUCCEEDED is not settlement and a lone
+// top-level FAILED is not failure — see the precedence tests below.
 const unreadableResponses = [
   {},
   { status: 0 },
   { status: 2 },
+  { status: 3 },
+  { status: 3, failureReason: 0, transaction: { payment: { failureId: 0 } } },
   { status: 7 },
   { transaction: {} },
   { transaction: { payment: {} } },
@@ -51,9 +54,50 @@ describe("paymentSendStatusFromIbex", () => {
     )
   })
 
-  it("falls back to the top-level status field for pending and failure", () => {
+  it("falls back to the top-level status field for pending unconditionally", () => {
+    // Pending needs no corroboration: it is the same outcome the unconfirmed
+    // path reports anyway, so reading it commits to nothing.
     expect(paymentSendStatusFromIbex({ status: 1 })).toBe(PaymentSendStatus.Pending)
-    expect(paymentSendStatusFromIbex({ status: 3 })).toBe(PaymentSendStatus.Failure)
+  })
+
+  it("falls back to the top-level status field for failure only when IBEX names a failure code", () => {
+    expect(paymentSendStatusFromIbex({ status: 3, failureReason: 2 })).toBe(
+      PaymentSendStatus.Failure,
+    )
+    expect(
+      paymentSendStatusFromIbex({
+        status: 3,
+        transaction: { payment: { failureId: 4 } },
+      }),
+    ).toBe(PaymentSendStatus.Failure)
+  })
+
+  it("never fails a payment on the top-level status field alone", () => {
+    // The mirror of "never invent a settled send". Telling a user "failed" for
+    // a send IBEX may in fact have made sends them back to retry with a fresh
+    // idempotency key — the double-pay hole withPaymentIdempotency (#478)
+    // exists to close. The top-level field is the least corroborated of the
+    // three and is only ever read when both payment-level fields said nothing;
+    // that argument does not stop applying when the digit is 3.
+    const unconfirmed = paymentSendStatusFromIbex({ status: 3 })
+
+    expect(unconfirmed).toBeInstanceOf(UnconfirmedIbexPayment)
+    expect((unconfirmed as UnconfirmedIbexPayment).message).toMatch(
+      /FAILED only in the top-level status field/i,
+    )
+  })
+
+  it("treats a zeroed failure code as no corroboration", () => {
+    // Every integer in the generated schema declares `default: 0`, so an unset
+    // failureReason/failureId arrives as 0 — that is IBEX saying "no failure",
+    // never "failed for reason zero".
+    expect(
+      paymentSendStatusFromIbex({
+        status: 3,
+        failureReason: 0,
+        transaction: { payment: { failureId: 0 } },
+      }),
+    ).toBeInstanceOf(UnconfirmedIbexPayment)
   })
 
   it("skips unset (0) fields rather than reading them as unknown", () => {
@@ -126,6 +170,26 @@ describe("paymentSendStatusFromIbex", () => {
         }),
       ).toBe(PaymentSendStatus.Failure)
     })
+
+    it("does not read a top-level FAILED past an unset payment-level statusId without a failure code", () => {
+      // The shape that made this a finding: payment-level unreadable (0 is
+      // unset/UNKNOWN, never an outcome) with a bare top-level 3. Uncorroborated
+      // it is unconfirmed; the moment IBEX also names a failure code it is a
+      // genuine failure.
+      expect(
+        paymentSendStatusFromIbex({
+          status: 3,
+          transaction: { payment: { statusId: 0 } },
+        }),
+      ).toBeInstanceOf(UnconfirmedIbexPayment)
+      expect(
+        paymentSendStatusFromIbex({
+          status: 3,
+          failureReason: 12,
+          transaction: { payment: { statusId: 0 } },
+        }),
+      ).toBe(PaymentSendStatus.Failure)
+    })
   })
 
   it("returns UnconfirmedIbexPayment when no recognised status is present", () => {
@@ -143,6 +207,15 @@ describe("paymentSendStatusFromIbex", () => {
   it("never reports success without an explicit success id", () => {
     for (const response of unreadableResponses) {
       expect(paymentSendStatusFromIbex(response)).not.toBe(PaymentSendStatus.Success)
+    }
+  })
+
+  it("never reports failure without an explicit, corroborated failure", () => {
+    // The mirror invariant. A fabricated "failed" is not a safe default: it
+    // sends the user back to retry with a new idempotency key against a send
+    // that may already have paid.
+    for (const response of unreadableResponses) {
+      expect(paymentSendStatusFromIbex(response)).not.toBe(PaymentSendStatus.Failure)
     }
   })
 })
@@ -205,9 +278,20 @@ describe("paymentSendStatusOrPending", () => {
     paymentSendStatusOrPending(withNestedStatus(1))
     paymentSendStatusOrPending(withNestedStatus(2))
     paymentSendStatusOrPending(withNestedStatus(3))
-    paymentSendStatusOrPending({ status: 3 })
+    paymentSendStatusOrPending({ status: 1 })
+    paymentSendStatusOrPending({ status: 3, failureReason: 2 })
 
     expect(recordMock).not.toHaveBeenCalled()
+  })
+
+  it("reports an uncorroborated top-level FAILED as pending, not as failed", () => {
+    const status = paymentSendStatusOrPending({
+      status: 3,
+      transaction: { payment: { statusId: 0, status: { id: 0 } } },
+    })
+
+    expect(status).toBe(PaymentSendStatus.Pending)
+    expect(recordMock).toHaveBeenCalledTimes(1)
   })
 })
 
@@ -264,6 +348,54 @@ describe("paymentSendStatusFromIbexLnurlPay", () => {
     ).toBeInstanceOf(UnconfirmedIbexPayment)
   })
 
+  describe("settleDateUtc serialisation", () => {
+    // The top-level field declares an integer epoch, but the payment-level one
+    // has no declared type at all and every payment-level date this vendor DOES
+    // declare is an ISO string ("2023-07-06T14:51:59.389565Z" — see
+    // test/flash/mocks/ibex/pay-invoice.ts). Settlement-on-settle-date is the
+    // only route by which an LNURL send can report success, so a number-only
+    // reader would return the pre-fix always-pending behaviour plus a Warn span
+    // on every send.
+    it("accepts an ISO string settle date at the top level", () => {
+      expect(
+        paymentSendStatusFromIbexLnurlPay({
+          settleDateUtc: "2022-11-15T20:30:41.960887Z",
+          transaction: { payment: { statusId: 0 } },
+        }),
+      ).toBe(PaymentSendStatus.Success)
+    })
+
+    it("accepts an ISO string settle date at the payment level", () => {
+      expect(
+        paymentSendStatusFromIbexLnurlPay({
+          transaction: {
+            payment: { statusId: 0, settleDateUtc: "2023-07-06T14:51:59.389565Z" },
+          },
+        }),
+      ).toBe(PaymentSendStatus.Success)
+    })
+
+    it("rejects the vendor's zero-date sentinel and unparseable strings", () => {
+      // "0001-01-01T00:00:00Z" is this vendor's zero value (it is the
+      // creationDateUtc example on the payToLnurl 201 itself) and parses to a
+      // large NEGATIVE epoch — it must be rejected exactly like the integer 0.
+      for (const settleDateUtc of [
+        "0001-01-01T00:00:00Z",
+        "",
+        "   ",
+        "not-a-date",
+        null,
+      ]) {
+        expect(
+          paymentSendStatusFromIbexLnurlPay({
+            settleDateUtc,
+            transaction: { payment: { statusId: 0 } },
+          }),
+        ).toBeInstanceOf(UnconfirmedIbexPayment)
+      }
+    })
+  })
+
   it("raises the unreadable LNURL case at Warn, not Critical", () => {
     // No real payToLnurl response has been captured on TEST yet, so an
     // unreadable one must not page — it may be this endpoint's happy path.
@@ -283,5 +415,40 @@ describe("lnurlPaymentSendStatusOrPending", () => {
     const [{ error, level }] = recordMock.mock.calls[0]
     expect(error).toBeInstanceOf(UnconfirmedIbexPayment)
     expect(level).toBe(ErrorLevel.Warn)
+  })
+
+  it("records the payment hash from the top level, where payToLnurl puts it", () => {
+    // payToLnurl's 201 declares `transaction.payment.hash` with an EMPTY schema
+    // and carries the 64-char hash at the top level instead. Reading only the
+    // payInvoiceV2 position hands an operator transaction id and account id but
+    // not the one field that names the payment — with the hash sitting right
+    // there in the response.
+    lnurlPaymentSendStatusOrPending({
+      hash: "19b7ff42e048d14791180d63592099b3394fc9ea7e3243906e810362124c29fd",
+      transaction: {
+        id: "dfeec8bd-b4e7-46f1-aa4a-cf4e4569df02",
+        accountId: "eeba6152-9432-448e-b7d2-4205e5099924",
+        payment: { statusId: 0 },
+      },
+    })
+
+    expect(recordMock).toHaveBeenCalledTimes(1)
+    expect(recordMock.mock.calls[0][0].attributes).toEqual({
+      "ibex.transaction.id": "dfeec8bd-b4e7-46f1-aa4a-cf4e4569df02",
+      "ibex.payment.hash":
+        "19b7ff42e048d14791180d63592099b3394fc9ea7e3243906e810362124c29fd",
+      "ibex.account.id": "eeba6152-9432-448e-b7d2-4205e5099924",
+    })
+  })
+
+  it("prefers the payment-level hash when the endpoint populates it", () => {
+    lnurlPaymentSendStatusOrPending({
+      hash: "top-level-hash",
+      transaction: { payment: { hash: "payment-level-hash", statusId: 0 } },
+    })
+
+    expect(recordMock.mock.calls[0][0].attributes["ibex.payment.hash"]).toBe(
+      "payment-level-hash",
+    )
   })
 })

--- a/test/flash/unit/services/ibex/payment-status.spec.ts
+++ b/test/flash/unit/services/ibex/payment-status.spec.ts
@@ -375,6 +375,29 @@ describe("paymentSendStatusFromIbexLnurlPay", () => {
       ).toBe(PaymentSendStatus.Success)
     })
 
+    it("reads an all-digit string as an epoch, not as a date", () => {
+      // Date.parse("0") is 946713600000 (V8 reads a bare "0" as the year 2000),
+      // so routing a stringified epoch through Date.parse inverts the check in
+      // BOTH directions: the unset sentinel would read as settled, and a real
+      // epoch would be rejected as an out-of-range year.
+      for (const settleDateUtc of ["0", "00", "-1", "+0"]) {
+        expect(
+          paymentSendStatusFromIbexLnurlPay({
+            settleDateUtc,
+            transaction: { payment: { statusId: 0 } },
+          }),
+        ).toBeInstanceOf(UnconfirmedIbexPayment)
+      }
+
+      expect(
+        paymentSendStatusFromIbexLnurlPay({
+          // the schema's own example, stringified
+          settleDateUtc: "1668544241",
+          transaction: { payment: { statusId: 0 } },
+        }),
+      ).toBe(PaymentSendStatus.Success)
+    })
+
     it("rejects the vendor's zero-date sentinel and unparseable strings", () => {
       // "0001-01-01T00:00:00Z" is this vendor's zero value (it is the
       // creationDateUtc example on the payToLnurl 201 itself) and parses to a

--- a/test/flash/unit/services/ibex/payment-status.spec.ts
+++ b/test/flash/unit/services/ibex/payment-status.spec.ts
@@ -629,7 +629,7 @@ describe("paymentSendStatusFromIbexLnurlPay", () => {
       )
     })
 
-    it("rejects the vendor's zero-date sentinel and unparseable strings", () => {
+    it("rejects the vendor's zero-date sentinel and unparsable strings", () => {
       // "0001-01-01T00:00:00Z" is this vendor's zero value (it is the
       // creationDateUtc example on the payToLnurl 201 itself) and parses to a
       // large NEGATIVE epoch — it must be rejected exactly like the integer 0.

--- a/test/flash/unit/services/ibex/payment-status.spec.ts
+++ b/test/flash/unit/services/ibex/payment-status.spec.ts
@@ -1,0 +1,86 @@
+import { PaymentSendStatus } from "@domain/bitcoin/lightning"
+import { UnconfirmedIbexPayment } from "@services/ibex/errors"
+import {
+  paymentSendStatusFromIbex,
+  paymentSendStatusOrPending,
+} from "@services/ibex/payment-status"
+
+const withNestedStatus = (id: number) => ({
+  transaction: { payment: { status: { id } } },
+})
+
+const unreadableResponses = [
+  {},
+  { status: 0 },
+  { status: 7 },
+  { transaction: {} },
+  { transaction: { payment: {} } },
+  { transaction: { payment: { status: {} } } },
+  { transaction: { payment: { statusId: 0, status: { id: 0 } } } },
+  null,
+  undefined,
+]
+
+describe("paymentSendStatusFromIbex", () => {
+  it("maps the recognised IBEX status ids", () => {
+    expect(paymentSendStatusFromIbex(withNestedStatus(1))).toBe(PaymentSendStatus.Pending)
+    expect(paymentSendStatusFromIbex(withNestedStatus(2))).toBe(PaymentSendStatus.Success)
+    expect(paymentSendStatusFromIbex(withNestedStatus(3))).toBe(PaymentSendStatus.Failure)
+  })
+
+  it("reads the flat statusId when the nested status object is absent", () => {
+    expect(paymentSendStatusFromIbex({ transaction: { payment: { statusId: 2 } } })).toBe(
+      PaymentSendStatus.Success,
+    )
+  })
+
+  it("falls back to the top-level status field", () => {
+    expect(paymentSendStatusFromIbex({ status: 3 })).toBe(PaymentSendStatus.Failure)
+  })
+
+  it("skips unset (0) fields rather than reading them as unknown", () => {
+    // IBEX omits nothing: unset integers come back as 0, so a 0 in the first
+    // position must not mask a real status further down the response. This is
+    // what the previous `status?.id ?? statusId` chain got wrong.
+    const response = {
+      status: 2,
+      transaction: { payment: { statusId: 0, status: { id: 0 } } },
+    }
+
+    expect(paymentSendStatusFromIbex(response)).toBe(PaymentSendStatus.Success)
+  })
+
+  it("returns UnconfirmedIbexPayment when no recognised status is present", () => {
+    for (const response of unreadableResponses) {
+      expect(paymentSendStatusFromIbex(response)).toBeInstanceOf(UnconfirmedIbexPayment)
+    }
+  })
+
+  it("never reports success without an explicit success id", () => {
+    for (const response of unreadableResponses) {
+      expect(paymentSendStatusFromIbex(response)).not.toBe(PaymentSendStatus.Success)
+    }
+  })
+})
+
+describe("paymentSendStatusOrPending", () => {
+  it("passes through a recognised status", () => {
+    expect(paymentSendStatusOrPending(withNestedStatus(2))).toBe(
+      PaymentSendStatus.Success,
+    )
+    expect(paymentSendStatusOrPending(withNestedStatus(3))).toBe(
+      PaymentSendStatus.Failure,
+    )
+  })
+
+  it("reports an unreadable response as pending, never as settled", () => {
+    // Pending keeps the result cacheable by withPaymentIdempotency, so a
+    // same-key retry replays it instead of paying again — the one case where
+    // we do not know whether funds moved is the last one that should re-pay.
+    for (const response of unreadableResponses) {
+      const status = paymentSendStatusOrPending(response)
+      expect(status).toBe(PaymentSendStatus.Pending)
+      expect(status).not.toBe(PaymentSendStatus.Success)
+    }
+  })
+})

--- a/test/flash/unit/services/ibex/payment-status.spec.ts
+++ b/test/flash/unit/services/ibex/payment-status.spec.ts
@@ -13,6 +13,13 @@ import {
 } from "@services/ibex/payment-status"
 import { recordExceptionInCurrentSpan } from "@services/tracing"
 
+// The vendor's own documented response bodies, committed verbatim. Neither is a
+// live capture — that is the point: these are the only evidence either reader
+// has, so the readers are asserted against them rather than against shapes we
+// imagined.
+import * as payInvoiceMock from "test/flash/mocks/ibex/pay-invoice"
+import * as payToLnurlMock from "test/flash/mocks/ibex/pay-to-lnurl"
+
 const recordMock = recordExceptionInCurrentSpan as jest.Mock
 
 const withNestedStatus = (id: number) => ({
@@ -198,10 +205,61 @@ describe("paymentSendStatusFromIbex", () => {
     }
   })
 
-  it("raises the unreadable payInvoiceV2 case at Critical", () => {
+  it("raises the unreadable payInvoiceV2 case at Warn, not Critical", () => {
+    // No real payInvoiceV2 200 has been captured on TEST: the committed
+    // fixture is the vendor's openapi example, and the pre-#483 intraledger
+    // code read the TOP-LEVEL status alone — direct evidence that a rail may
+    // populate only the field this reader treats as uncorroborated. Paging on
+    // every flash-to-flash send until a capture proves otherwise is an outage,
+    // not a severity.
     const unconfirmed = paymentSendStatusFromIbex({}) as UnconfirmedIbexPayment
 
-    expect(unconfirmed.level).toBe(ErrorLevel.Critical)
+    expect(unconfirmed.level).toBe(ErrorLevel.Warn)
+  })
+
+  it("reads the vendor's documented payInvoiceV2 200 example as in-flight", () => {
+    // The committed fixture populates all three status fields with IN_FLIGHT.
+    // Asserting the reader against the evidence that actually exists means a
+    // change to either the fixture or the precedence rules has to be deliberate.
+    expect(paymentSendStatusFromIbex(payInvoiceMock.response)).toBe(
+      PaymentSendStatus.Pending,
+    )
+  })
+
+  describe("named (non-numeric) failure codes", () => {
+    // The declared type admits strings, and a string reason can be NAMED
+    // rather than numeric. Coercing "NO_ROUTE" through Number() yields NaN,
+    // which used to read as "no corroboration" — reporting a definitively
+    // failed send as pending, which withPaymentIdempotency then caches for 24h
+    // under the same key.
+    it("accepts a named failureReason as corroboration", () => {
+      expect(paymentSendStatusFromIbex({ status: 3, failureReason: "NO_ROUTE" })).toBe(
+        PaymentSendStatus.Failure,
+      )
+    })
+
+    it("accepts a named payment-level failureId as corroboration", () => {
+      expect(
+        paymentSendStatusFromIbex({
+          status: 3,
+          transaction: { payment: { statusId: 0, failureId: "INSUFFICIENT_BALANCE" } },
+        }),
+      ).toBe(PaymentSendStatus.Failure)
+    })
+
+    it("accepts a numeric string code above zero", () => {
+      expect(paymentSendStatusFromIbex({ status: 3, failureReason: "2" })).toBe(
+        PaymentSendStatus.Failure,
+      )
+    })
+
+    it("still treats an explicit zero, blank or malformed string as no corroboration", () => {
+      for (const failureReason of ["0", "0.0", "-0", "", "   ", "-1", "Infinity"]) {
+        expect(paymentSendStatusFromIbex({ status: 3, failureReason })).toBeInstanceOf(
+          UnconfirmedIbexPayment,
+        )
+      }
+    })
   })
 
   it("never reports success without an explicit success id", () => {
@@ -241,7 +299,7 @@ describe("paymentSendStatusOrPending", () => {
     }
   })
 
-  it("records the anomaly exactly once, as a Critical UnconfirmedIbexPayment", () => {
+  it("records the anomaly exactly once, at the error's own level", () => {
     for (const response of unreadableResponses) {
       recordMock.mockClear()
 
@@ -250,7 +308,8 @@ describe("paymentSendStatusOrPending", () => {
       expect(recordMock).toHaveBeenCalledTimes(1)
       const [{ error, level }] = recordMock.mock.calls[0]
       expect(error).toBeInstanceOf(UnconfirmedIbexPayment)
-      expect(level).toBe(ErrorLevel.Critical)
+      expect(level).toBe(ErrorLevel.Warn)
+      expect(level).toBe((error as UnconfirmedIbexPayment).level)
     }
   })
 
@@ -298,14 +357,14 @@ describe("paymentSendStatusOrPending", () => {
 describe("paymentSendStatusFromIbexLnurlPay", () => {
   // payToLnurl's 201 has no top-level `status` and no
   // `transaction.payment.status` object — only `transaction.payment.statusId`
-  // (documented example: 0) next to a populated top-level `settleDateUtc`.
+  // (documented example: 0). Settlement is read from PAYMENT-LEVEL evidence
+  // only; see the top-level `settleDateUtc` tests below for why.
   const settledLnurlResponse = {
-    settleDateUtc: 1668544241,
     hash: "19b7ff42e048d14791180d63592099b3394fc9ea7e3243906e810362124c29fd",
     transaction: {
       id: "dfeec8bd-b4e7-46f1-aa4a-cf4e4569df02",
       accountId: "eeba6152-9432-448e-b7d2-4205e5099924",
-      payment: { statusId: 0 },
+      payment: { statusId: 0, settleDateUtc: "2022-11-15T20:30:41.960887Z" },
     },
   }
 
@@ -318,7 +377,7 @@ describe("paymentSendStatusFromIbexLnurlPay", () => {
     ).toBe(PaymentSendStatus.Failure)
   })
 
-  it("treats a populated settleDateUtc as settlement when statusId is 0", () => {
+  it("treats a populated payment-level settleDateUtc as settlement when statusId is 0", () => {
     expect(paymentSendStatusFromIbexLnurlPay(settledLnurlResponse)).toBe(
       PaymentSendStatus.Success,
     )
@@ -334,45 +393,92 @@ describe("paymentSendStatusFromIbexLnurlPay", () => {
     expect(
       paymentSendStatusFromIbexLnurlPay({
         ...settledLnurlResponse,
-        transaction: { payment: { statusId: 3 } },
+        transaction: { payment: { statusId: 3, settleDateUtc: "2022-11-15T20:30:41Z" } },
       }),
     ).toBe(PaymentSendStatus.Failure)
   })
 
-  it("treats an unset (0) settle date as no settlement", () => {
+  describe("the top-level settleDateUtc is never read as settlement", () => {
+    // The vendor's documented 201 example sets the top-level settleDateUtc to
+    // 1668544241 — `transaction.createdAt` ("2022-11-15T20:30:41.960887Z")
+    // floored to the second — while `statusId: 0`, `payment.settleDateUtc:
+    // null`, `paidMsat: 0` and `payment.hash: null` all say NOTHING SETTLED.
+    // payToLnurl also registers an async settlement webhook, so the 201 is an
+    // acceptance. Reading that field reported every LNURL send as success
+    // regardless of outcome — the "conversion successful while no funds moved"
+    // bug this module exists to close — with the Warn record suppressed on
+    // that path by design.
+    it("reports the vendor's documented 201 example as unconfirmed, never as success", () => {
+      const status = paymentSendStatusFromIbexLnurlPay(payToLnurlMock.response)
+
+      expect(status).toBeInstanceOf(UnconfirmedIbexPayment)
+      expect(status).not.toBe(PaymentSendStatus.Success)
+    })
+
+    it("reports the documented example as pending on the resolver path", () => {
+      expect(lnurlPaymentSendStatusOrPending(payToLnurlMock.response)).toBe(
+        PaymentSendStatus.Pending,
+      )
+      expect(recordMock).toHaveBeenCalledTimes(1)
+    })
+
+    it("ignores a top-level settle date in every serialisation", () => {
+      for (const settleDateUtc of [
+        1668544241,
+        "1668544241",
+        "2022-11-15T20:30:41.960887Z",
+        Date.now(),
+      ]) {
+        expect(
+          paymentSendStatusFromIbexLnurlPay({
+            settleDateUtc,
+            transaction: { payment: { statusId: 0 } },
+          }),
+        ).toBeInstanceOf(UnconfirmedIbexPayment)
+      }
+    })
+
+    it("does not let a top-level settle date mask an absent payment-level one", () => {
+      // The exact vendor-example shape: creation-time echo at the top, null
+      // below it.
+      expect(
+        paymentSendStatusFromIbexLnurlPay({
+          settleDateUtc: 1668544241,
+          transaction: { payment: { statusId: 0, settleDateUtc: null } },
+        }),
+      ).toBeInstanceOf(UnconfirmedIbexPayment)
+    })
+  })
+
+  it("treats an unset (0) payment-level settle date as no settlement", () => {
     expect(
       paymentSendStatusFromIbexLnurlPay({
-        settleDateUtc: 0,
-        transaction: { payment: { statusId: 0 } },
+        transaction: { payment: { statusId: 0, settleDateUtc: 0 } },
       }),
     ).toBeInstanceOf(UnconfirmedIbexPayment)
   })
 
-  describe("settleDateUtc serialisation", () => {
-    // The top-level field declares an integer epoch, but the payment-level one
-    // has no declared type at all and every payment-level date this vendor DOES
-    // declare is an ISO string ("2023-07-06T14:51:59.389565Z" — see
-    // test/flash/mocks/ibex/pay-invoice.ts). Settlement-on-settle-date is the
-    // only route by which an LNURL send can report success, so a number-only
-    // reader would return the pre-fix always-pending behaviour plus a Warn span
-    // on every send.
-    it("accepts an ISO string settle date at the top level", () => {
+  describe("payment-level settleDateUtc serialisation", () => {
+    // The payment-level field has no declared type at all, and every
+    // payment-level date this vendor DOES declare is an ISO string
+    // ("2023-07-06T14:51:59.389565Z" — see test/flash/mocks/ibex/pay-invoice.ts),
+    // while the sibling top-level field declares an integer epoch. Since it is
+    // the only settle-date this reader trusts, both serialisations have to be
+    // read or the rule is dead for one of them.
+    const atPaymentLevel = (settleDateUtc: unknown) => ({
+      transaction: { payment: { statusId: 0, settleDateUtc } },
+    })
+
+    it("accepts an ISO string settle date", () => {
       expect(
-        paymentSendStatusFromIbexLnurlPay({
-          settleDateUtc: "2022-11-15T20:30:41.960887Z",
-          transaction: { payment: { statusId: 0 } },
-        }),
+        paymentSendStatusFromIbexLnurlPay(atPaymentLevel("2023-07-06T14:51:59.389565Z")),
       ).toBe(PaymentSendStatus.Success)
     })
 
-    it("accepts an ISO string settle date at the payment level", () => {
-      expect(
-        paymentSendStatusFromIbexLnurlPay({
-          transaction: {
-            payment: { statusId: 0, settleDateUtc: "2023-07-06T14:51:59.389565Z" },
-          },
-        }),
-      ).toBe(PaymentSendStatus.Success)
+    it("accepts an integer epoch settle date", () => {
+      expect(paymentSendStatusFromIbexLnurlPay(atPaymentLevel(1668544241))).toBe(
+        PaymentSendStatus.Success,
+      )
     })
 
     it("reads an all-digit string as an epoch, not as a date", () => {
@@ -382,20 +488,13 @@ describe("paymentSendStatusFromIbexLnurlPay", () => {
       // epoch would be rejected as an out-of-range year.
       for (const settleDateUtc of ["0", "00", "-1", "+0"]) {
         expect(
-          paymentSendStatusFromIbexLnurlPay({
-            settleDateUtc,
-            transaction: { payment: { statusId: 0 } },
-          }),
+          paymentSendStatusFromIbexLnurlPay(atPaymentLevel(settleDateUtc)),
         ).toBeInstanceOf(UnconfirmedIbexPayment)
       }
 
-      expect(
-        paymentSendStatusFromIbexLnurlPay({
-          // the schema's own example, stringified
-          settleDateUtc: "1668544241",
-          transaction: { payment: { statusId: 0 } },
-        }),
-      ).toBe(PaymentSendStatus.Success)
+      expect(paymentSendStatusFromIbexLnurlPay(atPaymentLevel("1668544241"))).toBe(
+        PaymentSendStatus.Success,
+      )
     })
 
     it("rejects the vendor's zero-date sentinel and unparseable strings", () => {
@@ -410,10 +509,7 @@ describe("paymentSendStatusFromIbexLnurlPay", () => {
         null,
       ]) {
         expect(
-          paymentSendStatusFromIbexLnurlPay({
-            settleDateUtc,
-            transaction: { payment: { statusId: 0 } },
-          }),
+          paymentSendStatusFromIbexLnurlPay(atPaymentLevel(settleDateUtc)),
         ).toBeInstanceOf(UnconfirmedIbexPayment)
       }
     })

--- a/test/flash/unit/services/ibex/webhook-server/routes/on-pay-lnurl-gap.spec.ts
+++ b/test/flash/unit/services/ibex/webhook-server/routes/on-pay-lnurl-gap.spec.ts
@@ -1,0 +1,88 @@
+jest.mock("@services/ibex/client", () => ({
+  __esModule: true,
+  default: { invoiceFromHash: jest.fn() },
+}))
+jest.mock("@config", () => ({
+  IbexConfig: { webhook: { uri: "https://ibex.test.flashapp.me", secret: "s" } },
+}))
+jest.mock("@services/logger", () => {
+  const logger = {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+    child: jest.fn(() => logger),
+  }
+  return { baseLogger: logger }
+})
+jest.mock("@services/mongoose/wallets", () => ({ WalletsRepository: jest.fn() }))
+jest.mock("@services/mongoose/zap-request", () => ({ ZapRequestModel: jest.fn() }))
+jest.mock("@services/mongoose/lnurl-invoice", () => ({
+  LnurlInvoiceModel: { exists: jest.fn(), create: jest.fn() },
+}))
+jest.mock("@services/mongoose", () => ({ AccountsRepository: jest.fn() }))
+jest.mock("@utils", () => ({ extractPaymentHashFromBolt11: jest.fn() }))
+jest.mock("@services/ibex/webhook-server/middleware", () => ({
+  authenticate: jest.fn(),
+  logRequest: jest.fn(),
+  validateIbexIp: jest.fn(),
+}))
+
+import { router } from "@services/ibex/webhook-server/routes/on-pay"
+import { ibexWebhookEndpoints, ibexWebhookPaths } from "@services/ibex/webhook-config"
+
+type MountedRoute = { path: string; methods: Record<string, boolean> }
+
+const mountedRoutes = (): MountedRoute[] =>
+  (router.stack as unknown as { route?: MountedRoute }[])
+    .map((layer) => layer.route)
+    .filter((route): route is MountedRoute => route !== undefined)
+
+const methodsFor = (path: string): string[] =>
+  mountedRoutes()
+    .filter((route) => route.path === path)
+    .flatMap((route) => Object.keys(route.methods))
+    .filter((method) => method !== "_all")
+
+/**
+ * `Ibex.payToLnurl` hands IBEX a `webhookUrl` (services/ibex/client.ts), which
+ * reads as "a settlement callback will resolve this send". It will not. These
+ * assertions pin the gap so the claim cannot be made again by accident, and so
+ * that whoever DOES wire the callback is forced to come back here — and to the
+ * doc block on `paymentSendStatusFromIbexLnurlPay`, which states the gap — and
+ * update both.
+ *
+ * Until then: an LNURL send that `lnurlPaymentSendStatusOrPending` reports as
+ * `pending` is never resolved server-side, and `withPaymentIdempotency` replays
+ * that `pending` for 24h under the same key.
+ */
+describe("payToLnurl settlement webhook — the gap behind a pending LNURL send", () => {
+  it("sends IBEX an un-substituted express route template as the webhook URL", () => {
+    // `/pay/lnurl/:username` is a route pattern, not a URL. Nothing substitutes
+    // the parameter before it is handed to the vendor, so the callback target
+    // does not name a user even if IBEX were to POST to it.
+    expect(ibexWebhookPaths.onPay.lnurl).toBe("/pay/lnurl/:username")
+    expect(ibexWebhookEndpoints.onPay.lnurl).toContain("/pay/lnurl/:username")
+  })
+
+  it("mounts no POST handler at the LNURL pay path", () => {
+    // The only thing at this path is the PUBLIC GET LNURL-pay callback, which
+    // serves INBOUND payments to a Flash user — it has nothing to do with an
+    // outbound send's settlement.
+    expect(methodsFor(ibexWebhookPaths.onPay.lnurl)).toEqual(["get"])
+  })
+
+  it("has no route anywhere on this router that could transition an outbound LNURL send", () => {
+    // The two POST webhook routes that do exist are `resp.status(200).end()`
+    // stubs on other paths. Listing them here means adding a real handler makes
+    // this test fail loudly rather than leaving the doc block stale.
+    const postPaths = mountedRoutes()
+      .filter((route) => route.methods.post)
+      .map((route) => route.path)
+      .sort()
+
+    expect(postPaths).toEqual(
+      [ibexWebhookPaths.onPay.invoice, ibexWebhookPaths.onPay.onchain].sort(),
+    )
+  })
+})


### PR DESCRIPTION
## Symptom (found live)

A Cash→BTC conversion on TEST reported **"conversion successful" while no funds moved**. IBEX recorded no send transaction for the attempt (verified by querying the account directly).

## Cause

The IBEX send resolvers read the payment state from exactly one place — `transaction.payment.status.id` — and silently defaulted to `Pending` for anything else.

1. **The state lives in up to three fields.** Per the generated `PayInvoiceV2` schema, IBEX returns a top-level `status`, plus `transaction.payment.statusId` *and* `transaction.payment.status.id`. Unset integers arrive as **0** rather than being omitted, so a single-path read — or `lnurl-payment-send`'s `status?.id ?? statusId` chain, where a legitimate `0` short-circuits the `??` — can miss a status IBEX actually reported and call a settled or failed payment "pending".

2. **The fallback was silent.** A response we couldn't parse at all was indistinguishable from a genuine in-flight payment, with nothing recorded. Combined with the client treating `PENDING` as done, a payment that never executed rendered as a completed conversion.

## Change

New shared `@services/ibex/payment-status`, with **two readers for two dialects** — the endpoints do not return the same shape:

- **`paymentSendStatusFromIbex`** (`payInvoiceV2`) takes the first **recognised** id across all three status fields, so an unset `0` can't mask a real status. The top-level `status` is read only when both payment-level fields are unreadable, and then it can never invent a terminal outcome in either direction:
  - never `Success` from a lone top-level `2`;
  - never `Failure` from a lone top-level `3` either — accepted only when IBEX also names a failure code (`failureReason` or `transaction.payment.failureId`: a number > 0, or a **named** string reason like `"NO_ROUTE"`; only an explicit zero or blank means "no failure"). A fabricated "failed" sends the user back to retry with a fresh idempotency key against a send IBEX may in fact have made, which is the same double-pay hazard `withPaymentIdempotency` (#478) exists to close.
  - Pending needs no gate: it is the outcome the unconfirmed path reports anyway.
- **`paymentSendStatusFromIbexLnurlPay`** (`payToLnurl` 201) — this response carries no top-level `status` and no `transaction.payment.status` object. Settlement is read from **payment-level evidence only**: a recognised `transaction.payment.status.id` / `statusId`, or failing those a populated `transaction.payment.settleDateUtc` (integer epoch or ISO string — that field has no declared type, and every payment-level date this vendor does declare is a string — rejecting `0` and the `"0001-01-01T00:00:00Z"` zero-date sentinel alike).

  The **top-level `settleDateUtc` is deliberately not read.** The vendor's documented 201 example sets it to `1668544241`, which is `transaction.createdAt` (`"2022-11-15T20:30:41.960887Z"`) floored to the second, while every payment-level field in the same body says nothing settled: `statusId: 0`, `payment.settleDateUtc: null`, `paidMsat: 0`, `payment.hash: null`. On the example's own evidence, then, a 201 is an acceptance rather than a settlement — reading that echo would report **every** LNURL send as `success` regardless of outcome, i.e. the exact bug at the top of this PR, on the one rail whose real response has never been observed. The example is now committed as a fixture (`test/flash/mocks/ibex/pay-to-lnurl.ts`) and both readers are asserted against it.

  **Correction — there is no settlement webhook.** An earlier revision of this description, and of the reader's doc block, justified the acceptance reading with "`Ibex.payToLnurl` also registers an async settlement webhook". That was wrong. `payToLnurl` does pass a `webhookUrl` (`client.ts:348`), but the value it passes is `ibexWebhookEndpoints.onPay.lnurl`, which resolves to `<uri>/pay/lnurl/:username` — the express **route template** from `webhook-config.ts:13`, `:username` never substituted. The only route mounted at that path is the public **GET** LNURL-pay callback for *inbound* payments (`webhook-server/routes/on-pay.ts:143`); there is no POST handler for it, and the two POST webhook routes that do exist (`/pay/invoice`, `/pay/onchain`) are `resp.status(200).end()` stubs. So an LNURL send this reader reports as `pending` **is never resolved server-side** — no webhook, no poller, no reconciliation job — and `withPaymentIdempotency` replays that `pending` for 24h under the same key. The conclusion above (do not read the top-level `settleDateUtc`) is unaffected: it rests on the example's payment-level fields, not on the webhook. The gap is now stated in the reader's doc block and pinned by `test/flash/unit/services/ibex/webhook-server/routes/on-pay-lnurl-gap.spec.ts`, which fails the moment a real POST handler is mounted, so whoever wires one is forced back to both. See the **Known gap** section.
- Neither reader ever guesses: with no readable field they return `UnconfirmedIbexPayment`. `paymentSendStatusOrPending` / `lnurlPaymentSendStatusOrPending` — what the resolvers call — record that on the current span at **Warn** (both readers) with the transaction id, account id and payment hash attached, and still return `Pending`. (On *which* span channel, and why level alone was not enough, see "Alerting keys on span status" under Known gap.) Warn rather than Critical because **neither** endpoint has a captured response: the committed fixtures are the vendor's openapi examples, and the pre-PR intraledger code read the top-level `status` alone (with a `{ status: 2 }` fixture modelling exactly that), so a rail populating only the field the reader treats as uncorroborated is a live possibility. Paging on every flash-to-flash send until a capture proves otherwise would be an outage, not a severity. Capture one `payInvoiceV2` 200 and one `payToLnurl` 201 on TEST, commit them beside the examples, then raise the levels (noted in both readers' doc blocks).

  **Why still Pending, deliberately:** `withPaymentIdempotency` (#478) caches only a definitive `PaymentSendStatus`; an `ApplicationError` return is left uncached so a same-key retry can re-execute. Returning an error here would therefore make *the one case where we don't know whether funds moved* the one case a same-key retry could pay twice. Pending keeps it cacheable and replayable. What changes is that the anomaly is recorded rather than invisible, and that a status IBEX *did* report can no longer be missed.

Applied to **four call sites**: `ln-invoice-payment-send`, `ln-noamount-usd-invoice-payment-send`, `send-intraledger` (all three on the payInvoiceV2 reader) and `lnurl-payment-send` (on the LNURL reader), replacing four private copies of the status switch. `lnurl-payment-send`'s local `IbexPaymentStatus` type and helper go away.

### ⚠️ Behaviour change on the intraledger rail — read before merging

**`intraledger`: an unreadable IBEX status now returns `pending` where it previously returned a GraphQL error.** `send-intraledger` used to return `UnexpectedIbexResponse` for both the `0` case and the default case; `intraledger-usd-payment-send.ts` maps that to `{ status: "failed", errors: [...] }`. It now reports `{ errors: [], status: "pending" }`, for the double-pay reason above.

A bare top-level `status: 3` falls into the same bucket: intraledger's old switch reported it as `failed` outright, and it now reports `pending` unless IBEX also names a failure code (see the failure-corroboration rule above).

Since the shipped mobile client renders `PENDING` as a completed conversion — the symptom this PR opens with — flash-to-flash USD sends move from fail-closed to fail-open on that one case until the client fix lands. **This PR should therefore be sequenced behind lnflash/flash-mobile#699**, which makes the app render `pending` honestly. The change is deliberate and pinned by a test (`test/flash/unit/app/payments/send-intraledger.spec.ts`), documented at the call site and on `paymentSendStatusOrPending` — it is not an incidental side effect of the refactor.

### Behaviour change on the LN rails too — correcting an earlier claim in this description

An earlier revision of this description said "the three LN rails are unaffected: their inline switches already produced `Pending` for these responses." **That was wrong**, and the merge-sequencing argument above should not be read as resting on it. The old LN switches read `transaction.payment.status.id` and nothing else, defaulting to `Pending`, so two readings genuinely change on `ln-invoice-payment-send` and `ln-noamount-usd-invoice-payment-send`:

- **A corroborated top-level failure is now `failed` where it used to be `pending`.** `{ status: 3, failureReason: 2, transaction: { payment: { statusId: 0 } } }` returned `pending` from the old switch; it now returns `failed`. Pinned by `test/flash/unit/graphql/ln-invoice-payment-send.spec.ts` ("reports a corroborated top-level failure").
- **A flat payment-level `statusId` is now read at all.** `{ transaction: { payment: { statusId: 2 } } }` (or `3`) returned `pending` from the old switch and now returns `success` / `failed` — a status IBEX did report and we were dropping.

Both are fail-*closed* movements on those rails (pending → a definite outcome), the opposite direction to the intraledger change, and the shipped client already handles them without extra sequencing: `send-bitcoin-confirmation-screen.tsx` routes `SUCCESS`/`PENDING` to the success screen and everything else — `FAILURE` included — to the error path (`errorsMessage || "Something went wrong"`, error haptic). No client change is required for the LN rails; flash-mobile#699 remains the sequencing constraint for the intraledger `pending` case only.

Deliberately **not** touched: the generic "An unexpected error occurred" message for non-insufficient-balance IBEX errors — #476 landed typed `INSUFFICIENT_BALANCE` and consciously kept the generic text for the rest.

The client half of the bug (the app rendering `PENDING` as a completed conversion, plus swallowed fee-probe errors) is **lnflash/flash-mobile#699**.

### Known gap

**Neither endpoint has a captured response.** `test/flash/mocks/ibex/pay-invoice.ts` and `test/flash/mocks/ibex/pay-to-lnurl.ts` are the vendor's openapi examples, committed verbatim and labelled as such, not observations — they are in the repo so the readers are asserted against the only evidence that exists rather than against shapes we imagined. Two things follow, both deliberate:

- The LNURL `settleDateUtc` rule is payment-level only and schema-derived; on the documented 201 example the reader reports **pending**, which is what shipped before this PR. It cannot report `success` from a field the vendor's own example populates on an unsettled payment.
- Both unreadable cases record at **Warn**, not Critical.

Capture one `payInvoiceV2` 200 and one `payToLnurl` 201 on TEST, commit them beside the examples, then revisit both the settle-date rule and the severities.

**A `pending` LNURL send is never resolved server-side.** Stated plainly because the correction above removed the sentence that implied otherwise: `payToLnurl` is handed a `webhookUrl`, but this repo mounts no POST handler behind it (the path it sends is the un-substituted route template `/pay/lnurl/:username`, and the only route there is the public inbound GET callback). There is no poller and no reconciliation job either. So on the LNURL rail, `pending` is terminal in practice — `withPaymentIdempotency` replays it for 24h under the same key, and after flash-mobile#699 makes the client render `pending` honestly, such a send shows "pending" to the user indefinitely. This is pre-existing (the rail already reported `pending` for this shape before this PR); what this PR changes is that the gap is documented rather than implied away, and pinned by a test that fails when a real handler lands. Wiring that handler — or a reconciler — is the follow-up.

**Alerting keys on span status, not just `error.level` — checked.** `recordException` (`services/tracing.ts:354`) calls `span.setStatus({ code: SpanStatusCode.ERROR })` unconditionally; `ErrorLevel` only decides which `error.*` attributes win in `updateErrorForSpan`. Recording every unreadable response as an exception would therefore have turned **100%** of the LNURL rail's spans red if the 201 acceptance shape is the norm — this PR's own position — and the same on intraledger if the payment-level fields turn out unpopulated. `recordUnconfirmed` now splits by *evidence* rather than by severity: a response that reported nothing at all gets span attributes plus an `ibex.payment.unconfirmed` event (fully queryable, span stays green), while a response carrying a top-level `SUCCEEDED`/`FAILED` the corroboration rules refused keeps the recorded exception — there the payload disagrees with itself and the `pending` may be wrong in a direction that moved money. Carried on `UnconfirmedIbexPayment.uncorroboratedOutcome`; pinned at the reader and on all three payInvoiceV2 rails.

## Tests

- **Unit tests on the two readers** (`test/flash/unit/services/ibex/payment-status.spec.ts`): field precedence when fields disagree, the unset-`0` mask, failure-code corroboration including **named** string reasons, the payment-level `settleDateUtc` in both serialisations plus the zero-date sentinel, the top-level `settleDateUtc` being ignored in every serialisation, span-attribute identity for both dialects, **which of the two span channels each unreadable shape earns** (quiet event vs recorded exception, asserted as exactly one and never both), and four invariants — never `Success` without an explicit success id, never `Failure` without a corroborated one, an unreadable response is always `Pending`, and the recorded severity is the error's own.
- **The cashout rail now reads the status field at all.** `ValidOffer.execute` checked only `resp instanceof IbexError`, so a 200 carrying `transaction.payment.status.id === 3` counted as paid and Flash submitted a cashout in ERPNext — on the *fiat-payout* rail, with no `balanceVerifier.verifyBalanceMove` backstop, this PR's headline defect one call site over. It now refuses `submitCashout` on `Failure` (new `FailedIbexPayment`, mapped in `error-map`, reported to ops as the `payInvoice` step) and still submits on `Pending`, deliberately and documented: the cashout is an async reconciled flow, and holding the submit on a payment that probably settled would strand funds in a draft nobody watches. Pinned in `test/flash/unit/app/offers/ops-events-valid-offer.spec.ts`.
- **The LNURL webhook gap is pinned** (`test/flash/unit/services/ibex/webhook-server/routes/on-pay-lnurl-gap.spec.ts`): the webhook URL handed to IBEX is an un-substituted route template, the only method mounted at that path is `GET`, and the router's complete POST set is the two no-op stubs. Mounting a real handler fails this test, forcing the reader's doc block back into review.
- **Both vendor examples are pinned as fixtures.** The `payToLnurl` 201 example must read as unconfirmed → `pending` (never `success`), and the `payInvoiceV2` 200 example as in-flight — the regression tests for "a creation-time echo is not a settlement".
- **Call-site wiring assertions on all four rails.** The two readers are structurally interchangeable at the type level (`lnurlPaymentSendStatusOrPending` accepts a payInvoiceV2 response without complaint), so wrong-reader-on-wrong-endpoint — the bug that had shipped on LNURL — is invisible to the readers' own unit suite and only an assertion at the call site catches it. Each rail asserts a payment-level settle, the unreadable case, and a reading only its own reader makes (the LN rails: a corroborated top-level failure, and the unreadable message in the payInvoiceV2 dialect; LNURL: settlement from a payment-level settle date). `ln-noamount-usd-invoice-payment-send` gets its first spec file.
- Unit suite: **186 suites / 1710 tests** (1707 passing, 3 pre-existing skips). `tsc-check`, `tsc-check-noimplicitany`, `eslint`, `build`, `madge-check` and `check-yaml` all clean.

*(Rebased onto current main — the first push was based on a 40-commit-stale main, which is what the earlier schema check was complaining about.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NEoz7nBtdtsHyuYG5wNPQV


