### PR TITLE
test(api-keys): fix a 1-in-43 flake in the malformed-key spec

### DIFF
--- a/test/flash/unit/domain/api-keys/index.spec.ts
+++ b/test/flash/unit/domain/api-keys/index.spec.ts
@@ -79,13 +79,20 @@ describe("parseApiKey", () => {
 
   it("rejects malformed keys", () => {
     const { keyId, secret } = generateApiKey()
+    // The uppercase case needs a keyId that actually CONTAINS a hex letter.
+    // keyId is only 4 random bytes (8 hex chars), so ~2.3% of runs — 1 in 43 —
+    // generate an all-digit id, where `.toUpperCase()` is a no-op and the
+    // "malformed" string is a perfectly valid key. That made this spec fail
+    // randomly in CI on unrelated PRs. Substitute a known letter rather than
+    // regenerating in a loop, so the case is deterministic.
+    const keyIdWithLetter = ("a" + keyId.slice(1)) as typeof keyId
     const malformed = [
       "",
       "not-a-key",
       `flash_${keyId}_${secret}`, // wrong prefix
       `fk_${keyId}`, // missing secret
       `fk_${keyId.slice(0, 6)}_${secret}`, // short keyId
-      `fk_${keyId.toUpperCase()}_${secret}`, // keyId must be lowercase hex
+      `fk_${keyIdWithLetter.toUpperCase()}_${secret}`, // keyId must be lowercase hex
       `fk_${keyId}_${secret.slice(0, 63)}`, // short secret
       `fk_${keyId}_${secret}x`, // long secret
     ]


### PR DESCRIPTION
## The bug

`parseApiKey › rejects malformed keys` builds its uppercase case as:

```ts
`fk_${keyId.toUpperCase()}_${secret}`, // keyId must be lowercase hex
```

`keyId` is 4 random bytes → **8 hex chars**, and the parser is `/^fk_([0-9a-f]{8})_([A-Za-z0-9_-]{64})$/`. When the random id happens to be **all digits**, `.toUpperCase()` is a no-op, so the "malformed" string is a perfectly valid key — `parseApiKey` correctly returns a parsed object and the assertion fails with:

```
Expected constructor: InvalidApiKeyFormatError
Received constructor: Object
```

## How often

`(10/16)^8` = **2.3%, or 1 in 43 runs** — measured over 2,000,000 generated ids, matching theory exactly. Repo-wide, on every PR, including ones that never touch api-keys. It just failed the Unit test job on an unrelated feature PR.

## The fix

Substitute a known hex letter into the id for that one case, so it is deterministic. No loop, no retry, no seeding.

## Verification

- 60 consecutive runs of the spec with the fix: **0 failures**.
- Failure mode proven directly against the real `API_KEY_REGEX`: an all-digit id uppercases to a byte-identical string that the regex accepts; with a letter present, it does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017z72JdVxFAYpCQ3RJYkBRQ