### PR TITLE
feat(fygaro): server-signed card checkout with a pre-charge allowance check

### DIFF
--- a/dev/apollo-federation/supergraph.graphql
+++ b/dev/apollo-federation/supergraph.graphql
@@ -1117,7 +1117,7 @@ type FygaroCheckoutCreatePayload
   errors: [Error!]!
 
   """
-  What is left of today's top-up allowance after this request. Present on refusal too, so the client can say how much would be accepted instead of only saying no. Null when the allowance itself could not be established.
+  How much more could be authorised right now, after this request. Card top-up links you have open but have not paid are ALREADY SUBTRACTED, so this is what would be accepted this second — not a statement of what the account has spent today. Present on refusal too, so the client can say how much would go through instead of only saying no. Null when the allowance could not be established.
   """
   remainingAllowance: CentAmount
 }

--- a/dev/apollo-federation/supergraph.graphql
+++ b/dev/apollo-federation/supergraph.graphql
@@ -1083,6 +1083,44 @@ scalar FractionalCentAmount
   @join__type(graph: PUBLIC)
 
 """
+A server-authorised card top-up. The amount is signed into the URL, so it is the only amount that can be paid through it.
+"""
+type FygaroCheckout
+  @join__type(graph: PUBLIC)
+{
+  """
+  The authorised amount, echoed back so the client can display what was signed.
+  """
+  amount: CentAmount!
+
+  """
+  After this, the URL is rejected by the payment provider and a new one must be requested.
+  """
+  expiresAt: Timestamp!
+
+  """Open this in the payment webview. Single use."""
+  url: String!
+}
+
+input FygaroCheckoutCreateInput
+  @join__type(graph: PUBLIC)
+{
+  amount: CentAmount!
+}
+
+type FygaroCheckoutCreatePayload
+  @join__type(graph: PUBLIC)
+{
+  checkout: FygaroCheckout
+  errors: [Error!]!
+
+  """
+  What is left of today's top-up allowance after this request. Present on refusal too, so the client can say how much would be accepted instead of only saying no. Null when the allowance itself could not be established.
+  """
+  remainingAllowance: CentAmount
+}
+
+"""
 Fee parameters for Fygaro card top-ups, so the client can
 compute the net amount a user will receive. Null when the operator settings
 are unavailable — clients should degrade gracefully (hide the estimate).
@@ -1776,6 +1814,7 @@ type Mutation
   createInvite(input: CreateInviteInput!): CreateInvitePayload!
   deviceNotificationTokenCreate(input: DeviceNotificationTokenCreateInput!): SuccessPayload!
   feedbackSubmit(input: FeedbackSubmitInput!): SuccessPayload!
+  fygaroCheckoutCreate(input: FygaroCheckoutCreateInput!): FygaroCheckoutCreatePayload!
   idDocumentUploadUrlGenerate(input: IdDocumentUploadUrlGenerateInput!): IdDocumentUploadUrlPayload!
 
   """

--- a/dev/apollo-federation/supergraph.graphql
+++ b/dev/apollo-federation/supergraph.graphql
@@ -1098,7 +1098,9 @@ type FygaroCheckout
   """
   expiresAt: Timestamp!
 
-  """Open this in the payment webview. Single use."""
+  """
+  Open this in the payment webview. The amount and the destination account are signed into it and cannot be edited; it stops working at expiresAt.
+  """
   url: String!
 }
 

--- a/src/app/errors.ts
+++ b/src/app/errors.ts
@@ -29,6 +29,7 @@ import * as SvixErrors from "@services/svix/errors"
 import * as IbexErrors from "@services/ibex/errors"
 import * as ErpNextErrors from "@services/frappe/errors"
 import * as BridgeErrors from "@services/bridge/errors"
+import * as FygaroErrors from "@services/fygaro/errors"
 import * as ApiKeyErrors from "@domain/api-keys/errors"
 
 export const ApplicationErrors = {
@@ -64,5 +65,6 @@ export const ApplicationErrors = {
   ...IbexErrors,
   ...ErpNextErrors,
   ...BridgeErrors,
+  ...FygaroErrors,
   ...ApiKeyErrors,
 } as const

--- a/src/app/fygaro/authorize-topup.ts
+++ b/src/app/fygaro/authorize-topup.ts
@@ -1,0 +1,175 @@
+import { FygaroConfig } from "@config"
+import { AccountLevel } from "@domain/accounts"
+import { baseLogger } from "@services/logger"
+import { buildFygaroCheckout, type FygaroCheckout } from "@services/fygaro/checkout"
+import { newIntentId, saveIntent } from "@services/fygaro/checkout-intent-store"
+import { getFygaroSettings } from "@services/fygaro/webhook-server/fygaro-settings"
+import { sumFygaroTopupGrossCentsLast24h } from "@services/frappe/BridgeTransferRequestWriter"
+
+/**
+ * Authorise a card top-up BEFORE the customer is sent to Fygaro.
+ *
+ * This is the half of the daily-limit story that was missing. The webhook has
+ * always been able to refuse a credit, but by then Fygaro has captured the
+ * card, so refusing leaves the customer charged and empty-handed (which is
+ * exactly what happened to one account on 2026-08-16). Deciding here, before
+ * the hand-off, is the only point at which "no" costs the customer nothing.
+ *
+ * The returned checkout URL carries a signed amount, so the answer given here
+ * is the amount that can actually be paid.
+ */
+
+export type AuthorizeTopupFailure =
+  | "checkout-disabled"
+  | "settings-unavailable"
+  | "below-minimum"
+  | "above-single-payment-limit"
+  | "no-daily-limit-for-level"
+  | "history-unavailable"
+  | "exceeds-daily-allowance"
+
+export type AuthorizeTopupResult =
+  | {
+      authorized: true
+      checkout: FygaroCheckout
+      remainingAllowanceCents: number
+    }
+  | {
+      authorized: false
+      reason: AuthorizeTopupFailure
+      // Present whenever we know it, so the client can say "$45 left today"
+      // instead of a bare refusal. Undefined only when the allowance itself
+      // could not be established.
+      remainingAllowanceCents?: number
+      limitCents?: number
+      minimumCents?: number
+    }
+
+export const authorizeFygaroTopup = async ({
+  accountId,
+  username,
+  level,
+  amountCents,
+  nowMs = Date.now(),
+}: {
+  accountId: string
+  username: string
+  level: AccountLevel
+  amountCents: number
+  nowMs?: number
+}): Promise<AuthorizeTopupResult> => {
+  const checkoutConfig = FygaroConfig.checkout
+  if (!checkoutConfig?.enabled || !checkoutConfig.buttonUrl || !checkoutConfig.keyId) {
+    return { authorized: false, reason: "checkout-disabled" }
+  }
+
+  const secret = FygaroConfig.webhook?.secrets?.[checkoutConfig.keyId]
+  if (!secret) {
+    // Misconfiguration, not a user error: the key id names a secret that is not
+    // present. Fail as "disabled" so the caller degrades to the legacy flow
+    // rather than showing the customer an error we caused.
+    baseLogger.error(
+      { keyId: checkoutConfig.keyId },
+      "Fygaro checkout enabled but no signing secret for keyId",
+    )
+    return { authorized: false, reason: "checkout-disabled" }
+  }
+
+  // Returns undefined (never throws) when the ERPNext row is unreadable or
+  // malformed — same "record-only" posture the webhook takes.
+  const settings = await getFygaroSettings()
+  if (!settings) {
+    return { authorized: false, reason: "settings-unavailable" }
+  }
+  if (!settings.autoCreditEnabled) {
+    // Nothing would be credited even on a clean payment, so authorising a
+    // charge here would knowingly create another stuck top-up.
+    return { authorized: false, reason: "checkout-disabled" }
+  }
+
+  const minimumCents = Math.round(settings.minimumTopup * 100)
+  if (amountCents < minimumCents) {
+    return { authorized: false, reason: "below-minimum", minimumCents }
+  }
+
+  // The single-payment auto-credit ceiling. Anything above it would be recorded
+  // and held for manual review even if the daily allowance were untouched, so
+  // there is no honest way to authorise it here.
+  const singleLimitCents = Math.round(settings.autoCreditLimit * 100)
+  if (amountCents > singleLimitCents) {
+    return {
+      authorized: false,
+      reason: "above-single-payment-limit",
+      limitCents: singleLimitCents,
+    }
+  }
+
+  const dailyLimitUsd = settings.dailyTopupLimits[level]
+  if (dailyLimitUsd === undefined) {
+    return { authorized: false, reason: "no-daily-limit-for-level" }
+  }
+  const dailyLimitCents = Math.round(dailyLimitUsd * 100)
+
+  // Same read the webhook gate uses, so the answer here and the decision there
+  // cannot drift. `excludeTransactionId` has no counterpart yet — nothing has
+  // been paid — so pass a value that matches no row.
+  const priorCents = await sumFygaroTopupGrossCentsLast24h({
+    accountId,
+    excludeTransactionId: `intent-preauth-${accountId}`,
+  })
+  if (priorCents instanceof Error) {
+    // Never coerce an unreadable history to zero: that would treat an ERPNext
+    // outage as a clean slate and authorise the full allowance to everyone.
+    return { authorized: false, reason: "history-unavailable" }
+  }
+
+  const remainingAllowanceCents = Math.max(0, dailyLimitCents - priorCents)
+  if (amountCents > remainingAllowanceCents) {
+    return {
+      authorized: false,
+      reason: "exceeds-daily-allowance",
+      remainingAllowanceCents,
+      limitCents: dailyLimitCents,
+    }
+  }
+
+  const intentId = newIntentId()
+  const checkout = buildFygaroCheckout({
+    buttonUrl: checkoutConfig.buttonUrl,
+    username,
+    intentId,
+    amountCents,
+    currency: "USD",
+    keyId: checkoutConfig.keyId,
+    secret,
+    ttlSeconds: checkoutConfig.ttlSeconds,
+    nowMs,
+  })
+
+  const saved = await saveIntent({
+    intent: {
+      intentId,
+      accountId,
+      username,
+      amountCents,
+      currency: "USD",
+      createdAtMs: nowMs,
+    },
+    ttlSeconds: checkoutConfig.ttlSeconds,
+  })
+  if (saved instanceof Error) {
+    // The signed URL is still perfectly payable and the webhook gate still
+    // applies; only our own after-the-fact cross-check is missing. Log it and
+    // proceed rather than blocking a legitimate top-up on a cache write.
+    baseLogger.warn(
+      { intentId, error: saved.constructor.name },
+      "Failed to persist Fygaro checkout intent; proceeding without cross-check",
+    )
+  }
+
+  return {
+    authorized: true,
+    checkout,
+    remainingAllowanceCents: remainingAllowanceCents - amountCents,
+  }
+}

--- a/src/app/fygaro/authorize-topup.ts
+++ b/src/app/fygaro/authorize-topup.ts
@@ -2,8 +2,18 @@ import { FygaroConfig } from "@config"
 import { AccountLevel } from "@domain/accounts"
 import { baseLogger } from "@services/logger"
 import { buildFygaroCheckout, type FygaroCheckout } from "@services/fygaro/checkout"
-import { newIntentId, saveIntent } from "@services/fygaro/checkout-intent-store"
+import {
+  newIntentId,
+  releaseIntentReservation,
+  saveIntent,
+  sumOutstandingAuthorizedCents,
+} from "@services/fygaro/checkout-intent-store"
 import { getFygaroSettings } from "@services/fygaro/webhook-server/fygaro-settings"
+import {
+  evaluateCreditGate,
+  type RecordOnlyReason,
+} from "@services/fygaro/webhook-server/fees"
+import { getFlashFeeDiscountPercent } from "@services/frappe/fee-discounts"
 import { sumFygaroTopupGrossCentsLast24h } from "@services/frappe/BridgeTransferRequestWriter"
 
 /**
@@ -17,12 +27,18 @@ import { sumFygaroTopupGrossCentsLast24h } from "@services/frappe/BridgeTransfer
  *
  * The returned checkout URL carries a signed amount, so the answer given here
  * is the amount that can actually be paid.
+ *
+ * The decision itself is NOT reimplemented here: it is `evaluateCreditGate`,
+ * the same function the webhook runs after the charge. Any ladder written twice
+ * drifts, and every drifted gate is a customer charged for a credit that will
+ * be refused.
  */
 
 export type AuthorizeTopupFailure =
   | "checkout-disabled"
   | "settings-unavailable"
   | "below-minimum"
+  | "non-positive-net"
   | "above-single-payment-limit"
   | "no-daily-limit-for-level"
   | "history-unavailable"
@@ -45,6 +61,29 @@ export type AuthorizeTopupResult =
       minimumCents?: number
     }
 
+/**
+ * Every stop `evaluateCreditGate` can return, in the vocabulary this call site
+ * answers in. Exhaustive by type, so a new gate reason cannot be added to the
+ * webhook without a decision being made here too.
+ *
+ * `non-usd` and `intent-mismatch` are unreachable from this path — the currency
+ * is fixed to USD and no payment exists yet — but map to the same "we cannot
+ * offer you a checkout" answer rather than being asserted away.
+ */
+const FAILURE_BY_GATE_REASON: Record<RecordOnlyReason, AuthorizeTopupFailure> = {
+  "credit-disabled": "checkout-disabled",
+  "auto-credit-disabled": "checkout-disabled",
+  "non-usd": "checkout-disabled",
+  "intent-mismatch": "checkout-disabled",
+  "settings-unavailable": "settings-unavailable",
+  "history-unavailable": "history-unavailable",
+  "over-limit": "above-single-payment-limit",
+  "no-daily-limit-for-level": "no-daily-limit-for-level",
+  "daily-limit-exceeded": "exceeds-daily-allowance",
+  "non-positive-net": "non-positive-net",
+  "under-minimum": "below-minimum",
+}
+
 export const authorizeFygaroTopup = async ({
   accountId,
   username,
@@ -58,6 +97,18 @@ export const authorizeFygaroTopup = async ({
   amountCents: number
   nowMs?: number
 }): Promise<AuthorizeTopupResult> => {
+  // The yaml master gates come first, before any ERPNext read. `fygaro.enabled`
+  // off means the webhook server 503s every delivery (fygaroEnabledGuard), so a
+  // payment made against a link minted here would not even be RECORDED; and
+  // `credit.enabled` off — the default, and the very first rollout state —
+  // means the webhook records the payment with reason `credit-disabled` and
+  // credits nothing. Either way the customer is charged and uncredited, which
+  // is the failure this whole path exists to prevent.
+  const creditEnabled = Boolean(FygaroConfig?.credit?.enabled)
+  if (!FygaroConfig?.enabled || !creditEnabled) {
+    return { authorized: false, reason: "checkout-disabled" }
+  }
+
   const checkoutConfig = FygaroConfig.checkout
   if (!checkoutConfig?.enabled || !checkoutConfig.buttonUrl || !checkoutConfig.keyId) {
     return { authorized: false, reason: "checkout-disabled" }
@@ -78,60 +129,84 @@ export const authorizeFygaroTopup = async ({
   // Returns undefined (never throws) when the ERPNext row is unreadable or
   // malformed — same "record-only" posture the webhook takes.
   const settings = await getFygaroSettings()
-  if (!settings) {
-    return { authorized: false, reason: "settings-unavailable" }
-  }
-  if (!settings.autoCreditEnabled) {
-    // Nothing would be credited even on a clean payment, so authorising a
-    // charge here would knowingly create another stuck top-up.
-    return { authorized: false, reason: "checkout-disabled" }
-  }
 
-  const minimumCents = Math.round(settings.minimumTopup * 100)
-  if (amountCents < minimumCents) {
-    return { authorized: false, reason: "below-minimum", minimumCents }
-  }
+  const minimumCents =
+    settings === undefined ? undefined : Math.round(settings.minimumTopup * 100)
+  const singleLimitCents =
+    settings === undefined ? undefined : Math.round(settings.autoCreditLimit * 100)
+  const dailyLimitUsd = settings?.dailyTopupLimits[level]
+  const dailyLimitCents =
+    dailyLimitUsd === undefined ? undefined : Math.round(dailyLimitUsd * 100)
 
-  // The single-payment auto-credit ceiling. Anything above it would be recorded
-  // and held for manual review even if the daily allowance were untouched, so
-  // there is no honest way to authorise it here.
-  const singleLimitCents = Math.round(settings.autoCreditLimit * 100)
-  if (amountCents > singleLimitCents) {
-    return {
-      authorized: false,
-      reason: "above-single-payment-limit",
-      limitCents: singleLimitCents,
-    }
-  }
-
-  const dailyLimitUsd = settings.dailyTopupLimits[level]
-  if (dailyLimitUsd === undefined) {
-    return { authorized: false, reason: "no-daily-limit-for-level" }
-  }
-  const dailyLimitCents = Math.round(dailyLimitUsd * 100)
-
-  // Same read the webhook gate uses, so the answer here and the decision there
-  // cannot drift. `excludeTransactionId` has no counterpart yet — nothing has
-  // been paid — so pass a value that matches no row.
-  const priorCents = await sumFygaroTopupGrossCentsLast24h({
-    accountId,
-    excludeTransactionId: `intent-preauth-${accountId}`,
+  const refuse = (
+    reason: RecordOnlyReason,
+    remainingAllowanceCents?: number,
+  ): AuthorizeTopupResult => ({
+    authorized: false,
+    reason: FAILURE_BY_GATE_REASON[reason],
+    remainingAllowanceCents,
+    limitCents: reason === "over-limit" ? singleLimitCents : dailyLimitCents,
+    minimumCents,
   })
+
+  const gateArgs = {
+    creditEnabled,
+    currency: "USD",
+    settings,
+    grossCents: amountCents,
+    level,
+  }
+
+  // Probe with an unknown history: `history-unavailable` is the FIRST gate that
+  // needs one, so any other stop is decided without reading ERPNext at all — a
+  // client can no longer make us run a list query per rejected amount. The
+  // ordering lives in evaluateCreditGate; this reads it rather than restating it.
+  const probe = evaluateCreditGate({ ...gateArgs, priorDayGrossCents: undefined })
+  if (!probe.credit && probe.reason !== "history-unavailable") {
+    return refuse(probe.reason)
+  }
+
+  const priorCents = await sumFygaroTopupGrossCentsLast24h({ accountId })
   if (priorCents instanceof Error) {
     // Never coerce an unreadable history to zero: that would treat an ERPNext
     // outage as a clean slate and authorise the full allowance to everyone.
-    return { authorized: false, reason: "history-unavailable" }
+    return refuse("history-unavailable")
   }
 
-  const remainingAllowanceCents = Math.max(0, dailyLimitCents - priorCents)
-  if (amountCents > remainingAllowanceCents) {
-    return {
-      authorized: false,
-      reason: "exceeds-daily-allowance",
-      remainingAllowanceCents,
-      limitCents: dailyLimitCents,
-    }
+  // Authorisation is only a promise until it is also a reservation. Links this
+  // account already holds are money it can still spend, so they count against
+  // the allowance exactly like settled charges do — otherwise N calls each mint
+  // a full-allowance link and paying two of them strands the second.
+  const outstandingCents = await sumOutstandingAuthorizedCents({ accountId, nowMs })
+  if (outstandingCents instanceof Error) {
+    // Same posture as the history read: unknown outstanding is not zero
+    // outstanding. The customer is told we could not check, not that they are
+    // over a limit we never measured.
+    return refuse("history-unavailable")
   }
+
+  // Fail-open (0 on any failure), and gross-denominated gates are discount-blind
+  // anyway — it only moves the fee math, which is what `non-positive-net` turns
+  // on. Read here so this side and the webhook side compute the same net.
+  const flashFeeDiscountPercent = await getFlashFeeDiscountPercent({
+    username,
+    flow: "topup",
+  })
+
+  const spentCents = priorCents + outstandingCents
+  const remainingAllowanceCents =
+    dailyLimitCents === undefined ? undefined : Math.max(0, dailyLimitCents - spentCents)
+
+  const gate = evaluateCreditGate({
+    ...gateArgs,
+    priorDayGrossCents: spentCents,
+    flashFeeDiscountPercent,
+  })
+  if (!gate.credit) return refuse(gate.reason, remainingAllowanceCents)
+
+  // Past this point the gate said yes, so the daily limit exists by construction
+  // (`no-daily-limit-for-level` precedes it) — narrowed for the type checker.
+  const allowanceCents = remainingAllowanceCents ?? 0
 
   const intentId = newIntentId()
   const checkout = buildFygaroCheckout({
@@ -146,30 +221,52 @@ export const authorizeFygaroTopup = async ({
     nowMs,
   })
 
-  const saved = await saveIntent({
-    intent: {
-      intentId,
-      accountId,
-      username,
-      amountCents,
-      currency: "USD",
-      createdAtMs: nowMs,
-    },
-    ttlSeconds: checkoutConfig.ttlSeconds,
-  })
+  const intent = {
+    intentId,
+    accountId,
+    username,
+    amountCents,
+    currency: "USD",
+    createdAtMs: nowMs,
+  }
+  const saved = await saveIntent({ intent, ttlSeconds: checkoutConfig.ttlSeconds })
   if (saved instanceof Error) {
     // The signed URL is still perfectly payable and the webhook gate still
-    // applies; only our own after-the-fact cross-check is missing. Log it and
-    // proceed rather than blocking a legitimate top-up on a cache write.
+    // applies; only our own after-the-fact cross-check and reservation are
+    // missing. Log it and proceed rather than blocking a legitimate top-up on a
+    // cache write.
     baseLogger.warn(
       { intentId, error: saved.constructor.name },
-      "Failed to persist Fygaro checkout intent; proceeding without cross-check",
+      "Failed to persist Fygaro checkout authorisation; proceeding without cross-check",
     )
+    return { authorized: true, checkout, remainingAllowanceCents: allowanceCents }
+  }
+
+  // Reserve, then re-read. Two requests that raced past the check above have
+  // both reserved by now, so both see the combined total here and both back
+  // out: the allowance can be under-used for one round trip, never over-issued.
+  const outstandingAfter = await sumOutstandingAuthorizedCents({ accountId, nowMs })
+  if (
+    dailyLimitCents !== undefined &&
+    !(outstandingAfter instanceof Error) &&
+    priorCents + outstandingAfter > dailyLimitCents
+  ) {
+    await releaseIntentReservation(intent)
+    baseLogger.info(
+      { accountId, intentId },
+      "Concurrent Fygaro checkout authorisation would exceed the daily allowance; rolled back",
+    )
+    return {
+      authorized: false,
+      reason: "exceeds-daily-allowance",
+      remainingAllowanceCents,
+      limitCents: dailyLimitCents,
+    }
   }
 
   return {
     authorized: true,
     checkout,
-    remainingAllowanceCents: remainingAllowanceCents - amountCents,
+    remainingAllowanceCents: allowanceCents - amountCents,
   }
 }

--- a/src/app/fygaro/authorize-topup.ts
+++ b/src/app/fygaro/authorize-topup.ts
@@ -1,12 +1,19 @@
 import { FygaroConfig } from "@config"
 import { AccountLevel } from "@domain/accounts"
+import { alertBridge, generateDedupKey } from "@services/alerts"
 import { baseLogger } from "@services/logger"
-import { buildFygaroCheckout, type FygaroCheckout } from "@services/fygaro/checkout"
+import {
+  buildCustomReference,
+  buildFygaroCheckout,
+  type FygaroCheckout,
+} from "@services/fygaro/checkout"
 import {
   newIntentId,
+  readIntent,
+  readOutstandingReservations,
   releaseIntentReservation,
   saveIntent,
-  sumOutstandingAuthorizedCents,
+  type FygaroReservation,
 } from "@services/fygaro/checkout-intent-store"
 import { getFygaroSettings } from "@services/fygaro/webhook-server/fygaro-settings"
 import {
@@ -42,13 +49,26 @@ export type AuthorizeTopupFailure =
   | "above-single-payment-limit"
   | "no-daily-limit-for-level"
   | "history-unavailable"
+  // The reservation index (Redis) was unreadable. Deliberately NOT folded into
+  // `history-unavailable`: that name sends the operator reading the alert to
+  // ERPNext for a fault that is in Redis.
+  | "reservations-unavailable"
   | "exceeds-daily-allowance"
+  // The account has NOT spent its allowance — it is holding it, in links it
+  // authorised and has not paid. Distinct from `exceeds-daily-allowance`
+  // because telling someone who has spent $0 today that they have $0 left is
+  // simply false, and the honest answer ("finish or wait for the link you
+  // already have") is the one they can act on.
+  | "checkout-already-open"
 
 export type AuthorizeTopupResult =
   | {
       authorized: true
       checkout: FygaroCheckout
       remainingAllowanceCents: number
+      // True when this is a link the account already held, handed back rather
+      // than minted. Nothing new was reserved.
+      reused?: boolean
     }
   | {
       authorized: false
@@ -59,7 +79,13 @@ export type AuthorizeTopupResult =
       remainingAllowanceCents?: number
       limitCents?: number
       minimumCents?: number
+      // When (and for how much) the open link that is holding the allowance
+      // stops being payable. Only set for `checkout-already-open`.
+      holdExpiresAt?: Date
+      holdAmountCents?: number
     }
+
+export type AuthorizeTopupRefusal = Extract<AuthorizeTopupResult, { authorized: false }>
 
 /**
  * Every stop `evaluateCreditGate` can return, in the vocabulary this call site
@@ -138,16 +164,122 @@ export const authorizeFygaroTopup = async ({
   const dailyLimitCents =
     dailyLimitUsd === undefined ? undefined : Math.round(dailyLimitUsd * 100)
 
+  const refuseWith = (
+    reason: AuthorizeTopupFailure,
+    remainingAllowanceCents?: number,
+    limitCents?: number,
+  ): AuthorizeTopupRefusal => ({
+    authorized: false,
+    reason,
+    remainingAllowanceCents,
+    limitCents: limitCents ?? dailyLimitCents,
+    minimumCents,
+  })
+
   const refuse = (
     reason: RecordOnlyReason,
     remainingAllowanceCents?: number,
-  ): AuthorizeTopupResult => ({
-    authorized: false,
-    reason: FAILURE_BY_GATE_REASON[reason],
+  ): AuthorizeTopupRefusal =>
+    refuseWith(
+      FAILURE_BY_GATE_REASON[reason],
+      remainingAllowanceCents,
+      reason === "over-limit" ? singleLimitCents : dailyLimitCents,
+    )
+
+  /**
+   * Refuse a request because a dependency of the CHECK is down, and page for it.
+   *
+   * The webhook side pages on both of its transient stops (payment.ts). This
+   * side had no signal at all, so card top-ups could be 100% unavailable for
+   * every user while nothing fired. The dedup key is static per reason: an
+   * outage is one incident, not one per refused customer, and naming the reason
+   * in the key keeps "ERPNext is down" from masquerading as "Redis is down".
+   */
+  const refuseTransient = (
+    reason: "settings-unavailable" | "history-unavailable" | "reservations-unavailable",
+  ): AuthorizeTopupRefusal => {
+    alertBridge({
+      dedupKey: generateDedupKey.fygaroAuthorizeUnavailable(reason),
+      source: "fygaro-checkout",
+      severity: "warning",
+      title: "Fygaro pre-charge allowance check unavailable — card top-ups refusing",
+      detail: `reason=${reason}`,
+      context: { reason, account_id: accountId },
+    })
+    return refuseWith(reason)
+  }
+
+  /**
+   * The account is HOLDING its allowance, not spending it.
+   *
+   * First choice is to give it back: if one of the live holds is for exactly
+   * this amount, the customer is asking for the link they already have, so hand
+   * that link back rather than refusing them for their own reservation. Nothing
+   * new is reserved and the outstanding total does not move.
+   *
+   * Failing that (a different amount, or a record from before the URL was
+   * stored), refuse with a reason that says what is actually true and when the
+   * hold lifts.
+   */
+  const refuseOpenCheckout = async ({
+    reservations,
+    amountCents,
+    dailyLimitCents,
     remainingAllowanceCents,
-    limitCents: reason === "over-limit" ? singleLimitCents : dailyLimitCents,
-    minimumCents,
-  })
+  }: {
+    reservations: FygaroReservation[]
+    amountCents: number
+    dailyLimitCents: number
+    remainingAllowanceCents: number
+  }): Promise<AuthorizeTopupResult> => {
+    const sameAmount = reservations.find((r) => r.amountCents === amountCents)
+    if (sameAmount) {
+      const open = await readIntent(sameAmount.intentId)
+      if (
+        open.found &&
+        // Belt and braces: the id came out of THIS account's reservation index,
+        // so a record naming another account means the two disagree and the
+        // link is not ours to hand out.
+        open.intent.accountId === accountId &&
+        open.intent.checkoutUrl !== undefined &&
+        open.intent.expiresAtMs !== undefined &&
+        open.intent.expiresAtMs > nowMs
+      ) {
+        baseLogger.info(
+          { accountId, intentId: sameAmount.intentId },
+          "Re-offering the Fygaro checkout link this account already holds",
+        )
+        return {
+          authorized: true,
+          reused: true,
+          checkout: {
+            url: open.intent.checkoutUrl,
+            expiresAt: new Date(open.intent.expiresAtMs),
+            customReference: buildCustomReference({
+              username: open.intent.username,
+              intentId: open.intent.intentId,
+            }),
+          },
+          // The hold is already inside `remainingAllowanceCents`, so nothing is
+          // subtracted a second time for handing the same link back.
+          remainingAllowanceCents,
+        }
+      }
+    }
+
+    // The soonest hold to lift is the soonest moment more allowance exists, so
+    // that — not the latest — is the time worth telling the customer.
+    const soonest = reservations.reduce(
+      (earliest: FygaroReservation | undefined, r) =>
+        earliest === undefined || r.expiresAtMs < earliest.expiresAtMs ? r : earliest,
+      undefined,
+    )
+    return {
+      ...refuseWith("checkout-already-open", remainingAllowanceCents, dailyLimitCents),
+      holdExpiresAt: soonest ? new Date(soonest.expiresAtMs) : undefined,
+      holdAmountCents: soonest?.amountCents,
+    }
+  }
 
   const gateArgs = {
     creditEnabled,
@@ -163,6 +295,9 @@ export const authorizeFygaroTopup = async ({
   // ordering lives in evaluateCreditGate; this reads it rather than restating it.
   const probe = evaluateCreditGate({ ...gateArgs, priorDayGrossCents: undefined })
   if (!probe.credit && probe.reason !== "history-unavailable") {
+    if (probe.reason === "settings-unavailable") {
+      return refuseTransient("settings-unavailable")
+    }
     return refuse(probe.reason)
   }
 
@@ -170,20 +305,22 @@ export const authorizeFygaroTopup = async ({
   if (priorCents instanceof Error) {
     // Never coerce an unreadable history to zero: that would treat an ERPNext
     // outage as a clean slate and authorise the full allowance to everyone.
-    return refuse("history-unavailable")
+    return refuseTransient("history-unavailable")
   }
 
   // Authorisation is only a promise until it is also a reservation. Links this
   // account already holds are money it can still spend, so they count against
   // the allowance exactly like settled charges do — otherwise N calls each mint
   // a full-allowance link and paying two of them strands the second.
-  const outstandingCents = await sumOutstandingAuthorizedCents({ accountId, nowMs })
-  if (outstandingCents instanceof Error) {
+  const reservations = await readOutstandingReservations({ accountId, nowMs })
+  if (reservations instanceof Error) {
     // Same posture as the history read: unknown outstanding is not zero
     // outstanding. The customer is told we could not check, not that they are
-    // over a limit we never measured.
-    return refuse("history-unavailable")
+    // over a limit we never measured — and the reason names REDIS, so nobody
+    // goes hunting through ERPNext for it.
+    return refuseTransient("reservations-unavailable")
   }
+  const outstandingCents = reservations.reduce((sum, r) => sum + r.amountCents, 0)
 
   // Fail-open (0 on any failure), and gross-denominated gates are discount-blind
   // anyway — it only moves the fee math, which is what `non-positive-net` turns
@@ -202,7 +339,29 @@ export const authorizeFygaroTopup = async ({
     priorDayGrossCents: spentCents,
     flashFeeDiscountPercent,
   })
-  if (!gate.credit) return refuse(gate.reason, remainingAllowanceCents)
+  if (!gate.credit) {
+    // Settled spend and live holds are both "gone" as far as the cap is
+    // concerned, but they are NOT the same thing to the customer. When the
+    // shortfall is entirely this account's own unpaid links — the single most
+    // common thing a payer does is open a payment page and abandon it — the
+    // honest answers are, in order: hand them the link they already have, or
+    // tell them when it expires. Telling someone who has spent nothing today
+    // that they have $0.00 left is false, and their natural response (retry
+    // immediately) is exactly what keeps hitting it.
+    if (
+      gate.reason === "daily-limit-exceeded" &&
+      dailyLimitCents !== undefined &&
+      priorCents + amountCents <= dailyLimitCents
+    ) {
+      return refuseOpenCheckout({
+        reservations,
+        amountCents,
+        dailyLimitCents,
+        remainingAllowanceCents: remainingAllowanceCents ?? 0,
+      })
+    }
+    return refuse(gate.reason, remainingAllowanceCents)
+  }
 
   // Past this point the gate said yes, so the daily limit exists by construction
   // (`no-daily-limit-for-level` precedes it) — narrowed for the type checker.
@@ -228,6 +387,11 @@ export const authorizeFygaroTopup = async ({
     amountCents,
     currency: "USD",
     createdAtMs: nowMs,
+    // Stored so an abandoned checkout can be re-offered instead of refused by
+    // its own hold. The URL is already in the customer's hands at this point,
+    // so keeping a copy adds no exposure the payment page does not already have.
+    checkoutUrl: checkout.url,
+    expiresAtMs: checkout.expiresAt.getTime(),
   }
   const saved = await saveIntent({ intent, ttlSeconds: checkoutConfig.ttlSeconds })
   if (saved instanceof Error) {
@@ -245,7 +409,9 @@ export const authorizeFygaroTopup = async ({
   // Reserve, then re-read. Two requests that raced past the check above have
   // both reserved by now, so both see the combined total here and both back
   // out: the allowance can be under-used for one round trip, never over-issued.
-  const outstandingAfter = await sumOutstandingAuthorizedCents({ accountId, nowMs })
+  const after = await readOutstandingReservations({ accountId, nowMs })
+  const outstandingAfter =
+    after instanceof Error ? after : after.reduce((sum, r) => sum + r.amountCents, 0)
   if (
     dailyLimitCents !== undefined &&
     !(outstandingAfter instanceof Error) &&
@@ -256,10 +422,20 @@ export const authorizeFygaroTopup = async ({
       { accountId, intentId },
       "Concurrent Fygaro checkout authorisation would exceed the daily allowance; rolled back",
     )
+    // `remainingAllowanceCents` was computed from the FIRST read — the read
+    // this branch has just been told was stale. Reporting it here hands the
+    // client a bigger number than reality in exactly the case where it is
+    // wrong, so it retries the same amount and fails again. `outstandingAfter`
+    // includes this request's own reservation, which the line above just
+    // released, so it comes back out.
+    const remainingAfterRollback = Math.max(
+      0,
+      dailyLimitCents - priorCents - (outstandingAfter - amountCents),
+    )
     return {
       authorized: false,
       reason: "exceeds-daily-allowance",
-      remainingAllowanceCents,
+      remainingAllowanceCents: remainingAfterRollback,
       limitCents: dailyLimitCents,
     }
   }

--- a/src/app/fygaro/authorize-topup.ts
+++ b/src/app/fygaro/authorize-topup.ts
@@ -7,6 +7,7 @@ import {
   buildFygaroCheckout,
   type FygaroCheckout,
 } from "@services/fygaro/checkout"
+import { FygaroReservationWriteError } from "@services/fygaro/errors"
 import {
   newIntentId,
   readIntent,
@@ -230,6 +231,12 @@ export const authorizeFygaroTopup = async ({
     reservations: FygaroReservation[]
     amountCents: number
     dailyLimitCents: number
+    // How much MORE could be authorised right now — live holds already
+    // subtracted. In the canonical abandoned-link case this is 0, and that is
+    // the true answer to "what else can I do this second": nothing, until the
+    // hold lifts. It is not a claim about what the account has spent, which is
+    // why `holdAmountCents`/`holdExpiresAt` travel with it and why the field's
+    // schema description says outright that holds count against it.
     remainingAllowanceCents: number
   }): Promise<AuthorizeTopupResult> => {
     const sameAmount = reservations.find((r) => r.amountCents === amountCents)
@@ -260,8 +267,8 @@ export const authorizeFygaroTopup = async ({
               intentId: open.intent.intentId,
             }),
           },
-          // The hold is already inside `remainingAllowanceCents`, so nothing is
-          // subtracted a second time for handing the same link back.
+          // The hold is already counted, so nothing is subtracted a second
+          // time for handing the same link back.
           remainingAllowanceCents,
         }
       }
@@ -394,6 +401,14 @@ export const authorizeFygaroTopup = async ({
     expiresAtMs: checkout.expiresAt.getTime(),
   }
   const saved = await saveIntent({ intent, ttlSeconds: checkoutConfig.ttlSeconds })
+  if (saved instanceof FygaroReservationWriteError) {
+    // The hold could not be recorded, so the next request would see this
+    // allowance as still free and hand it out again — the over-issue the
+    // reservation exists to stop. The read side of the same index already
+    // refuses when it is unreachable; the write side has to match, or the
+    // guarantee only holds while Redis is healthy.
+    return refuseTransient("reservations-unavailable")
+  }
   if (saved instanceof Error) {
     // The signed URL is still perfectly payable and the webhook gate still
     // applies; only our own after-the-fact cross-check and reservation are
@@ -401,7 +416,7 @@ export const authorizeFygaroTopup = async ({
     // cache write.
     baseLogger.warn(
       { intentId, error: saved.constructor.name },
-      "Failed to persist Fygaro checkout authorisation; proceeding without cross-check",
+      "Failed to persist the Fygaro cross-check record; the hold is in place, so proceeding",
     )
     return { authorized: true, checkout, remainingAllowanceCents: allowanceCents }
   }

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -802,6 +802,30 @@ export const configSchema = {
           // the treasury -> user transfer stays manual.
           default: { enabled: false },
         },
+        // Server-signed checkout. With this OFF the app keeps building the
+        // pre-fill URL on the device, where the customer can edit both the
+        // amount and custom_reference; the webhook credit gate is the only
+        // protection. Turning it ON requires a Fygaro plan that supports JWT
+        // links (Pro or above) — the token is rejected by Fygaro otherwise, so
+        // enabling it without the plan breaks checkout rather than degrading.
+        checkout: {
+          type: "object",
+          properties: {
+            enabled: { type: "boolean", default: false },
+            // Full payment-button URL to append `?jwt=` to.
+            buttonUrl: { type: "string", default: "" },
+            // Which entry of `webhook.secrets` signs the token. The value lands
+            // in the JWT header `kid` so Fygaro picks the matching secret,
+            // which is what makes rotation a config change and nothing else.
+            keyId: { type: "string", default: "" },
+            // How long an authorised checkout stays payable. Long enough to
+            // enter card details, short enough that a URL captured from the
+            // WebView cannot be paid after the daily allowance has moved on.
+            ttlSeconds: { type: "integer", default: 900 },
+          },
+          additionalProperties: false,
+          default: { enabled: false, buttonUrl: "", keyId: "", ttlSeconds: 900 },
+        },
         float: {
           type: "object",
           properties: {

--- a/src/config/schema.types.d.ts
+++ b/src/config/schema.types.d.ts
@@ -80,6 +80,12 @@ type FygaroConfig = {
   credit: {
     enabled: boolean
   }
+  checkout: {
+    enabled: boolean
+    buttonUrl: string
+    keyId: string
+    ttlSeconds: number
+  }
   float: {
     floorUsd: number
   }

--- a/src/config/yaml.ts
+++ b/src/config/yaml.ts
@@ -230,6 +230,23 @@ export const getInviteTargetAttemptLimits = () => ({
   blockDuration: toSeconds(86400), // 24 hours
 })
 
+/**
+ * Card top-up checkout links, per account.
+ *
+ * Every call runs an ERPNext list query for the trailing-24h history — the same
+ * read every other top-up depends on, and one whose failure mode refuses card
+ * top-ups for EVERY user. Amounts below the minimum do not short-circuit before
+ * it (that gate sits after the history gate), so an unbounded mutation is an
+ * unbounded ERPNext load an authenticated client can point at a shared
+ * dependency. Generous against real use: minting more than a few links a minute
+ * is not a customer topping up.
+ */
+export const getFygaroCheckoutCreateAttemptLimits = () => ({
+  points: 10,
+  duration: toSeconds(60), // 1 minute
+  blockDuration: toSeconds(300), // 5 minutes
+})
+
 export const getOnChainWalletConfig = () => ({
   dustThreshold: yamlConfig.onChainWallet.dustThreshold,
 })

--- a/src/domain/api-keys/scope-map.ts
+++ b/src/domain/api-keys/scope-map.ts
@@ -60,6 +60,9 @@ export const apiKeyScopeForField: Readonly<Record<string, ApiKeyFieldAccess>> =
     bridgeRequestWithdrawal: "BLOCKED",
     bridgeInitiateWithdrawal: "BLOCKED",
     bridgeCancelWithdrawalRequest: "BLOCKED",
+    // Mints a payment link that charges a card. Interactive-session only, in
+    // the same family as the cashout and Bridge money-movement mutations.
+    fygaroCheckoutCreate: "BLOCKED",
     requestCashout: "BLOCKED",
     initiateCashout: "BLOCKED",
     apiKeyCreate: "BLOCKED",

--- a/src/domain/rate-limit/errors.ts
+++ b/src/domain/rate-limit/errors.ts
@@ -18,3 +18,4 @@ export class InvoiceCreateForRecipientRateLimiterExceededError extends RateLimit
 export class OnChainAddressCreateRateLimiterExceededError extends RateLimiterExceededError {}
 export class InviteCreateRateLimiterExceededError extends RateLimiterExceededError {}
 export class InviteTargetRateLimiterExceededError extends RateLimiterExceededError {}
+export class FygaroCheckoutCreateRateLimiterExceededError extends RateLimiterExceededError {}

--- a/src/domain/rate-limit/index.ts
+++ b/src/domain/rate-limit/index.ts
@@ -1,6 +1,7 @@
 import {
   getFailedLoginAttemptPerIpLimits,
   getFailedLoginAttemptPerLoginIdentifierLimits,
+  getFygaroCheckoutCreateAttemptLimits,
   getInviteCreateAttemptLimits,
   getInviteTargetAttemptLimits,
   getInvoiceCreateAttemptLimits,
@@ -11,6 +12,7 @@ import {
 } from "@config"
 
 import {
+  FygaroCheckoutCreateRateLimiterExceededError,
   InviteCreateRateLimiterExceededError,
   InviteTargetRateLimiterExceededError,
   InvoiceCreateForRecipientRateLimiterExceededError,
@@ -32,6 +34,7 @@ export const RateLimitPrefix = {
   onChainAddressCreate: "onchain_address_create",
   inviteCreate: "invite_daily",
   inviteTarget: "invite_target",
+  fygaroCheckoutCreate: "fygaro_checkout_create",
 } as const
 
 export const RateLimitConfig: { [key: string]: RateLimitConfig } = {
@@ -79,5 +82,13 @@ export const RateLimitConfig: { [key: string]: RateLimitConfig } = {
     key: RateLimitPrefix.inviteTarget,
     limits: getInviteTargetAttemptLimits(),
     error: InviteTargetRateLimiterExceededError,
+  },
+  // Same class of per-account resource-minting call as invoiceCreate and
+  // onChainAddressCreate — except this one also runs an ERPNext list query per
+  // call, against the exact read every other card top-up depends on.
+  fygaroCheckoutCreate: {
+    key: RateLimitPrefix.fygaroCheckoutCreate,
+    limits: getFygaroCheckoutCreateAttemptLimits(),
+    error: FygaroCheckoutCreateRateLimiterExceededError,
   },
 }

--- a/src/graphql/error-map.ts
+++ b/src/graphql/error-map.ts
@@ -706,6 +706,13 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
         message,
       })
 
+    case "FygaroLevelNotEligibleError":
+      message = error.message || "Card top-up isn't available on your account level yet"
+      return bridgeGqlError({
+        code: "FYGARO_LEVEL_NOT_ELIGIBLE",
+        message,
+      })
+
     case "BridgeInvalidPlaidTokenError":
       message = error.message || "linkToken and publicToken are required"
       return bridgeGqlError({

--- a/src/graphql/error-map.ts
+++ b/src/graphql/error-map.ts
@@ -263,6 +263,10 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
         "Too many onchain addresses creation, please wait for a while and try again."
       return new TooManyRequestError({ message, logger: baseLogger })
 
+    case "FygaroCheckoutCreateRateLimiterExceededError":
+      message = "Too many card top-up attempts, please wait for a while and try again."
+      return new TooManyRequestError({ message, logger: baseLogger })
+
     case "UserCodeAttemptIdentifierRateLimiterExceededError":
       message = "Too many request code attempts, please wait for a while and try again."
       return new TooManyRequestError({ message, logger: baseLogger })
@@ -696,6 +700,13 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
       message = error.message || "Amount is above your remaining daily top-up allowance"
       return bridgeGqlError({
         code: "FYGARO_DAILY_ALLOWANCE_EXCEEDED",
+        message,
+      })
+
+    case "FygaroCheckoutAlreadyOpenError":
+      message = error.message || "You already have a card top-up link open"
+      return bridgeGqlError({
+        code: "FYGARO_CHECKOUT_ALREADY_OPEN",
         message,
       })
 

--- a/src/graphql/error-map.ts
+++ b/src/graphql/error-map.ts
@@ -671,6 +671,41 @@ export const mapError = (error: ApplicationError): CustomApolloError => {
         message,
       })
 
+    case "FygaroCheckoutDisabledError":
+      message = error.message || "Card top-up is currently unavailable"
+      return bridgeGqlError({
+        code: "FYGARO_CHECKOUT_DISABLED",
+        message,
+      })
+
+    case "FygaroBelowMinimumError":
+      message = error.message || "Amount is below the minimum top-up"
+      return bridgeGqlError({
+        code: "FYGARO_BELOW_MINIMUM",
+        message,
+      })
+
+    case "FygaroAboveSinglePaymentLimitError":
+      message = error.message || "Amount is above the single top-up limit"
+      return bridgeGqlError({
+        code: "FYGARO_ABOVE_SINGLE_PAYMENT_LIMIT",
+        message,
+      })
+
+    case "FygaroDailyAllowanceExceededError":
+      message = error.message || "Amount is above your remaining daily top-up allowance"
+      return bridgeGqlError({
+        code: "FYGARO_DAILY_ALLOWANCE_EXCEEDED",
+        message,
+      })
+
+    case "FygaroAllowanceUnavailableError":
+      message = error.message || "Could not check your top-up allowance right now"
+      return bridgeGqlError({
+        code: "FYGARO_ALLOWANCE_UNAVAILABLE",
+        message,
+      })
+
     case "BridgeInvalidPlaidTokenError":
       message = error.message || "linkToken and publicToken are required"
       return bridgeGqlError({

--- a/src/graphql/public/mutations.ts
+++ b/src/graphql/public/mutations.ts
@@ -66,6 +66,7 @@ import InitiateCashoutMutation from "./root/mutation/offers/initiate-cash-out"
 import IdDocumentUploadUrlGenerateMutation from "./root/mutation/id-document-upload-url-generate"
 import UpdateExternalWalletMutation from "./root/mutation/update-external-wallet"
 import BridgeInitiateKycMutation from "./root/mutation/bridge-initiate-kyc"
+import FygaroCheckoutCreateMutation from "./root/mutation/fygaro-checkout-create"
 import BridgeCreateVirtualAccountMutation from "./root/mutation/bridge-create-virtual-account"
 import BridgeAddExternalAccountMutation from "./root/mutation/bridge-add-external-account"
 import BridgeExchangePlaidPublicTokenMutation from "./root/mutation/bridge-exchange-plaid-public-token"
@@ -141,6 +142,7 @@ export const mutationFields = {
 
       updateExternalWallet: UpdateExternalWalletMutation,
       bridgeInitiateKyc: BridgeInitiateKycMutation,
+      fygaroCheckoutCreate: FygaroCheckoutCreateMutation,
       bridgeCreateVirtualAccount: BridgeCreateVirtualAccountMutation,
       bridgeAddExternalAccount: BridgeAddExternalAccountMutation,
       bridgeExchangePlaidPublicToken: BridgeExchangePlaidPublicTokenMutation,

--- a/src/graphql/public/root/mutation/fygaro-checkout-create.ts
+++ b/src/graphql/public/root/mutation/fygaro-checkout-create.ts
@@ -3,11 +3,13 @@ import {
   type AuthorizeTopupResult,
 } from "@app/fygaro/authorize-topup"
 import { RateLimitConfig } from "@domain/rate-limit"
+import { FygaroCheckoutCreateRateLimiterExceededError } from "@domain/rate-limit/errors"
 import { mapAndParseErrorForGqlResponse } from "@graphql/error-map"
 import { GT } from "@graphql/index"
 import FygaroCheckout from "@graphql/public/types/object/fygaro-checkout"
 import CentAmount from "@graphql/public/types/scalar/cent-amount"
 import IError from "@graphql/shared/types/abstract/error"
+import { baseLogger } from "@services/logger"
 import { consumeLimiter } from "@services/rate-limit"
 import {
   FygaroAboveSinglePaymentLimitError,
@@ -27,9 +29,11 @@ const FygaroCheckoutCreatePayload = GT.Object({
     remainingAllowance: {
       type: CentAmount,
       description:
-        "What is left of today's top-up allowance after this request. Present on refusal " +
-        "too, so the client can say how much would be accepted instead of only saying no. " +
-        "Null when the allowance itself could not be established.",
+        "How much more could be authorised right now, after this request. Card top-up " +
+        "links you have open but have not paid are ALREADY SUBTRACTED, so this is what " +
+        "would be accepted this second — not a statement of what the account has spent " +
+        "today. Present on refusal too, so the client can say how much would go through " +
+        "instead of only saying no. Null when the allowance could not be established.",
     },
   }),
 })
@@ -171,8 +175,22 @@ const fygaroCheckoutCreate = GT.Field<
       rateLimitConfig: RateLimitConfig.fygaroCheckoutCreate,
       keyToConsume: domainAccount.id,
     })
-    if (limitOk instanceof Error) {
+    if (limitOk instanceof FygaroCheckoutCreateRateLimiterExceededError) {
       return { errors: [mapAndParseErrorForGqlResponse(limitOk)] }
+    }
+    if (limitOk instanceof Error) {
+      // The limiter STORE is down, not the caller misbehaving. Refusing here
+      // would tell every customer they are rate limited on their first attempt
+      // and would page nobody, because authorizeFygaroTopup — which fails
+      // closed on its own Redis read and alerts as `reservations-unavailable`
+      // — would never be entered. Fall through instead: the same outage stops
+      // the authorisation one step later, with the honest message and the
+      // page. This cannot open an abuse window, because no link can be minted
+      // while the store the reservation index lives in is unreachable.
+      baseLogger.warn(
+        { accountId: domainAccount.id, error: limitOk.name },
+        "Fygaro checkout rate limiter unavailable; deferring to the authorisation gate",
+      )
     }
 
     const result = await authorizeFygaroTopup({

--- a/src/graphql/public/root/mutation/fygaro-checkout-create.ts
+++ b/src/graphql/public/root/mutation/fygaro-checkout-create.ts
@@ -13,6 +13,7 @@ import {
   FygaroBelowMinimumError,
   FygaroCheckoutDisabledError,
   FygaroDailyAllowanceExceededError,
+  FygaroLevelNotEligibleError,
 } from "@services/fygaro/errors"
 
 const FygaroCheckoutCreatePayload = GT.Object({
@@ -67,9 +68,20 @@ const failureError = (result: AuthorizeTopupResult & { authorized: false }): Err
           ? "Amount is above your remaining daily top-up allowance"
           : `You have $${centsToDollars(remainingAllowanceCents)} left of today's top-up limit`,
       )
+    case "non-positive-net":
+      // Above the operator minimum, but the fixed processor + Flash fees eat
+      // the whole thing. "Too small" is the honest thing to tell the customer;
+      // it is not a limit and not an outage.
+      return new FygaroBelowMinimumError(
+        "That amount is too small to cover the payment fees",
+      )
+    case "no-daily-limit-for-level":
+      // Deterministic and permanent until the account upgrades — NOT one of the
+      // two transient ERPNext failures below. Telling a level-0 account to try
+      // again later would loop forever and send support after a phantom outage.
+      return new FygaroLevelNotEligibleError()
     case "settings-unavailable":
     case "history-unavailable":
-    case "no-daily-limit-for-level":
       return new FygaroAllowanceUnavailableError()
     case "checkout-disabled":
       return new FygaroCheckoutDisabledError()
@@ -88,8 +100,14 @@ const fygaroCheckoutCreate = GT.Field<
   },
   resolve: async (_, args, { domainAccount }) => {
     const { amount } = args.input
+    // What CentAmount hands back for a negative/oversized/non-integer value is
+    // an InputValidationError — an Apollo error, NOT an ApplicationError. Run
+    // through mapAndParseErrorForGqlResponse it falls off the end of the switch
+    // and throws `assertUnreachable`, turning a bad client amount into an
+    // internal error. Same handling as every other scalar-validated mutation
+    // (see ln-noamount-usd-invoice-payment-send).
     if (amount instanceof Error) {
-      return { errors: [mapAndParseErrorForGqlResponse(amount)] }
+      return { errors: [{ message: amount.message }] }
     }
 
     // custom_reference is how the webhook attributes the payment to an account.

--- a/src/graphql/public/root/mutation/fygaro-checkout-create.ts
+++ b/src/graphql/public/root/mutation/fygaro-checkout-create.ts
@@ -1,0 +1,134 @@
+import {
+  authorizeFygaroTopup,
+  type AuthorizeTopupResult,
+} from "@app/fygaro/authorize-topup"
+import { mapAndParseErrorForGqlResponse } from "@graphql/error-map"
+import { GT } from "@graphql/index"
+import FygaroCheckout from "@graphql/public/types/object/fygaro-checkout"
+import CentAmount from "@graphql/public/types/scalar/cent-amount"
+import IError from "@graphql/shared/types/abstract/error"
+import {
+  FygaroAboveSinglePaymentLimitError,
+  FygaroAllowanceUnavailableError,
+  FygaroBelowMinimumError,
+  FygaroCheckoutDisabledError,
+  FygaroDailyAllowanceExceededError,
+} from "@services/fygaro/errors"
+
+const FygaroCheckoutCreatePayload = GT.Object({
+  name: "FygaroCheckoutCreatePayload",
+  fields: () => ({
+    errors: { type: GT.NonNullList(IError) },
+    checkout: { type: FygaroCheckout },
+    remainingAllowance: {
+      type: CentAmount,
+      description:
+        "What is left of today's top-up allowance after this request. Present on refusal " +
+        "too, so the client can say how much would be accepted instead of only saying no. " +
+        "Null when the allowance itself could not be established.",
+    },
+  }),
+})
+
+const FygaroCheckoutCreateInput = GT.Input({
+  name: "FygaroCheckoutCreateInput",
+  fields: () => ({
+    amount: { type: GT.NonNull(CentAmount) },
+  }),
+})
+
+const centsToDollars = (cents: number) => (cents / 100).toFixed(2)
+
+/**
+ * Turn a refusal into the error the client shows the customer.
+ *
+ * Where we know the actual number, it goes in the message: "you have $45 left
+ * today" is actionable, "limit exceeded" is not — and the customer has not been
+ * charged at this point, so they can still act on it.
+ */
+const failureError = (result: AuthorizeTopupResult & { authorized: false }): Error => {
+  const { reason, limitCents, minimumCents, remainingAllowanceCents } = result
+  switch (reason) {
+    case "below-minimum":
+      return new FygaroBelowMinimumError(
+        minimumCents === undefined
+          ? "Amount is below the minimum top-up"
+          : `The minimum top-up is $${centsToDollars(minimumCents)}`,
+      )
+    case "above-single-payment-limit":
+      return new FygaroAboveSinglePaymentLimitError(
+        limitCents === undefined
+          ? "Amount is above the single top-up limit"
+          : `The most you can top up in one payment is $${centsToDollars(limitCents)}`,
+      )
+    case "exceeds-daily-allowance":
+      return new FygaroDailyAllowanceExceededError(
+        remainingAllowanceCents === undefined
+          ? "Amount is above your remaining daily top-up allowance"
+          : `You have $${centsToDollars(remainingAllowanceCents)} left of today's top-up limit`,
+      )
+    case "settings-unavailable":
+    case "history-unavailable":
+    case "no-daily-limit-for-level":
+      return new FygaroAllowanceUnavailableError()
+    case "checkout-disabled":
+      return new FygaroCheckoutDisabledError()
+  }
+}
+
+const fygaroCheckoutCreate = GT.Field<
+  null,
+  GraphQLPublicContextAuth,
+  { input: { amount: number | InputValidationError } }
+>({
+  extensions: { complexity: 120 },
+  type: GT.NonNull(FygaroCheckoutCreatePayload),
+  args: {
+    input: { type: GT.NonNull(FygaroCheckoutCreateInput) },
+  },
+  resolve: async (_, args, { domainAccount }) => {
+    const { amount } = args.input
+    if (amount instanceof Error) {
+      return { errors: [mapAndParseErrorForGqlResponse(amount)] }
+    }
+
+    // custom_reference is how the webhook attributes the payment to an account.
+    // Without a username there is nothing to put in it, so the payment would
+    // arrive unattributable — refuse before the customer is charged.
+    if (!domainAccount.username) {
+      return {
+        errors: [
+          mapAndParseErrorForGqlResponse(
+            new FygaroCheckoutDisabledError("Set a username before topping up by card"),
+          ),
+        ],
+      }
+    }
+
+    const result = await authorizeFygaroTopup({
+      accountId: domainAccount.id,
+      username: domainAccount.username,
+      level: domainAccount.level,
+      amountCents: amount,
+    })
+
+    if (!result.authorized) {
+      return {
+        errors: [mapAndParseErrorForGqlResponse(failureError(result))],
+        remainingAllowance: result.remainingAllowanceCents,
+      }
+    }
+
+    return {
+      errors: [],
+      checkout: {
+        url: result.checkout.url,
+        expiresAt: result.checkout.expiresAt,
+        amount: amount,
+      },
+      remainingAllowance: result.remainingAllowanceCents,
+    }
+  },
+})
+
+export default fygaroCheckoutCreate

--- a/src/graphql/public/root/mutation/fygaro-checkout-create.ts
+++ b/src/graphql/public/root/mutation/fygaro-checkout-create.ts
@@ -2,15 +2,18 @@ import {
   authorizeFygaroTopup,
   type AuthorizeTopupResult,
 } from "@app/fygaro/authorize-topup"
+import { RateLimitConfig } from "@domain/rate-limit"
 import { mapAndParseErrorForGqlResponse } from "@graphql/error-map"
 import { GT } from "@graphql/index"
 import FygaroCheckout from "@graphql/public/types/object/fygaro-checkout"
 import CentAmount from "@graphql/public/types/scalar/cent-amount"
 import IError from "@graphql/shared/types/abstract/error"
+import { consumeLimiter } from "@services/rate-limit"
 import {
   FygaroAboveSinglePaymentLimitError,
   FygaroAllowanceUnavailableError,
   FygaroBelowMinimumError,
+  FygaroCheckoutAlreadyOpenError,
   FygaroCheckoutDisabledError,
   FygaroDailyAllowanceExceededError,
   FygaroLevelNotEligibleError,
@@ -41,6 +44,16 @@ const FygaroCheckoutCreateInput = GT.Input({
 const centsToDollars = (cents: number) => (cents / 100).toFixed(2)
 
 /**
+ * Whole minutes until `at`, floor 1.
+ *
+ * Deliberately relative rather than a wall-clock "HH:MM": the server renders in
+ * UTC and the customer is not in it, so a clock time here is a time they cannot
+ * act on. "in 12 minutes" is correct in every timezone.
+ */
+const minutesUntil = (at: Date, nowMs: number = Date.now()): number =>
+  Math.max(1, Math.ceil((at.getTime() - nowMs) / 60_000))
+
+/**
  * Turn a refusal into the error the client shows the customer.
  *
  * Where we know the actual number, it goes in the message: "you have $45 left
@@ -48,7 +61,14 @@ const centsToDollars = (cents: number) => (cents / 100).toFixed(2)
  * charged at this point, so they can still act on it.
  */
 const failureError = (result: AuthorizeTopupResult & { authorized: false }): Error => {
-  const { reason, limitCents, minimumCents, remainingAllowanceCents } = result
+  const {
+    reason,
+    limitCents,
+    minimumCents,
+    remainingAllowanceCents,
+    holdExpiresAt,
+    holdAmountCents,
+  } = result
   switch (reason) {
     case "below-minimum":
       return new FygaroBelowMinimumError(
@@ -68,6 +88,18 @@ const failureError = (result: AuthorizeTopupResult & { authorized: false }): Err
           ? "Amount is above your remaining daily top-up allowance"
           : `You have $${centsToDollars(remainingAllowanceCents)} left of today's top-up limit`,
       )
+    case "checkout-already-open":
+      // The account has NOT spent this money — it is holding it in a link it
+      // opened and did not pay. Saying "you have $0.00 left of today's limit"
+      // to an account that has spent $0.00 today is simply false, and it points
+      // the customer (and support) at the wrong thing entirely.
+      return new FygaroCheckoutAlreadyOpenError(
+        holdExpiresAt === undefined
+          ? "You already have a card top-up link open. Finish that payment, or wait for it to expire, before starting another."
+          : `You already have a${
+              holdAmountCents === undefined ? "" : ` $${centsToDollars(holdAmountCents)}`
+            } card top-up link open — it expires in ${minutesUntil(holdExpiresAt)} minute(s). Finish that payment, or wait for it to expire, before starting another.`,
+      )
     case "non-positive-net":
       // Above the operator minimum, but the fixed processor + Flash fees eat
       // the whole thing. "Too small" is the honest thing to tell the customer;
@@ -77,11 +109,16 @@ const failureError = (result: AuthorizeTopupResult & { authorized: false }): Err
       )
     case "no-daily-limit-for-level":
       // Deterministic and permanent until the account upgrades — NOT one of the
-      // two transient ERPNext failures below. Telling a level-0 account to try
-      // again later would loop forever and send support after a phantom outage.
+      // three transient failures below. Telling a level-0 account to try again
+      // later would loop forever and send support after a phantom outage.
       return new FygaroLevelNotEligibleError()
+    // The three transient stops. ERPNext settings, ERPNext history and the
+    // Redis reservation index fail differently and alert differently, but the
+    // customer-facing answer is identical: we could not measure your allowance,
+    // try again. The distinction exists for the ALERT and the log, not here.
     case "settings-unavailable":
     case "history-unavailable":
+    case "reservations-unavailable":
       return new FygaroAllowanceUnavailableError()
     case "checkout-disabled":
       return new FygaroCheckoutDisabledError()
@@ -121,6 +158,21 @@ const fygaroCheckoutCreate = GT.Field<
           ),
         ],
       }
+    }
+
+    // Per-account, BEFORE the authorisation runs. Every call that gets past the
+    // cheap deterministic gates runs an ERPNext list query, and the two gates a
+    // spam client would trip (`under-minimum`, `non-positive-net`) sit AFTER
+    // the history gate — so `fygaroCheckoutCreate(amount: 1)` in a loop is
+    // unbounded ERPNext load pointed at the exact read whose failure refuses
+    // card top-ups for every user. Same treatment as invoiceCreate /
+    // onChainAddressCreate / inviteCreate.
+    const limitOk = await consumeLimiter({
+      rateLimitConfig: RateLimitConfig.fygaroCheckoutCreate,
+      keyToConsume: domainAccount.id,
+    })
+    if (limitOk instanceof Error) {
+      return { errors: [mapAndParseErrorForGqlResponse(limitOk)] }
     }
 
     const result = await authorizeFygaroTopup({

--- a/src/graphql/public/schema.graphql
+++ b/src/graphql/public/schema.graphql
@@ -862,6 +862,38 @@ Cent amount (1/100 of a dollar) as a float, can be positive or negative
 scalar FractionalCentAmount
 
 """
+A server-authorised card top-up. The amount is signed into the URL, so it is the only amount that can be paid through it.
+"""
+type FygaroCheckout {
+  """
+  The authorised amount, echoed back so the client can display what was signed.
+  """
+  amount: CentAmount!
+
+  """
+  After this, the URL is rejected by the payment provider and a new one must be requested.
+  """
+  expiresAt: Timestamp!
+
+  """Open this in the payment webview. Single use."""
+  url: String!
+}
+
+input FygaroCheckoutCreateInput {
+  amount: CentAmount!
+}
+
+type FygaroCheckoutCreatePayload {
+  checkout: FygaroCheckout
+  errors: [Error!]!
+
+  """
+  What is left of today's top-up allowance after this request. Present on refusal too, so the client can say how much would be accepted instead of only saying no. Null when the allowance itself could not be established.
+  """
+  remainingAllowance: CentAmount
+}
+
+"""
 Fee parameters for Fygaro card top-ups, so the client can
 compute the net amount a user will receive. Null when the operator settings
 are unavailable — clients should degrade gracefully (hide the estimate).
@@ -1424,6 +1456,7 @@ type Mutation {
   createInvite(input: CreateInviteInput!): CreateInvitePayload!
   deviceNotificationTokenCreate(input: DeviceNotificationTokenCreateInput!): SuccessPayload!
   feedbackSubmit(input: FeedbackSubmitInput!): SuccessPayload!
+  fygaroCheckoutCreate(input: FygaroCheckoutCreateInput!): FygaroCheckoutCreatePayload!
   idDocumentUploadUrlGenerate(input: IdDocumentUploadUrlGenerateInput!): IdDocumentUploadUrlPayload!
 
   """

--- a/src/graphql/public/schema.graphql
+++ b/src/graphql/public/schema.graphql
@@ -875,7 +875,9 @@ type FygaroCheckout {
   """
   expiresAt: Timestamp!
 
-  """Open this in the payment webview. Single use."""
+  """
+  Open this in the payment webview. The amount and the destination account are signed into it and cannot be edited; it stops working at expiresAt.
+  """
   url: String!
 }
 

--- a/src/graphql/public/schema.graphql
+++ b/src/graphql/public/schema.graphql
@@ -890,7 +890,7 @@ type FygaroCheckoutCreatePayload {
   errors: [Error!]!
 
   """
-  What is left of today's top-up allowance after this request. Present on refusal too, so the client can say how much would be accepted instead of only saying no. Null when the allowance itself could not be established.
+  How much more could be authorised right now, after this request. Card top-up links you have open but have not paid are ALREADY SUBTRACTED, so this is what would be accepted this second — not a statement of what the account has spent today. Present on refusal too, so the client can say how much would go through instead of only saying no. Null when the allowance could not be established.
   """
   remainingAllowance: CentAmount
 }

--- a/src/graphql/public/types/object/fygaro-checkout.ts
+++ b/src/graphql/public/types/object/fygaro-checkout.ts
@@ -10,7 +10,9 @@ const FygaroCheckout = GT.Object({
   fields: () => ({
     url: {
       type: GT.NonNull(GT.String),
-      description: "Open this in the payment webview. Single use.",
+      description:
+        "Open this in the payment webview. The amount and the destination account are " +
+        "signed into it and cannot be edited; it stops working at expiresAt.",
     },
     expiresAt: {
       type: GT.NonNull(Timestamp),

--- a/src/graphql/public/types/object/fygaro-checkout.ts
+++ b/src/graphql/public/types/object/fygaro-checkout.ts
@@ -1,0 +1,28 @@
+import { GT } from "@graphql/index"
+import CentAmount from "@graphql/public/types/scalar/cent-amount"
+import Timestamp from "@graphql/shared/types/scalar/timestamp"
+
+const FygaroCheckout = GT.Object({
+  name: "FygaroCheckout",
+  description:
+    "A server-authorised card top-up. The amount is signed into the URL, so it is " +
+    "the only amount that can be paid through it.",
+  fields: () => ({
+    url: {
+      type: GT.NonNull(GT.String),
+      description: "Open this in the payment webview. Single use.",
+    },
+    expiresAt: {
+      type: GT.NonNull(Timestamp),
+      description:
+        "After this, the URL is rejected by the payment provider and a new one must be requested.",
+    },
+    amount: {
+      type: GT.NonNull(CentAmount),
+      description:
+        "The authorised amount, echoed back so the client can display what was signed.",
+    },
+  }),
+})
+
+export default FygaroCheckout

--- a/src/services/alerts/dedup-key.ts
+++ b/src/services/alerts/dedup-key.ts
@@ -53,6 +53,14 @@ export const generateDedupKey = {
   // collapse into one alert per window. Distinct from fygaroUnattributed so an
   // outage never masquerades as "this payer typed a bad username".
   fygaroAccountLookupFailed: () => "fygaro:account-lookup-failed",
+  // The PRE-charge allowance check could not run: ERPNext settings, ERPNext
+  // 24h history, or the Redis reservation index. Static per reason — an outage
+  // refuses every card top-up at once, so it must collapse into ONE incident
+  // per failing dependency rather than one per refused customer. The reason is
+  // in the key (not just the body) so a Redis outage never lands in the same
+  // incident as an ERPNext one and get triaged as the wrong system.
+  fygaroAuthorizeUnavailable: (reason: string) =>
+    `fygaro:authorize-unavailable:${reason}`,
 }
 
 export const normalizeDedupKey = (key: string): string =>

--- a/src/services/alerts/index.types.ts
+++ b/src/services/alerts/index.types.ts
@@ -8,6 +8,10 @@ export type AlertSource =
   | "ibex"
   | "erpnext-audit"
   | "fygaro-webhook"
+  // The PRE-charge side (fygaroCheckoutCreate), as distinct from the webhook
+  // that runs after the card is captured. Different blast radius: a fault here
+  // refuses everyone before they pay, rather than stranding one payment.
+  | "fygaro-checkout"
 
 export interface BridgeAlert {
   dedupKey: string

--- a/src/services/frappe/BridgeTransferRequestWriter.ts
+++ b/src/services/frappe/BridgeTransferRequestWriter.ts
@@ -256,17 +256,21 @@ export const writeFygaroTopupRequest = async ({
   )
 }
 
-// Gross cents this account was charged via Fygaro over the trailing 24h,
-// excluding the given transaction's own audit row (which is written before the
-// credit gate runs). Feeds the per-level daily top-up cap. An unconfigured
-// ERPNext client is an error, not zero — the gate must fail closed rather
-// than treat a missing history as a clean slate.
+// Gross cents this account was charged via Fygaro over the trailing 24h. Feeds
+// the per-level daily top-up cap. An unconfigured ERPNext client is an error,
+// not zero — the gate must fail closed rather than treat a missing history as a
+// clean slate.
+//
+// `excludeTransactionId` drops the caller's OWN audit row, which the webhook
+// writes before the credit gate runs; without it every payment double-counts
+// itself. It is optional because the pre-charge check has no such row — nothing
+// has been paid yet — and omitting the filter is the honest way to say so.
 export const sumFygaroTopupGrossCentsLast24h = async ({
   accountId,
   excludeTransactionId,
 }: {
   accountId: AccountId | string
-  excludeTransactionId: string
+  excludeTransactionId?: string
 }): Promise<number | FygaroTopupHistoryQueryError> => {
   if (!ErpNext?.sumFygaroTopupGrossCentsSince) {
     return new FygaroTopupHistoryQueryError("ERPNext client is not configured")
@@ -274,7 +278,9 @@ export const sumFygaroTopupGrossCentsLast24h = async ({
   return ErpNext.sumFygaroTopupGrossCentsSince({
     accountId: String(accountId),
     since: new Date(Date.now() - 24 * 60 * 60 * 1000),
-    excludeRequestId: `fygaro:${excludeTransactionId}`,
+    ...(excludeTransactionId === undefined
+      ? {}
+      : { excludeRequestId: `fygaro:${excludeTransactionId}` }),
   })
 }
 

--- a/src/services/frappe/ErpNext.ts
+++ b/src/services/frappe/ErpNext.ts
@@ -512,7 +512,11 @@ export class ErpNext {
   }: {
     accountId: string
     since: Date
-    excludeRequestId: string
+    // Omitted by callers with no row of their own to exclude (the pre-charge
+    // allowance check runs before any payment exists). Omitting it drops the
+    // filter entirely rather than sending a sentinel that must be guaranteed
+    // never to collide with a real request_id.
+    excludeRequestId?: string
   }): Promise<number | FygaroTopupHistoryQueryError> {
     try {
       const filters = JSON.stringify([
@@ -540,7 +544,9 @@ export class ErpNext {
           ">=",
           toFrappeDatetime(since.toISOString()),
         ],
-        [BridgeTransferRequest.doctype, "request_id", "!=", excludeRequestId],
+        ...(excludeRequestId === undefined
+          ? []
+          : [[BridgeTransferRequest.doctype, "request_id", "!=", excludeRequestId]]),
       ])
       const fields = JSON.stringify(["request_id", "amount", "source_systems_seen"])
       const resp = await axios.get(

--- a/src/services/fygaro/checkout-intent-store.ts
+++ b/src/services/fygaro/checkout-intent-store.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from "crypto"
 
+import { CacheUndefinedError } from "@domain/cache"
 import { baseLogger } from "@services/logger"
 
 // Loaded on first use rather than at import time. `@services/cache` and
@@ -13,14 +14,29 @@ const redisClient = async () => (await import("@services/redis")).redis
 
 /**
  * What the server authorised, so the webhook can check what actually got paid
- * against it.
+ * against it — and so the pre-charge allowance check can subtract links this
+ * account is still holding.
  *
- * The signed JWT already prevents the customer editing the amount, so this is
- * not the primary defence — it is the record that lets us verify the two
- * independently, catch a signing/config mistake on our side, and make each
- * authorisation redeemable at most once. Losing this store degrades a payment
- * to the legacy unverified path; it never blocks a credit on its own (see
- * readIntent).
+ * This store has TWO halves with OPPOSITE failure postures. Read both before
+ * ruling Redis in or out of an incident:
+ *
+ *   - The RESERVATION INDEX (`readOutstandingReservations`) is FAIL-CLOSED, and
+ *     `authorizeFygaroTopup` refuses when it cannot be read. Redis is therefore
+ *     ON THE CRITICAL PATH for authorising a card top-up: if Redis is down,
+ *     `fygaroCheckoutCreate` refuses every request with
+ *     FYGARO_ALLOWANCE_UNAVAILABLE. Failing open here is what would let a second
+ *     full-allowance link be minted against an allowance the first already
+ *     spent, so this is deliberate — but it means "card top-ups are refusing"
+ *     has Redis as a first-class suspect alongside ERPNext.
+ *   - The CROSS-CHECK record (`readIntent`) is FAIL-OPEN: an unreadable intent
+ *     is treated as "no authorisation on file", the same position every legacy
+ *     payment is in, and the webhook's own credit gate still applies in full.
+ *     Losing it never blocks a credit for a payment already captured.
+ *
+ * The signed JWT already prevents the customer editing the amount, so the
+ * cross-check is not the primary defence — it is the record that lets us verify
+ * the two independently, catch a signing/config mistake on our side, and make
+ * each authorisation redeemable at most once.
  */
 export type FygaroCheckoutIntent = {
   intentId: string
@@ -29,6 +45,13 @@ export type FygaroCheckoutIntent = {
   amountCents: number
   currency: string
   createdAtMs: number
+  // The signed link itself, so a customer who abandoned the payment page can be
+  // handed their OWN live link back instead of being refused by the hold it
+  // still has on their allowance. Optional because records written before this
+  // field existed are still in Redis (and still verifiable); a record without
+  // them simply cannot be re-offered.
+  checkoutUrl?: string
+  expiresAtMs?: number
 }
 
 const cacheKey = (intentId: string) => `fygaro-checkout-intent:${intentId}`
@@ -102,28 +125,60 @@ export const saveIntent = async ({
 }
 
 /**
- * Gross cents this account has live, unredeemed authorisations for.
+ * One live, unredeemed authorisation this account is still holding.
  *
- * Fails closed (returns the error) rather than resolving to 0: treating an
- * unreadable index as "nothing outstanding" is precisely the state that lets a
- * second link be minted against an allowance the first one already spent.
+ * `expiresAtMs` is the zset score — the moment the JWT stops being payable and
+ * the hold therefore stops counting against the allowance. The caller needs it
+ * to tell a refused customer WHEN their allowance frees up, which is the
+ * difference between an actionable refusal and a dead end.
  */
-export const sumOutstandingAuthorizedCents = async ({
+export type FygaroReservation = {
+  intentId: string
+  amountCents: number
+  expiresAtMs: number
+}
+
+/**
+ * The live, unredeemed authorisations this account is still holding.
+ *
+ * FAIL-CLOSED (returns the error) rather than resolving to an empty list:
+ * treating an unreadable index as "nothing outstanding" is precisely the state
+ * that lets a second link be minted against an allowance the first one already
+ * spent. See the type docstring above — this is the half that puts Redis on the
+ * critical path for authorising a top-up.
+ */
+export const readOutstandingReservations = async ({
   accountId,
   nowMs,
 }: {
   accountId: string
   nowMs: number
-}): Promise<number | Error> => {
+}): Promise<FygaroReservation[] | Error> => {
   try {
     const redis = await redisClient()
     const key = accountIntentsKey(accountId)
-    // Drop everything whose JWT has expired before summing: those URLs cannot
+    // Drop everything whose JWT has expired before reading: those URLs cannot
     // be paid any more, so holding their amount against the allowance would
     // lock a customer out for the rest of the window for links they abandoned.
     await redis.zremrangebyscore(key, "-inf", nowMs)
-    const members = await redis.zrange(key, 0, -1)
-    return members.reduce((sum, member) => sum + reservationAmountCents(member), 0)
+    // WITHSCORES: the score IS the expiry, and a refusal that cannot say when
+    // the hold lifts is the same dead end as no refusal reason at all.
+    const flat = await redis.zrange(key, 0, -1, "WITHSCORES")
+
+    const reservations: FygaroReservation[] = []
+    for (let i = 0; i < flat.length; i += 2) {
+      const member = flat[i]
+      const amountCents = reservationAmountCents(member)
+      // A member we cannot parse is dropped rather than summed as NaN.
+      if (amountCents <= 0) continue
+      const expiresAtMs = Number(flat[i + 1])
+      reservations.push({
+        intentId: member.slice(member.indexOf(":") + 1),
+        amountCents,
+        expiresAtMs: Number.isFinite(expiresAtMs) ? expiresAtMs : nowMs,
+      })
+    }
+    return reservations
   } catch (err) {
     baseLogger.warn(
       { accountId, error: err instanceof Error ? err.constructor.name : String(err) },
@@ -188,10 +243,18 @@ export const readIntent = async (intentId: string): Promise<IntentLookup> => {
   const cache = await cacheService()
   const found = await cache.get<FygaroCheckoutIntent>({ key: cacheKey(intentId) })
   if (found instanceof Error) {
-    baseLogger.warn(
-      { intentId, error: found.constructor.name },
-      "Fygaro checkout intent lookup failed; treating payment as unauthorised-legacy",
-    )
+    // A plain cache MISS is the ordinary case, not a fault: every expired,
+    // evicted or already-redeemed intent lands here, including every provider
+    // re-delivery of a payment whose intent the first delivery redeemed.
+    // Warning on all of those turns the one line that should mean "Redis is
+    // broken" into routine noise. The caller already logs the miss with the
+    // transaction id, so this side stays silent for it.
+    if (!(found instanceof CacheUndefinedError)) {
+      baseLogger.warn(
+        { intentId, error: found.constructor.name },
+        "Fygaro checkout intent lookup failed; treating payment as unauthorised-legacy",
+      )
+    }
     return { found: false }
   }
   return { found: true, intent: found }

--- a/src/services/fygaro/checkout-intent-store.ts
+++ b/src/services/fygaro/checkout-intent-store.ts
@@ -3,6 +3,8 @@ import { randomUUID } from "crypto"
 import { CacheUndefinedError } from "@domain/cache"
 import { baseLogger } from "@services/logger"
 
+import { FygaroReservationWriteError } from "./errors"
+
 // Loaded on first use rather than at import time. `@services/cache` and
 // `@services/redis` construct a Redis client as a module side effect, and this
 // module is imported by the Fygaro webhook route — eagerly importing them would
@@ -118,7 +120,9 @@ export const saveIntent = async ({
     // up does not leave a key behind forever.
     await redis.expire(key, ttlSeconds + 3600)
   } catch (err) {
-    return err instanceof Error ? err : new Error(String(err))
+    return new FygaroReservationWriteError(
+      err instanceof Error ? err.message : String(err),
+    )
   }
 
   return true

--- a/src/services/fygaro/checkout-intent-store.ts
+++ b/src/services/fygaro/checkout-intent-store.ts
@@ -1,0 +1,90 @@
+import { randomUUID } from "crypto"
+
+import { baseLogger } from "@services/logger"
+
+// Loaded on first use rather than at import time. `@services/cache` constructs
+// a Redis client as a module side effect, and this module is imported by the
+// Fygaro webhook route — eagerly importing it would drag a live Redis
+// connection into every consumer of that route, including its unit tests.
+const cacheService = async () => (await import("@services/cache")).RedisCacheService()
+
+/**
+ * What the server authorised, so the webhook can check what actually got paid
+ * against it.
+ *
+ * The signed JWT already prevents the customer editing the amount, so this is
+ * not the primary defence — it is the record that lets us verify the two
+ * independently, catch a signing/config mistake on our side, and make each
+ * authorisation single-use. Losing this store degrades a payment to the legacy
+ * unverified path; it never blocks a credit on its own (see consumeIntent).
+ */
+export type FygaroCheckoutIntent = {
+  intentId: string
+  accountId: string
+  username: string
+  amountCents: number
+  currency: string
+  createdAtMs: number
+}
+
+const cacheKey = (intentId: string) => `fygaro-checkout-intent:${intentId}`
+
+export const newIntentId = (): string => randomUUID()
+
+export const saveIntent = async ({
+  intent,
+  ttlSeconds,
+}: {
+  intent: FygaroCheckoutIntent
+  ttlSeconds: number
+}): Promise<true | Error> => {
+  // Outlive the JWT by a margin: a payment authorised at the very end of the
+  // token's window still arrives (and must still be verifiable) minutes later,
+  // once the customer has finished typing their card details.
+  const res = await (
+    await cacheService()
+  ).set<FygaroCheckoutIntent>({
+    key: cacheKey(intent.intentId),
+    value: intent,
+    ttlSecs: (ttlSeconds + 3600) as Seconds,
+  })
+  if (res instanceof Error) return res
+  return true
+}
+
+export type IntentLookup =
+  | { found: true; intent: FygaroCheckoutIntent }
+  // Expired, evicted, already consumed, or minted by a different deployment.
+  | { found: false }
+
+/**
+ * Read an intent and immediately invalidate it, so a replayed webhook cannot
+ * present the same authorisation twice.
+ *
+ * A cache failure returns `found: false` rather than an error: the caller
+ * treats an unverifiable intent as "no authorisation on file" and falls through
+ * to the credit gate, which is the same position every legacy payment is in.
+ * Failing the credit outright here would turn a Redis blip into stuck customer
+ * funds — the exact outcome this whole workstream exists to avoid.
+ */
+export const consumeIntent = async (intentId: string): Promise<IntentLookup> => {
+  const cache = await cacheService()
+  const found = await cache.get<FygaroCheckoutIntent>({ key: cacheKey(intentId) })
+  if (found instanceof Error) {
+    baseLogger.warn(
+      { intentId, error: found.constructor.name },
+      "Fygaro checkout intent lookup failed; treating payment as unauthorised-legacy",
+    )
+    return { found: false }
+  }
+
+  const cleared = await cache.clear({ key: cacheKey(intentId) })
+  if (cleared instanceof Error) {
+    // The credit itself is still exactly-once downstream (the webhook dedupes
+    // on transactionId), so a failed clear cannot double-credit — it only means
+    // a replay would re-verify against a live intent instead of falling back.
+    baseLogger.warn({ intentId }, "Failed to clear consumed Fygaro checkout intent")
+  }
+
+  return { found: true, intent: found }
+}

--- a/src/services/fygaro/checkout-intent-store.ts
+++ b/src/services/fygaro/checkout-intent-store.ts
@@ -2,11 +2,14 @@ import { randomUUID } from "crypto"
 
 import { baseLogger } from "@services/logger"
 
-// Loaded on first use rather than at import time. `@services/cache` constructs
-// a Redis client as a module side effect, and this module is imported by the
-// Fygaro webhook route — eagerly importing it would drag a live Redis
-// connection into every consumer of that route, including its unit tests.
-const cacheService = async () => (await import("@services/cache")).RedisCacheService()
+// Loaded on first use rather than at import time. `@services/cache` and
+// `@services/redis` construct a Redis client as a module side effect, and this
+// module is imported by the Fygaro webhook route — eagerly importing them would
+// drag a live Redis connection into every consumer of that route, including its
+// unit tests.
+const cacheModule = () => import("@services/cache")
+const cacheService = async () => (await cacheModule()).RedisCacheService()
+const redisClient = async () => (await import("@services/redis")).redis
 
 /**
  * What the server authorised, so the webhook can check what actually got paid
@@ -15,8 +18,9 @@ const cacheService = async () => (await import("@services/cache")).RedisCacheSer
  * The signed JWT already prevents the customer editing the amount, so this is
  * not the primary defence — it is the record that lets us verify the two
  * independently, catch a signing/config mistake on our side, and make each
- * authorisation single-use. Losing this store degrades a payment to the legacy
- * unverified path; it never blocks a credit on its own (see consumeIntent).
+ * authorisation redeemable at most once. Losing this store degrades a payment
+ * to the legacy unverified path; it never blocks a credit on its own (see
+ * readIntent).
  */
 export type FygaroCheckoutIntent = {
   intentId: string
@@ -28,6 +32,32 @@ export type FygaroCheckoutIntent = {
 }
 
 const cacheKey = (intentId: string) => `fygaro-checkout-intent:${intentId}`
+
+// Per-account index of authorisations that are still payable, so the pre-charge
+// allowance check can subtract what it has already handed out. Without it,
+// authorisation is not reservation: N calls against a $100 allowance each mint a
+// $100 link, and paying two of them captures $200 while the webhook credits one
+// — charged and uncredited, the incident this workstream exists to end.
+//
+// A sorted set scored by the JWT's expiry in epoch ms: entries past `now` are no
+// longer payable (Fygaro rejects an expired token) and are pruned on read.
+const accountIntentsKey = (accountId: string) => `fygaro-checkout-intents:${accountId}`
+
+// `<amountCents>:<intentId>`. Amount first because an intentId is a uuid and
+// carries no colon, so the split point is unambiguous either way, and a
+// malformed member yields NaN which is dropped rather than summed.
+const reservationMember = ({
+  intentId,
+  amountCents,
+}: {
+  intentId: string
+  amountCents: number
+}) => `${amountCents}:${intentId}`
+
+const reservationAmountCents = (member: string): number => {
+  const amount = Number(member.slice(0, member.indexOf(":")))
+  return Number.isFinite(amount) && amount > 0 ? amount : 0
+}
 
 export const newIntentId = (): string => randomUUID()
 
@@ -49,7 +79,89 @@ export const saveIntent = async ({
     ttlSecs: (ttlSeconds + 3600) as Seconds,
   })
   if (res instanceof Error) return res
+
+  // The RESERVATION expires with the JWT, not with the record: once the token is
+  // no longer payable the amount is no longer outstanding, even though the
+  // record must stick around to verify a payment already in flight.
+  try {
+    const redis = await redisClient()
+    const key = accountIntentsKey(intent.accountId)
+    await redis.zadd(
+      key,
+      intent.createdAtMs + ttlSeconds * 1000,
+      reservationMember(intent),
+    )
+    // Bounded lifetime for the index itself, so an account that stops topping
+    // up does not leave a key behind forever.
+    await redis.expire(key, ttlSeconds + 3600)
+  } catch (err) {
+    return err instanceof Error ? err : new Error(String(err))
+  }
+
   return true
+}
+
+/**
+ * Gross cents this account has live, unredeemed authorisations for.
+ *
+ * Fails closed (returns the error) rather than resolving to 0: treating an
+ * unreadable index as "nothing outstanding" is precisely the state that lets a
+ * second link be minted against an allowance the first one already spent.
+ */
+export const sumOutstandingAuthorizedCents = async ({
+  accountId,
+  nowMs,
+}: {
+  accountId: string
+  nowMs: number
+}): Promise<number | Error> => {
+  try {
+    const redis = await redisClient()
+    const key = accountIntentsKey(accountId)
+    // Drop everything whose JWT has expired before summing: those URLs cannot
+    // be paid any more, so holding their amount against the allowance would
+    // lock a customer out for the rest of the window for links they abandoned.
+    await redis.zremrangebyscore(key, "-inf", nowMs)
+    const members = await redis.zrange(key, 0, -1)
+    return members.reduce((sum, member) => sum + reservationAmountCents(member), 0)
+  } catch (err) {
+    baseLogger.warn(
+      { accountId, error: err instanceof Error ? err.constructor.name : String(err) },
+      "Failed to read outstanding Fygaro checkout authorisations",
+    )
+    return err instanceof Error ? err : new Error(String(err))
+  }
+}
+
+/**
+ * Drop an authorisation's hold on the allowance without invalidating the record.
+ *
+ * Used to roll back a reservation we decided not to hand out, and by
+ * `consumeIntent` once the authorisation has actually been redeemed.
+ */
+export const releaseIntentReservation = async ({
+  accountId,
+  intentId,
+  amountCents,
+}: {
+  accountId: string
+  intentId: string
+  amountCents: number
+}): Promise<void> => {
+  try {
+    const redis = await redisClient()
+    await redis.zrem(
+      accountIntentsKey(accountId),
+      reservationMember({ intentId, amountCents }),
+    )
+  } catch (err) {
+    // The entry expires with the JWT anyway, so the worst case is that the
+    // customer's allowance frees up at `exp` instead of immediately.
+    baseLogger.warn(
+      { accountId, intentId, error: err instanceof Error ? err.constructor.name : err },
+      "Failed to release Fygaro checkout reservation",
+    )
+  }
 }
 
 export type IntentLookup =
@@ -58,8 +170,13 @@ export type IntentLookup =
   | { found: false }
 
 /**
- * Read an intent and immediately invalidate it, so a replayed webhook cannot
- * present the same authorisation twice.
+ * Read an intent WITHOUT invalidating it.
+ *
+ * Deliberately non-destructive: the webhook consults this before it knows
+ * whether the delivery will end in a terminal answer or a 500 asking the
+ * provider to retry. Consuming here would burn the authorisation on the retry
+ * path, so the delivery that actually credits the payment — the one most worth
+ * verifying — would arrive with nothing to check against.
  *
  * A cache failure returns `found: false` rather than an error: the caller
  * treats an unverifiable intent as "no authorisation on file" and falls through
@@ -67,7 +184,7 @@ export type IntentLookup =
  * Failing the credit outright here would turn a Redis blip into stuck customer
  * funds — the exact outcome this whole workstream exists to avoid.
  */
-export const consumeIntent = async (intentId: string): Promise<IntentLookup> => {
+export const readIntent = async (intentId: string): Promise<IntentLookup> => {
   const cache = await cacheService()
   const found = await cache.get<FygaroCheckoutIntent>({ key: cacheKey(intentId) })
   if (found instanceof Error) {
@@ -77,14 +194,33 @@ export const consumeIntent = async (intentId: string): Promise<IntentLookup> => 
     )
     return { found: false }
   }
-
-  const cleared = await cache.clear({ key: cacheKey(intentId) })
-  if (cleared instanceof Error) {
-    // The credit itself is still exactly-once downstream (the webhook dedupes
-    // on transactionId), so a failed clear cannot double-credit — it only means
-    // a replay would re-verify against a live intent instead of falling back.
-    baseLogger.warn({ intentId }, "Failed to clear consumed Fygaro checkout intent")
-  }
-
   return { found: true, intent: found }
+}
+
+/**
+ * Redeem an intent, atomically, so exactly one caller can claim a given
+ * authorisation.
+ *
+ * The claim is gated on `consumeCacheKey`, whose DEL removed-count is the only
+ * thing that distinguishes the winner: `clear` discards that count and always
+ * resolves `true`, which makes get-then-`clear` a TOCTOU race in which every
+ * concurrent consumer "succeeds" (see the docstring on `consumeCacheKey`).
+ *
+ * Call this only on terminal outcomes — a delivery that will be retried must
+ * leave the authorisation in place.
+ */
+export const consumeIntent = async (intentId: string): Promise<{ consumed: boolean }> => {
+  // Read first, purely so a winning claim knows which account reservation to
+  // release. The read is not the gate; the DEL below is.
+  const lookup = await readIntent(intentId)
+
+  const claimed = await (await cacheModule()).consumeCacheKey({ key: cacheKey(intentId) })
+  if (claimed instanceof Error) {
+    baseLogger.warn({ intentId }, "Failed to consume Fygaro checkout intent")
+    return { consumed: false }
+  }
+  if (!claimed) return { consumed: false }
+
+  if (lookup.found) await releaseIntentReservation(lookup.intent)
+  return { consumed: true }
 }

--- a/src/services/fygaro/checkout.ts
+++ b/src/services/fygaro/checkout.ts
@@ -1,0 +1,178 @@
+import { createHmac } from "crypto"
+
+/**
+ * Fygaro Links supports two ways of handing a payment to their hosted checkout
+ * (https://help.fygaro.com/en-us/article/fygaro-links-integration-api-h78p9y/):
+ *
+ *   pre-fill  `[button]?amount=…&custom_reference=…`  — customer CAN edit
+ *   jwt       `[button]?jwt=<token>`                  — cryptographically locked
+ *
+ * The app has always built the pre-fill URL on the device, which makes both the
+ * amount and — more importantly — `custom_reference` user-controlled. That
+ * reference is the credit key: it decides whose wallet the payment lands in.
+ * So neither the amount nor the destination was ever authenticated, and any
+ * client-side limit was advisory.
+ *
+ * This module mints the signed alternative. Nothing here talks to Fygaro: the
+ * token is an HMAC over values we choose, using the same shared secret the
+ * webhook already verifies inbound calls with, so there is no outbound call and
+ * no new failure mode at request time.
+ */
+
+// Separates the username from the server-issued intent id inside
+// `custom_reference`. Chosen because usernames cannot contain it (see
+// checkedToUsername) and it survives URL/JSON encoding unescaped.
+export const FYGARO_REFERENCE_SEPARATOR = "|"
+
+export type FygaroCustomReference = {
+  username: string
+  // Absent for references built by app versions that predate signed checkout.
+  // Those payments are still recorded and still pass through the credit gate —
+  // they simply carry no proof of what was authorised.
+  intentId?: string
+}
+
+/**
+ * `<username>|<intentId>`, or bare `<username>` when no intent is bound.
+ */
+export const buildCustomReference = ({
+  username,
+  intentId,
+}: {
+  username: string
+  intentId?: string
+}): string =>
+  intentId ? `${username}${FYGARO_REFERENCE_SEPARATOR}${intentId}` : username
+
+/**
+ * Read a `custom_reference` coming back from Fygaro.
+ *
+ * Deliberately lenient about shape and strict about meaning: anything that is
+ * not exactly `username|intentId` yields no intentId, so the caller falls back
+ * to the unverified legacy path rather than treating a malformed reference as
+ * an authorisation. Returns undefined only when there is no usable username at
+ * all — that is the "payment we cannot attribute" case the webhook already
+ * records and alerts on.
+ */
+export const parseCustomReference = (
+  raw: string | undefined | null,
+): FygaroCustomReference | undefined => {
+  const trimmed = (raw ?? "").trim()
+  if (trimmed === "") return undefined
+
+  const parts = trimmed.split(FYGARO_REFERENCE_SEPARATOR)
+  const username = parts[0].trim()
+  if (username === "") return undefined
+
+  // Exactly two segments, both non-empty, is the only shape that carries an
+  // intent. A third segment means something built a reference we do not
+  // understand; treating that as legacy is the safe reading.
+  if (parts.length !== 2) return { username }
+  const intentId = parts[1].trim()
+  if (intentId === "") return { username }
+
+  return { username, intentId }
+}
+
+const base64Url = (input: Buffer | string): string =>
+  Buffer.from(input)
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "")
+
+/**
+ * Fygaro renders the amount as given, so it must be a plain 2-decimal string:
+ * "80" or "80.5" are not acceptable where "80.00" and "80.50" are.
+ */
+export const formatFygaroAmount = (amountCents: number): string =>
+  (amountCents / 100).toFixed(2)
+
+export type FygaroCheckoutJwtPayload = {
+  amount: string
+  currency: string
+  custom_reference: string
+  // Seconds since epoch. `exp` bounds replay: a URL captured from the WebView
+  // cannot be paid tomorrow, when the rolling-24h allowance has moved on.
+  exp: number
+  nbf: number
+}
+
+/**
+ * Sign a Fygaro checkout payload. HS256 over the shared secret, with the key id
+ * in the header so Fygaro knows which secret to verify against — the same
+ * key-id/secret pairing the inbound webhook already uses, which is why secret
+ * rotation needs no change here.
+ */
+export const signFygaroCheckoutJwt = ({
+  payload,
+  keyId,
+  secret,
+}: {
+  payload: FygaroCheckoutJwtPayload
+  keyId: string
+  secret: string
+}): string => {
+  const header = { alg: "HS256", typ: "JWT", kid: keyId }
+  const signingInput = `${base64Url(JSON.stringify(header))}.${base64Url(
+    JSON.stringify(payload),
+  )}`
+  const signature = base64Url(createHmac("sha256", secret).update(signingInput).digest())
+  return `${signingInput}.${signature}`
+}
+
+export type FygaroCheckout = {
+  url: string
+  expiresAt: Date
+  customReference: string
+}
+
+/**
+ * Build the locked checkout URL for one authorised top-up.
+ *
+ * `nowMs` is injected so the caller (and tests) control the validity window
+ * rather than inheriting wall-clock behaviour.
+ */
+export const buildFygaroCheckout = ({
+  buttonUrl,
+  username,
+  intentId,
+  amountCents,
+  currency,
+  keyId,
+  secret,
+  ttlSeconds,
+  nowMs,
+}: {
+  buttonUrl: string
+  username: string
+  intentId: string
+  amountCents: number
+  currency: string
+  keyId: string
+  secret: string
+  ttlSeconds: number
+  nowMs: number
+}): FygaroCheckout => {
+  const nowSecs = Math.floor(nowMs / 1000)
+  const customReference = buildCustomReference({ username, intentId })
+  const payload: FygaroCheckoutJwtPayload = {
+    amount: formatFygaroAmount(amountCents),
+    currency,
+    custom_reference: customReference,
+    nbf: nowSecs,
+    exp: nowSecs + ttlSeconds,
+  }
+
+  const token = signFygaroCheckoutJwt({ payload, keyId, secret })
+  // The token carries every payment parameter, so nothing else is appended:
+  // an `amount` query param alongside it would be exactly the editable value
+  // this change exists to remove.
+  const separator = buttonUrl.includes("?") ? "&" : "?"
+
+  return {
+    url: `${buttonUrl}${separator}jwt=${token}`,
+    expiresAt: new Date((nowSecs + ttlSeconds) * 1000),
+    customReference,
+  }
+}

--- a/src/services/fygaro/checkout.ts
+++ b/src/services/fygaro/checkout.ts
@@ -99,6 +99,18 @@ export type FygaroCheckoutJwtPayload = {
 }
 
 /**
+ * How far `nbf` is backdated.
+ *
+ * Fygaro validates the token against THEIR clock. `nbf: now` with zero leeway
+ * means a server running even a second fast mints a link that is "not yet
+ * valid" — a dead end at the payment page, which is a payer-facing hard failure
+ * rather than a degraded credit. Flash already tolerates 5 minutes of skew on
+ * the inbound webhook (`webhook.timestampSkewMs`); the outbound side has no
+ * business being stricter. `exp` is what actually bounds replay.
+ */
+export const NBF_SKEW_SECONDS = 60
+
+/**
  * Sign a Fygaro checkout payload. HS256 over the shared secret, with the key id
  * in the header so Fygaro knows which secret to verify against — the same
  * key-id/secret pairing the inbound webhook already uses, which is why secret
@@ -160,7 +172,7 @@ export const buildFygaroCheckout = ({
     amount: formatFygaroAmount(amountCents),
     currency,
     custom_reference: customReference,
-    nbf: nowSecs,
+    nbf: nowSecs - NBF_SKEW_SECONDS,
     exp: nowSecs + ttlSeconds,
   }
 

--- a/src/services/fygaro/errors.ts
+++ b/src/services/fygaro/errors.ts
@@ -17,6 +17,18 @@ export class FygaroAboveSinglePaymentLimitError extends FygaroError {}
 export class FygaroDailyAllowanceExceededError extends FygaroError {}
 
 /**
+ * The account is HOLDING its allowance in an unpaid checkout link, not spending
+ * it.
+ *
+ * Deliberately NOT `FygaroDailyAllowanceExceededError`: an account that has
+ * spent $0 today and abandoned one payment page has not exceeded anything, and
+ * telling it "you have $0.00 left of today's top-up limit" is a false statement
+ * that also invites the one action — retry now — that keeps hitting it. This
+ * says what is true and, in the message, when the hold lifts.
+ */
+export class FygaroCheckoutAlreadyOpenError extends FygaroError {}
+
+/**
  * We could not establish what the customer is allowed to spend — the settings
  * row or the 24h history was unreadable.
  *

--- a/src/services/fygaro/errors.ts
+++ b/src/services/fygaro/errors.ts
@@ -55,3 +55,13 @@ export class FygaroLevelNotEligibleError extends FygaroError {
     super(message)
   }
 }
+
+/**
+ * The reservation index could not be written.
+ *
+ * Distinct from a failed cross-check record: without the reservation the
+ * authorisation is invisible to the next request, so the same allowance can be
+ * handed out again. The read side already fails closed, and the write side has
+ * to match — a link minted with no hold is exactly the over-issue this guards.
+ */
+export class FygaroReservationWriteError extends FygaroError {}

--- a/src/services/fygaro/errors.ts
+++ b/src/services/fygaro/errors.ts
@@ -29,3 +29,17 @@ export class FygaroAllowanceUnavailableError extends FygaroError {
     super(message)
   }
 }
+
+/**
+ * The account's level has no configured top-up allowance (level 0 today).
+ *
+ * Deliberately NOT an "unavailable" error: that reason is deterministic and
+ * permanent until the account upgrades, so telling the customer to try again
+ * later sends them into a loop and sends support chasing a phantom outage. Its
+ * own code exists so the client can route them to the upgrade flow instead.
+ */
+export class FygaroLevelNotEligibleError extends FygaroError {
+  constructor(message: string = "Card top-up isn't available on your account level yet") {
+    super(message)
+  }
+}

--- a/src/services/fygaro/errors.ts
+++ b/src/services/fygaro/errors.ts
@@ -1,0 +1,31 @@
+import { DomainError, ErrorLevel } from "@domain/shared"
+
+export class FygaroError extends DomainError {
+  readonly level: ErrorLevel = ErrorLevel.Warn
+}
+
+export class FygaroCheckoutDisabledError extends FygaroError {
+  constructor(message: string = "Card top-up is currently unavailable") {
+    super(message)
+  }
+}
+
+export class FygaroBelowMinimumError extends FygaroError {}
+
+export class FygaroAboveSinglePaymentLimitError extends FygaroError {}
+
+export class FygaroDailyAllowanceExceededError extends FygaroError {}
+
+/**
+ * We could not establish what the customer is allowed to spend — the settings
+ * row or the 24h history was unreadable.
+ *
+ * Deliberately distinct from "you have hit your limit": the customer has done
+ * nothing wrong, and the client should say so rather than accusing them of
+ * exceeding an allowance we never actually measured.
+ */
+export class FygaroAllowanceUnavailableError extends FygaroError {
+  constructor(message: string = "Could not check your top-up allowance right now") {
+    super(message)
+  }
+}

--- a/src/services/fygaro/webhook-server/fees.ts
+++ b/src/services/fygaro/webhook-server/fees.ts
@@ -76,6 +76,11 @@ export type RecordOnlyReason =
   | "daily-limit-exceeded"
   | "under-minimum"
   | "non-positive-net"
+  // The payment did not match the checkout we signed for it. Not reachable
+  // from user input — the amount is inside the JWT — so it means a bug or a
+  // replay on our side, and crediting anyway would be crediting something we
+  // cannot account for.
+  | "intent-mismatch"
 
 export type CreditGate =
   | { credit: true; fees: FygaroFees }

--- a/src/services/fygaro/webhook-server/routes/payment.ts
+++ b/src/services/fygaro/webhook-server/routes/payment.ts
@@ -44,7 +44,7 @@ import {
 } from "../credit-topup"
 import { getFygaroSettings } from "../fygaro-settings"
 import { parseCustomReference } from "../../checkout"
-import { consumeIntent } from "../../checkout-intent-store"
+import { consumeIntent, readIntent } from "../../checkout-intent-store"
 import { evaluateCreditGate, RecordOnlyReason } from "../fees"
 
 type FygaroPaymentPayload = {
@@ -354,9 +354,17 @@ export const paymentHandler = async (req: Request, res: Response) => {
     // payment we cannot account for is the failure this whole workstream is
     // about. A missing intent is NOT treated as a mismatch: it is the legacy
     // position (unverified), and the credit gate below still applies in full.
+    //
+    // The read is NON-DESTRUCTIVE. This handler answers 500 on the transient
+    // stops below so the provider retries; consuming here would burn the
+    // authorisation on a delivery that credited nothing, leaving the retry that
+    // actually moves money — the one most worth verifying — with nothing to
+    // check against. The intent is redeemed instead on the terminal paths
+    // (`redeemIntent` below), which is also where its hold on the account's
+    // daily allowance is released.
     let intentMismatch: string | undefined
     if (intentId) {
-      const lookup = await consumeIntent(intentId)
+      const lookup = await readIntent(intentId)
       if (lookup.found) {
         const authorized = lookup.intent
         if (authorized.amountCents !== grossCents) {
@@ -370,6 +378,14 @@ export const paymentHandler = async (req: Request, res: Response) => {
           "Fygaro payment references an intent that is expired, consumed or unknown",
         )
       }
+    }
+
+    // Terminal-path redemption: atomic, so a replayed authorisation is claimed
+    // exactly once. Deliberately not awaited for its answer — losing the claim
+    // means another delivery already redeemed it, which changes nothing about
+    // this payment's outcome.
+    const redeemIntent = async () => {
+      if (intentId) await consumeIntent(intentId)
     }
 
     const settings = creditEnabled ? await getFygaroSettings() : undefined
@@ -514,6 +530,9 @@ export const paymentHandler = async (req: Request, res: Response) => {
           reason: gate.reason,
         },
       })
+      // Terminal: this reason will not change on retry, so the authorisation is
+      // spent and its hold on the daily allowance must be released.
+      await redeemIntent()
       return res.status(200).json({ status: "recorded", credited: false })
     }
 
@@ -629,6 +648,10 @@ export const paymentHandler = async (req: Request, res: Response) => {
             net: centsToDollars(fees.netCents),
           },
         })
+
+        // The money moved: the authorisation is spent. Not done on the credit-
+        // FAILURE branch above, which is deliberately retryable.
+        await redeemIntent()
 
         return { code: 200, body: { status: "success", credited: true } }
       },

--- a/src/services/fygaro/webhook-server/routes/payment.ts
+++ b/src/services/fygaro/webhook-server/routes/payment.ts
@@ -43,6 +43,8 @@ import {
   INSUFFICIENT_TREASURY_FLOAT_STEP,
 } from "../credit-topup"
 import { getFygaroSettings } from "../fygaro-settings"
+import { parseCustomReference } from "../../checkout"
+import { consumeIntent } from "../../checkout-intent-store"
 import { evaluateCreditGate, RecordOnlyReason } from "../fees"
 
 type FygaroPaymentPayload = {
@@ -110,6 +112,8 @@ const RECORD_ONLY_ALERT_TITLE: Record<
   "daily-limit-exceeded":
     "Fygaro payment exceeds the account's daily top-up limit — not auto-credited",
   "under-minimum": "Fygaro payment below the minimum top-up — not auto-credited",
+  "intent-mismatch":
+    "Fygaro payment does not match the checkout Flash signed for it — not auto-credited",
   "non-positive-net": "Fygaro payment net after fees is not positive — not auto-credited",
 }
 
@@ -117,7 +121,13 @@ export const paymentHandler = async (req: Request, res: Response) => {
   const payload = (req.body ?? {}) as FygaroPaymentPayload
   const { transactionId, createdAt } = payload
   const currency = (payload.currency ?? "USD").toUpperCase()
-  const username = payload.customReference?.trim() || undefined
+  // `custom_reference` is either a bare username (built on-device by app
+  // versions predating signed checkout, and editable by the payer) or
+  // `username|intentId` minted by authorizeFygaroTopup. Both are accepted for
+  // as long as older clients are in the wild; only the second can be verified.
+  const reference = parseCustomReference(payload.customReference)
+  const username = reference?.username
+  const intentId = reference?.intentId
 
   if (!transactionId || !payload.amount) {
     baseLogger.warn(
@@ -337,6 +347,31 @@ export const paymentHandler = async (req: Request, res: Response) => {
     // ERPNext for this.
     const creditEnabled = Boolean(FygaroConfig.credit?.enabled)
     const grossCents = Math.round(grossAmount * 100)
+    // Cross-check the payment against what the server authorised, when the
+    // reference carries an intent. The signed JWT already prevents the customer
+    // altering the amount, so a mismatch here means something on OUR side is
+    // wrong — a signing bug, a stale intent, a replay — and quietly crediting a
+    // payment we cannot account for is the failure this whole workstream is
+    // about. A missing intent is NOT treated as a mismatch: it is the legacy
+    // position (unverified), and the credit gate below still applies in full.
+    let intentMismatch: string | undefined
+    if (intentId) {
+      const lookup = await consumeIntent(intentId)
+      if (lookup.found) {
+        const authorized = lookup.intent
+        if (authorized.amountCents !== grossCents) {
+          intentMismatch = `authorised ${authorized.amountCents}c, paid ${grossCents}c`
+        } else if (accountId && authorized.accountId !== accountId) {
+          intentMismatch = `authorised for account ${authorized.accountId}, paid as ${accountId}`
+        }
+      } else {
+        baseLogger.info(
+          { transactionId, intentId },
+          "Fygaro payment references an intent that is expired, consumed or unknown",
+        )
+      }
+    }
+
     const settings = creditEnabled ? await getFygaroSettings() : undefined
 
     // Trailing-24h charged gross for the per-level daily cap, read only when a
@@ -375,15 +410,19 @@ export const paymentHandler = async (req: Request, res: Response) => {
       })
     }
 
-    const gate = evaluateCreditGate({
-      creditEnabled,
-      currency,
-      settings,
-      grossCents,
-      level: account.level,
-      priorDayGrossCents,
-      flashFeeDiscountPercent,
-    })
+    // A mismatch overrides every other outcome: the gate can only reason about
+    // the payment in front of it, not about whether we ever authorised it.
+    const gate = intentMismatch
+      ? ({ credit: false, reason: "intent-mismatch" } as const)
+      : evaluateCreditGate({
+          creditEnabled,
+          currency,
+          settings,
+          grossCents,
+          level: account.level,
+          priorDayGrossCents,
+          flashFeeDiscountPercent,
+        })
 
     if (!gate.credit) {
       // `settings-unavailable` and `history-unavailable` are TRANSIENT (an
@@ -446,13 +485,19 @@ export const paymentHandler = async (req: Request, res: Response) => {
           source: "fygaro-webhook",
           severity: "warning",
           title: RECORD_ONLY_ALERT_TITLE[gate.reason],
-          detail: `reason=${gate.reason} currency=${currency} gross=${centsToDollars(grossCents)} level=${account.level}`,
+          detail: `reason=${gate.reason} currency=${currency} gross=${centsToDollars(grossCents)} level=${account.level}${
+            intentMismatch ? ` mismatch=${intentMismatch}` : ""
+          }`,
           context: {
             transaction_id: transactionId,
             amount: String(payload.amount),
             reason: gate.reason,
             username,
             account_level: account.level,
+            // Without these numbers the alert says a payment was refused but
+            // not what it was refused against, which is the only thing that
+            // tells an operator whether to credit it by hand.
+            ...(intentMismatch ? { intent_mismatch: intentMismatch } : {}),
           },
         })
       }

--- a/src/services/fygaro/webhook-server/routes/payment.ts
+++ b/src/services/fygaro/webhook-server/routes/payment.ts
@@ -44,7 +44,12 @@ import {
 } from "../credit-topup"
 import { getFygaroSettings } from "../fygaro-settings"
 import { parseCustomReference } from "../../checkout"
-import { consumeIntent, readIntent } from "../../checkout-intent-store"
+import {
+  consumeIntent,
+  readIntent,
+  releaseIntentReservation,
+  type FygaroCheckoutIntent,
+} from "../../checkout-intent-store"
 import { evaluateCreditGate, RecordOnlyReason } from "../fees"
 
 type FygaroPaymentPayload = {
@@ -287,6 +292,45 @@ export const paymentHandler = async (req: Request, res: Response) => {
       return res.status(500).json({ error: "Failed to persist audit row" })
     }
 
+    // Look the authorisation up ONCE, and do it BEFORE the unattributed branch
+    // below, so every terminal answer in this handler can let go of the hold
+    // the authorisation still has on the account's daily allowance. A leaked
+    // hold is not cosmetic: the audit row already counts the payment towards
+    // the cap, so a hold left behind on top of it double-counts one payment for
+    // the rest of the JWT's window and refuses the account's next legitimate
+    // top-up — piling a second failure onto an already-bad event.
+    //
+    // The read is NON-DESTRUCTIVE. This handler answers 500 on the transient
+    // stops below so the provider retries; consuming here would burn the
+    // authorisation on a delivery that credited nothing, leaving the retry that
+    // actually moves money — the one most worth verifying — with nothing to
+    // check against.
+    let authorizedIntent: FygaroCheckoutIntent | undefined
+    if (intentId) {
+      const lookup = await readIntent(intentId)
+      if (lookup.found) {
+        authorizedIntent = lookup.intent
+      } else {
+        baseLogger.info(
+          { transactionId, intentId },
+          "Fygaro payment references an intent that is expired, consumed or unknown",
+        )
+      }
+    }
+
+    /**
+     * Drop the authorisation's hold on the daily allowance WITHOUT consuming the
+     * record.
+     *
+     * For terminal answers that did not move money: the hold must go (it is
+     * holding allowance against a payment that is already counted in ERPNext),
+     * but the record must stay, so a later manual credit still has the
+     * cross-check of what we originally authorised.
+     */
+    const releaseAuthorizedHold = async () => {
+      if (authorizedIntent) await releaseIntentReservation(authorizedIntent)
+    }
+
     if (!account) {
       // Dedupe re-deliveries before emitting: alertBridge is TTL-deduped but
       // the ops feed is not, so a Fygaro retry of an unattributed payment
@@ -335,6 +379,11 @@ export const paymentHandler = async (req: Request, res: Response) => {
           ...(resolvedUsername ? { emailMatchedUsername: resolvedUsername } : {}),
         },
       })
+      // Terminal (the dedupe lock above is non-releasing, so retries ack
+      // "already_processed"): a signed reference whose username no longer
+      // resolves never reaches the redemption paths below, so release its hold
+      // here or it sits on the allowance until the JWT expires.
+      await releaseAuthorizedHold()
       return res.status(200).json({ status: "recorded", attributed: false })
     }
     const accountId = account.id
@@ -347,36 +396,25 @@ export const paymentHandler = async (req: Request, res: Response) => {
     // ERPNext for this.
     const creditEnabled = Boolean(FygaroConfig.credit?.enabled)
     const grossCents = Math.round(grossAmount * 100)
-    // Cross-check the payment against what the server authorised, when the
-    // reference carries an intent. The signed JWT already prevents the customer
-    // altering the amount, so a mismatch here means something on OUR side is
-    // wrong — a signing bug, a stale intent, a replay — and quietly crediting a
-    // payment we cannot account for is the failure this whole workstream is
-    // about. A missing intent is NOT treated as a mismatch: it is the legacy
-    // position (unverified), and the credit gate below still applies in full.
+    // Cross-check the payment against what the server authorised (read above),
+    // when the reference carries an intent. The signed JWT already prevents the
+    // customer altering the amount, so a mismatch here means something on OUR
+    // side is wrong — a signing bug, a stale intent, a replay — and quietly
+    // crediting a payment we cannot account for is the failure this whole
+    // workstream is about. A missing intent is NOT treated as a mismatch: it is
+    // the legacy position (unverified), and the credit gate below still applies
+    // in full.
     //
-    // The read is NON-DESTRUCTIVE. This handler answers 500 on the transient
-    // stops below so the provider retries; consuming here would burn the
-    // authorisation on a delivery that credited nothing, leaving the retry that
-    // actually moves money — the one most worth verifying — with nothing to
-    // check against. The intent is redeemed instead on the terminal paths
-    // (`redeemIntent` below), which is also where its hold on the account's
-    // daily allowance is released.
+    // The intent is redeemed on the terminal paths (`redeemIntent` below), which
+    // is also where its hold on the account's daily allowance is released; the
+    // terminal paths that did NOT move money release the hold alone
+    // (`releaseAuthorizedHold`), keeping the record for a manual credit.
     let intentMismatch: string | undefined
-    if (intentId) {
-      const lookup = await readIntent(intentId)
-      if (lookup.found) {
-        const authorized = lookup.intent
-        if (authorized.amountCents !== grossCents) {
-          intentMismatch = `authorised ${authorized.amountCents}c, paid ${grossCents}c`
-        } else if (accountId && authorized.accountId !== accountId) {
-          intentMismatch = `authorised for account ${authorized.accountId}, paid as ${accountId}`
-        }
-      } else {
-        baseLogger.info(
-          { transactionId, intentId },
-          "Fygaro payment references an intent that is expired, consumed or unknown",
-        )
+    if (authorizedIntent) {
+      if (authorizedIntent.amountCents !== grossCents) {
+        intentMismatch = `authorised ${authorizedIntent.amountCents}c, paid ${grossCents}c`
+      } else if (accountId && authorizedIntent.accountId !== accountId) {
+        intentMismatch = `authorised for account ${authorizedIntent.accountId}, paid as ${accountId}`
       }
     }
 
@@ -600,6 +638,17 @@ export const paymentHandler = async (req: Request, res: Response) => {
           // send is not cached, so a provider retry re-attempts the credit
           // (self-healing for transient failures); ops has the critical alert
           // for the deterministic ones.
+          //
+          // Release the HOLD but not the record. The ERPNext row already counts
+          // this payment towards the daily cap (Fiat Received rows are summed),
+          // so leaving the reservation up as well double-counts one payment:
+          // $50 paid on a $125 cap would read as $100 spent and refuse the
+          // customer's next $50 for the rest of the JWT window — a second
+          // failure stacked on an already-failed credit. The record survives so
+          // the manual credit this alert asks for still has its cross-check,
+          // and so a provider retry (which this branch invites) can still
+          // verify the payment.
+          await releaseAuthorizedHold()
           return { code: 200, body: { status: "recorded", credited: false } }
         }
 

--- a/src/services/rate-limit/index.ts
+++ b/src/services/rate-limit/index.ts
@@ -3,7 +3,7 @@ import {
   UnknownRateLimitServiceError,
 } from "@domain/rate-limit/errors"
 import { redis } from "@services/redis"
-import { RateLimiterRedis } from "rate-limiter-flexible"
+import { RateLimiterRedis, RateLimiterRes } from "rate-limiter-flexible"
 
 export const RedisRateLimitService = ({
   keyPrefix,
@@ -19,7 +19,15 @@ export const RedisRateLimitService = ({
       await limiter.consume(key)
       return true
     } catch (err) {
-      return new RateLimiterExceededError()
+      // `limiter.consume` rejects for two unrelated reasons, and they must not
+      // be conflated. A RateLimiterRes rejection means the caller really is
+      // over the limit. Anything else is the STORE failing — with no
+      // insuranceLimiter configured, a Redis outage rejects with the raw store
+      // error — and reporting that as "too many attempts" tells every user
+      // they are rate limited on their first request of the day, while hiding
+      // the outage from whoever is on call.
+      if (err instanceof RateLimiterRes) return new RateLimiterExceededError()
+      return new UnknownRateLimitServiceError(err)
     }
   }
 
@@ -56,7 +64,10 @@ export const consumeLimiter = async ({
     limitOptions: rateLimitConfig.limits,
   })
   const consume = await limiter.consume(keyToConsume)
-  return consume instanceof Error ? new rateLimitConfig.error() : consume
+  // Only a genuine limit breach becomes the caller's "too many attempts"
+  // error; a store fault propagates as itself so it can be told apart.
+  if (consume instanceof RateLimiterExceededError) return new rateLimitConfig.error()
+  return consume
 }
 
 export const resetLimiter = async ({

--- a/test/flash/unit/app/authentication/ops-events-hooks.spec.ts
+++ b/test/flash/unit/app/authentication/ops-events-hooks.spec.ts
@@ -27,6 +27,7 @@ jest.mock("@config", () => {
     getTestAccounts: jest.fn(() => []),
     getFailedLoginAttemptPerIpLimits: jest.fn(() => limits),
     getFailedLoginAttemptPerLoginIdentifierLimits: jest.fn(() => limits),
+    getFygaroCheckoutCreateAttemptLimits: jest.fn(() => limits),
     getInvoiceCreateAttemptLimits: jest.fn(() => limits),
     getInvoiceCreateForRecipientAttemptLimits: jest.fn(() => limits),
     getInviteCreateAttemptLimits: jest.fn(() => limits),

--- a/test/flash/unit/app/fygaro/authorize-topup.spec.ts
+++ b/test/flash/unit/app/fygaro/authorize-topup.spec.ts
@@ -4,6 +4,9 @@ import { parseCustomReference } from "@services/fygaro/checkout"
 const mockGetFygaroSettings = jest.fn()
 const mockSumPrior = jest.fn()
 const mockSaveIntent = jest.fn()
+const mockSumOutstanding = jest.fn()
+const mockReleaseReservation = jest.fn()
+const mockGetFlashFeeDiscountPercent = jest.fn()
 
 jest.mock("@services/fygaro/webhook-server/fygaro-settings", () => ({
   getFygaroSettings: (...args: unknown[]) => mockGetFygaroSettings(...args),
@@ -11,9 +14,15 @@ jest.mock("@services/fygaro/webhook-server/fygaro-settings", () => ({
 jest.mock("@services/frappe/BridgeTransferRequestWriter", () => ({
   sumFygaroTopupGrossCentsLast24h: (...args: unknown[]) => mockSumPrior(...args),
 }))
+jest.mock("@services/frappe/fee-discounts", () => ({
+  getFlashFeeDiscountPercent: (...args: unknown[]) =>
+    mockGetFlashFeeDiscountPercent(...args),
+}))
 jest.mock("@services/fygaro/checkout-intent-store", () => ({
   newIntentId: () => "intent-fixed",
   saveIntent: (...args: unknown[]) => mockSaveIntent(...args),
+  sumOutstandingAuthorizedCents: (...args: unknown[]) => mockSumOutstanding(...args),
+  releaseIntentReservation: (...args: unknown[]) => mockReleaseReservation(...args),
 }))
 
 const CHECKOUT = {
@@ -26,6 +35,8 @@ const CHECKOUT = {
 jest.mock("@config", () => ({
   get FygaroConfig() {
     return {
+      enabled: mockFygaroEnabled,
+      credit: { enabled: mockCreditEnabled },
       checkout: mockCheckoutConfig,
       webhook: { secrets: { "key-1": "shared-secret" } },
     }
@@ -33,11 +44,21 @@ jest.mock("@config", () => ({
 }))
 
 let mockCheckoutConfig: typeof CHECKOUT = { ...CHECKOUT }
+let mockFygaroEnabled = true
+let mockCreditEnabled = true
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { authorizeFygaroTopup } = require("@app/fygaro/authorize-topup")
 
+// The same canonical operator settings the webhook spec uses, so the two sides
+// of this feature are pinned against one fee ladder: 2.99% + $0.49 processor,
+// 2.0% Flash margin. $5 minimum, $200 single-payment ceiling, $100/$500 daily.
 const SETTINGS = {
+  processor: "Fygaro",
+  processorFeePercent: 2.99,
+  processorFeeFixed: 0.49,
+  flashMarginPercent: 2.0,
+  flashMarginFixed: 0,
   autoCreditEnabled: true,
   minimumTopup: 5, // USD
   autoCreditLimit: 200, // USD, single payment
@@ -57,9 +78,13 @@ const authorize = (overrides: Record<string, unknown> = {}) =>
 beforeEach(() => {
   jest.clearAllMocks()
   mockCheckoutConfig = { ...CHECKOUT }
+  mockFygaroEnabled = true
+  mockCreditEnabled = true
   mockGetFygaroSettings.mockResolvedValue({ ...SETTINGS })
   mockSumPrior.mockResolvedValue(0)
+  mockSumOutstanding.mockResolvedValue(0)
   mockSaveIntent.mockResolvedValue(true)
+  mockGetFlashFeeDiscountPercent.mockResolvedValue(0)
 })
 
 describe("authorizeFygaroTopup", () => {
@@ -211,14 +236,138 @@ describe("authorizeFygaroTopup", () => {
     expect(res.checkout.url).toContain("?jwt=")
   })
 
-  it("excludes nothing real from the prior-24h sum", async () => {
-    // Nothing has been paid yet, so the exclusion must not match a live row —
-    // an accidental match would under-count the customer's spend.
+  it("asks the trailing-24h sum for the whole window, with nothing excluded", async () => {
+    // Nothing has been paid yet, so there is no row of this request's own to
+    // exclude. The parameter is omitted rather than filled with a sentinel whose
+    // correctness would rest on "this string can never collide with a real id".
     await authorize()
 
-    const [{ excludeTransactionId, accountId }] = mockSumPrior.mock.calls[0]
-    expect(accountId).toBe("acct-1")
-    expect(excludeTransactionId).toContain("acct-1")
-    expect(excludeTransactionId).not.toBe("acct-1")
+    const [args] = mockSumPrior.mock.calls[0]
+    expect(args).toEqual({ accountId: "acct-1" })
+    expect(args.excludeTransactionId).toBeUndefined()
+  })
+
+  describe("yaml master gates", () => {
+    // The first rollout state is checkout ON, credit still OFF (credit.enabled
+    // ships default-false). Minting links in that state charges the card and
+    // records the payment with reason `credit-disabled` — charged and
+    // uncredited, the 2026-08-16 incident reached through the very path that
+    // was supposed to prevent it.
+    it("refuses while fygaro.credit.enabled is off", async () => {
+      mockCreditEnabled = false
+      const res = await authorize()
+
+      expect(res.authorized).toBe(false)
+      expect(res.reason).toBe("checkout-disabled")
+      expect(mockGetFygaroSettings).not.toHaveBeenCalled()
+      expect(mockSaveIntent).not.toHaveBeenCalled()
+    })
+
+    it("refuses while fygaro.enabled is off", async () => {
+      // Worse than credit-off: fygaroEnabledGuard 503s every webhook delivery,
+      // so the payment is not even RECORDED.
+      mockFygaroEnabled = false
+      const res = await authorize()
+
+      expect(res.authorized).toBe(false)
+      expect(res.reason).toBe("checkout-disabled")
+      expect(mockGetFygaroSettings).not.toHaveBeenCalled()
+      expect(mockSaveIntent).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("outstanding authorisations count against the allowance", () => {
+    it("refuses a second full-allowance link while the first is still live", async () => {
+      // Authorisation is not reservation unless live links are subtracted:
+      // otherwise N calls against a $100 allowance each mint a $100 link, and
+      // paying two of them captures $200 while the webhook credits one.
+      mockSumOutstanding.mockResolvedValue(8000)
+      const res = await authorize({ amountCents: 8000 })
+
+      expect(res.authorized).toBe(false)
+      expect(res.reason).toBe("exceeds-daily-allowance")
+      expect(res.remainingAllowanceCents).toBe(2000)
+      expect(mockSaveIntent).not.toHaveBeenCalled()
+    })
+
+    it("counts outstanding links alongside settled charges", async () => {
+      // $30 settled + $30 authorised-but-unpaid = $60 of a $100 allowance.
+      mockSumPrior.mockResolvedValue(3000)
+      mockSumOutstanding.mockResolvedValue(3000)
+      const res = await authorize({ amountCents: 3000 })
+
+      expect(res.authorized).toBe(true)
+      expect(res.remainingAllowanceCents).toBe(1000)
+    })
+
+    it("never treats an unreadable reservation index as nothing outstanding", async () => {
+      // Failing open here is exactly the hole: "no live links" is what lets a
+      // second full-allowance link be minted.
+      mockSumOutstanding.mockResolvedValue(new Error("redis down"))
+      const res = await authorize()
+
+      expect(res.authorized).toBe(false)
+      expect(res.reason).toBe("history-unavailable")
+      expect(mockSaveIntent).not.toHaveBeenCalled()
+    })
+
+    it("rolls the reservation back when a racing request got in between", async () => {
+      // Both requests passed the check, both reserved; the re-read now shows the
+      // combined total, so this one backs out rather than over-issuing.
+      mockSumOutstanding.mockResolvedValueOnce(0).mockResolvedValueOnce(16000)
+      const res = await authorize({ amountCents: 8000 })
+
+      expect(res.authorized).toBe(false)
+      expect(res.reason).toBe("exceeds-daily-allowance")
+      expect(mockReleaseReservation).toHaveBeenCalledWith(
+        expect.objectContaining({ intentId: "intent-fixed", accountId: "acct-1" }),
+      )
+    })
+
+    it("keeps the reservation when the re-read still fits", async () => {
+      mockSumOutstanding.mockResolvedValueOnce(0).mockResolvedValueOnce(8000)
+      const res = await authorize({ amountCents: 8000 })
+
+      expect(res.authorized).toBe(true)
+      expect(mockReleaseReservation).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("one gate function, no drift", () => {
+    it("refuses an above-minimum amount whose fees sink the net to zero", async () => {
+      // The gate the webhook runs has a `non-positive-net` stop. A pre-charge
+      // check that skipped it would authorise this and the webhook would refuse
+      // it: charged, uncredited.
+      mockGetFygaroSettings.mockResolvedValue({
+        ...SETTINGS,
+        processorFeeFixed: 100, // $100 fixed against a $10 top-up
+      })
+      const res = await authorize({ amountCents: 1000 })
+
+      expect(res.authorized).toBe(false)
+      expect(res.reason).toBe("non-positive-net")
+      expect(mockSaveIntent).not.toHaveBeenCalled()
+    })
+
+    it("applies the account's Flash-fee discount to the same net the webhook will compute", async () => {
+      mockGetFlashFeeDiscountPercent.mockResolvedValue(100)
+      const res = await authorize()
+
+      expect(mockGetFlashFeeDiscountPercent).toHaveBeenCalledWith({
+        username: "jaceth2009",
+        flow: "topup",
+      })
+      expect(res.authorized).toBe(true)
+    })
+
+    it("does not read ERPNext history for a stop that precedes it", async () => {
+      // A client can otherwise make us run a list query per rejected amount.
+      const res = await authorize({ amountCents: 50_000 })
+
+      expect(res.authorized).toBe(false)
+      expect(res.reason).toBe("above-single-payment-limit")
+      expect(mockSumPrior).not.toHaveBeenCalled()
+      expect(mockSumOutstanding).not.toHaveBeenCalled()
+    })
   })
 })

--- a/test/flash/unit/app/fygaro/authorize-topup.spec.ts
+++ b/test/flash/unit/app/fygaro/authorize-topup.spec.ts
@@ -4,9 +4,11 @@ import { parseCustomReference } from "@services/fygaro/checkout"
 const mockGetFygaroSettings = jest.fn()
 const mockSumPrior = jest.fn()
 const mockSaveIntent = jest.fn()
-const mockSumOutstanding = jest.fn()
+const mockReadReservations = jest.fn()
+const mockReadIntent = jest.fn()
 const mockReleaseReservation = jest.fn()
 const mockGetFlashFeeDiscountPercent = jest.fn()
+const mockAlertBridge = jest.fn()
 
 jest.mock("@services/fygaro/webhook-server/fygaro-settings", () => ({
   getFygaroSettings: (...args: unknown[]) => mockGetFygaroSettings(...args),
@@ -18,10 +20,19 @@ jest.mock("@services/frappe/fee-discounts", () => ({
   getFlashFeeDiscountPercent: (...args: unknown[]) =>
     mockGetFlashFeeDiscountPercent(...args),
 }))
+jest.mock("@services/alerts", () => ({
+  alertBridge: (...args: unknown[]) => mockAlertBridge(...args),
+  // The REAL key generator: the static-per-reason key selection is exactly what
+  // makes an outage one incident per failing dependency instead of one page per
+  // refused customer (or, before this, zero), so stubbing it would let a
+  // regression pass.
+  generateDedupKey: jest.requireActual("@services/alerts/dedup-key").generateDedupKey,
+}))
 jest.mock("@services/fygaro/checkout-intent-store", () => ({
   newIntentId: () => "intent-fixed",
   saveIntent: (...args: unknown[]) => mockSaveIntent(...args),
-  sumOutstandingAuthorizedCents: (...args: unknown[]) => mockSumOutstanding(...args),
+  readOutstandingReservations: (...args: unknown[]) => mockReadReservations(...args),
+  readIntent: (...args: unknown[]) => mockReadIntent(...args),
   releaseIntentReservation: (...args: unknown[]) => mockReleaseReservation(...args),
 }))
 
@@ -65,15 +76,25 @@ const SETTINGS = {
   dailyTopupLimits: { 1: 100, 2: 500 },
 }
 
+const NOW_MS = 1_700_000_000_000
+
 const authorize = (overrides: Record<string, unknown> = {}) =>
   authorizeFygaroTopup({
     accountId: "acct-1",
     username: "jaceth2009",
     level: AccountLevel.One,
     amountCents: 8000,
-    nowMs: 1_700_000_000_000,
+    nowMs: NOW_MS,
     ...overrides,
   })
+
+// One live, unpaid link the account is holding. `expiresAtMs` is the zset score
+// — the moment the JWT stops being payable and the hold stops counting.
+const hold = (amountCents: number, intentId = "intent-open", expiresInMs = 900_000) => ({
+  intentId,
+  amountCents,
+  expiresAtMs: NOW_MS + expiresInMs,
+})
 
 beforeEach(() => {
   jest.clearAllMocks()
@@ -82,7 +103,8 @@ beforeEach(() => {
   mockCreditEnabled = true
   mockGetFygaroSettings.mockResolvedValue({ ...SETTINGS })
   mockSumPrior.mockResolvedValue(0)
-  mockSumOutstanding.mockResolvedValue(0)
+  mockReadReservations.mockResolvedValue([])
+  mockReadIntent.mockResolvedValue({ found: false })
   mockSaveIntent.mockResolvedValue(true)
   mockGetFlashFeeDiscountPercent.mockResolvedValue(0)
 })
@@ -116,6 +138,16 @@ describe("authorizeFygaroTopup", () => {
       username: intent.username,
       intentId: intent.intentId,
     })
+  })
+
+  it("stores the signed link itself, so an abandoned checkout can be re-offered", async () => {
+    // Without the URL on the record there is no way out of a self-inflicted
+    // hold: the client cannot cancel it and cannot be given it back.
+    const res = await authorize()
+
+    const [{ intent }] = mockSaveIntent.mock.calls[0]
+    expect(intent.checkoutUrl).toBe(res.checkout.url)
+    expect(intent.expiresAtMs).toBe(res.checkout.expiresAt.getTime())
   })
 
   it("reports what is left after the authorised amount, not before it", async () => {
@@ -277,15 +309,14 @@ describe("authorizeFygaroTopup", () => {
   })
 
   describe("outstanding authorisations count against the allowance", () => {
-    it("refuses a second full-allowance link while the first is still live", async () => {
+    it("refuses a second link for a DIFFERENT amount while the first is still live", async () => {
       // Authorisation is not reservation unless live links are subtracted:
       // otherwise N calls against a $100 allowance each mint a $100 link, and
       // paying two of them captures $200 while the webhook credits one.
-      mockSumOutstanding.mockResolvedValue(8000)
-      const res = await authorize({ amountCents: 8000 })
+      mockReadReservations.mockResolvedValue([hold(8000)])
+      const res = await authorize({ amountCents: 5000 })
 
       expect(res.authorized).toBe(false)
-      expect(res.reason).toBe("exceeds-daily-allowance")
       expect(res.remainingAllowanceCents).toBe(2000)
       expect(mockSaveIntent).not.toHaveBeenCalled()
     })
@@ -293,7 +324,7 @@ describe("authorizeFygaroTopup", () => {
     it("counts outstanding links alongside settled charges", async () => {
       // $30 settled + $30 authorised-but-unpaid = $60 of a $100 allowance.
       mockSumPrior.mockResolvedValue(3000)
-      mockSumOutstanding.mockResolvedValue(3000)
+      mockReadReservations.mockResolvedValue([hold(3000)])
       const res = await authorize({ amountCents: 3000 })
 
       expect(res.authorized).toBe(true)
@@ -303,18 +334,22 @@ describe("authorizeFygaroTopup", () => {
     it("never treats an unreadable reservation index as nothing outstanding", async () => {
       // Failing open here is exactly the hole: "no live links" is what lets a
       // second full-allowance link be minted.
-      mockSumOutstanding.mockResolvedValue(new Error("redis down"))
+      mockReadReservations.mockResolvedValue(new Error("redis down"))
       const res = await authorize()
 
       expect(res.authorized).toBe(false)
-      expect(res.reason).toBe("history-unavailable")
+      // NOT `history-unavailable`: that name sends whoever reads the alert to
+      // ERPNext for a fault that is in Redis.
+      expect(res.reason).toBe("reservations-unavailable")
       expect(mockSaveIntent).not.toHaveBeenCalled()
     })
 
     it("rolls the reservation back when a racing request got in between", async () => {
       // Both requests passed the check, both reserved; the re-read now shows the
       // combined total, so this one backs out rather than over-issuing.
-      mockSumOutstanding.mockResolvedValueOnce(0).mockResolvedValueOnce(16000)
+      mockReadReservations
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([hold(8000, "intent-racer"), hold(8000, "intent-fixed")])
       const res = await authorize({ amountCents: 8000 })
 
       expect(res.authorized).toBe(false)
@@ -322,14 +357,161 @@ describe("authorizeFygaroTopup", () => {
       expect(mockReleaseReservation).toHaveBeenCalledWith(
         expect.objectContaining({ intentId: "intent-fixed", accountId: "acct-1" }),
       )
+      // The number reported must come from the RE-READ, minus this request's own
+      // reservation (just released). Reporting the pre-race $100 would hand the
+      // client a bigger number than reality in exactly the case where it is
+      // wrong — it retries the same amount and fails again.
+      expect(res.remainingAllowanceCents).toBe(2000)
     })
 
     it("keeps the reservation when the re-read still fits", async () => {
-      mockSumOutstanding.mockResolvedValueOnce(0).mockResolvedValueOnce(8000)
+      mockReadReservations
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([hold(8000, "intent-fixed")])
       const res = await authorize({ amountCents: 8000 })
 
       expect(res.authorized).toBe(true)
       expect(mockReleaseReservation).not.toHaveBeenCalled()
+    })
+  })
+
+  // The single most common thing a payer does is open a payment page and walk
+  // away from it. Before this, that self-inflicted hold was reported as
+  // "exceeds-daily-allowance" with "$0.00 left" — to an account that had spent
+  // nothing — and there was no way for the client to clear its own hold.
+  describe("an abandoned checkout is not a spent allowance", () => {
+    const OPEN_URL = "https://fygaro.com/en/pb/ABC123?jwt=open.link.signature"
+    const openIntent = (overrides: Record<string, unknown> = {}) => ({
+      found: true,
+      intent: {
+        intentId: "intent-open",
+        accountId: "acct-1",
+        username: "jaceth2009",
+        amountCents: 10000,
+        currency: "USD",
+        createdAtMs: NOW_MS - 60_000,
+        checkoutUrl: OPEN_URL,
+        expiresAtMs: NOW_MS + 840_000,
+        ...overrides,
+      },
+    })
+
+    it("hands the SAME live link back when the customer retries the same amount", async () => {
+      // $100 cap, $0 settled, one live $100 link: the customer is asking for the
+      // link they already have. Refusing them for their own reservation with
+      // "you have $0.00 left" is both false and a dead end.
+      mockReadReservations.mockResolvedValue([hold(10000)])
+      mockReadIntent.mockResolvedValue(openIntent())
+      const res = await authorize({ amountCents: 10000 })
+
+      expect(res.authorized).toBe(true)
+      expect(res.reused).toBe(true)
+      expect(res.checkout.url).toBe(OPEN_URL)
+      // Nothing new is minted or reserved — the outstanding total must not move.
+      expect(mockSaveIntent).not.toHaveBeenCalled()
+      expect(res.remainingAllowanceCents).toBe(0)
+    })
+
+    it("refuses with checkout-already-open, not exceeds-daily-allowance, when it cannot re-offer", async () => {
+      // A different amount: the hold still blocks it, but the account has spent
+      // $0.00 today, so "you have $0.00 left of today's top-up limit" would be a
+      // false statement about a limit it never reached.
+      mockReadReservations.mockResolvedValue([hold(10000)])
+      const res = await authorize({ amountCents: 5000 })
+
+      expect(res.authorized).toBe(false)
+      expect(res.reason).toBe("checkout-already-open")
+      expect(res.holdExpiresAt).toEqual(new Date(NOW_MS + 900_000))
+      expect(res.holdAmountCents).toBe(10000)
+    })
+
+    it("never hands back a link whose record names a different account", async () => {
+      // The id came out of THIS account's reservation index, so a record naming
+      // someone else means the two disagree — and the link is not ours to give.
+      mockReadReservations.mockResolvedValue([hold(10000)])
+      mockReadIntent.mockResolvedValue(openIntent({ accountId: "acct-someone-else" }))
+      const res = await authorize({ amountCents: 10000 })
+
+      expect(res.authorized).toBe(false)
+      expect(res.reason).toBe("checkout-already-open")
+    })
+
+    it("refuses an intent record written before the URL was stored", async () => {
+      // Records already in Redis when this shipped have no checkoutUrl, so they
+      // cannot be re-offered — but the refusal must still be the honest one.
+      mockReadReservations.mockResolvedValue([hold(10000)])
+      mockReadIntent.mockResolvedValue(
+        openIntent({ checkoutUrl: undefined, expiresAtMs: undefined }),
+      )
+      const res = await authorize({ amountCents: 10000 })
+
+      expect(res.authorized).toBe(false)
+      expect(res.reason).toBe("checkout-already-open")
+    })
+
+    it("names the SOONEST hold to lift, since that is when allowance reappears", async () => {
+      mockReadReservations.mockResolvedValue([
+        hold(6000, "intent-late", 800_000),
+        hold(4000, "intent-soon", 120_000),
+      ])
+      const res = await authorize({ amountCents: 5000 })
+
+      expect(res.reason).toBe("checkout-already-open")
+      expect(res.holdExpiresAt).toEqual(new Date(NOW_MS + 120_000))
+      expect(res.holdAmountCents).toBe(4000)
+    })
+
+    it("still says exceeds-daily-allowance when the SETTLED spend is what blocks it", async () => {
+      // $95 already charged today against a $100 cap. The holds are irrelevant:
+      // this account really has spent its allowance, and saying so is correct.
+      mockSumPrior.mockResolvedValue(9500)
+      mockReadReservations.mockResolvedValue([hold(1000)])
+      const res = await authorize({ amountCents: 8000 })
+
+      expect(res.authorized).toBe(false)
+      expect(res.reason).toBe("exceeds-daily-allowance")
+    })
+  })
+
+  // The webhook side pages on both of its transient stops. This side had no
+  // signal at all, so card top-ups could be 100% unavailable for every user
+  // while nothing fired.
+  describe("a broken pre-charge check is an incident, not a silence", () => {
+    it.each([
+      ["settings-unavailable", () => mockGetFygaroSettings.mockResolvedValue(undefined)],
+      [
+        "history-unavailable",
+        () => mockSumPrior.mockResolvedValue(new Error("erpnext down")),
+      ],
+      [
+        "reservations-unavailable",
+        () => mockReadReservations.mockResolvedValue(new Error("redis down")),
+      ],
+    ])("pages once, naming %s, when the check cannot run", async (reason, arrange) => {
+      arrange()
+      const res = await authorize()
+
+      expect(res.authorized).toBe(false)
+      expect(res.reason).toBe(reason)
+      expect(mockAlertBridge).toHaveBeenCalledTimes(1)
+      expect(mockAlertBridge).toHaveBeenCalledWith(
+        expect.objectContaining({
+          severity: "warning",
+          // Static per reason: an outage collapses to ONE incident per failing
+          // dependency rather than one page per refused customer, and Redis
+          // never lands in the same incident as ERPNext.
+          dedupKey: `fygaro:authorize-unavailable:${reason}`,
+          context: expect.objectContaining({ reason }),
+        }),
+      )
+    })
+
+    it("never pages for a refusal the customer caused", async () => {
+      mockSumPrior.mockResolvedValue(9500)
+      const res = await authorize({ amountCents: 8000 })
+
+      expect(res.reason).toBe("exceeds-daily-allowance")
+      expect(mockAlertBridge).not.toHaveBeenCalled()
     })
   })
 
@@ -367,7 +549,7 @@ describe("authorizeFygaroTopup", () => {
       expect(res.authorized).toBe(false)
       expect(res.reason).toBe("above-single-payment-limit")
       expect(mockSumPrior).not.toHaveBeenCalled()
-      expect(mockSumOutstanding).not.toHaveBeenCalled()
+      expect(mockReadReservations).not.toHaveBeenCalled()
     })
   })
 })

--- a/test/flash/unit/app/fygaro/authorize-topup.spec.ts
+++ b/test/flash/unit/app/fygaro/authorize-topup.spec.ts
@@ -1,5 +1,6 @@
 import { AccountLevel } from "@domain/accounts"
 import { parseCustomReference } from "@services/fygaro/checkout"
+import { FygaroReservationWriteError } from "@services/fygaro/errors"
 
 const mockGetFygaroSettings = jest.fn()
 const mockSumPrior = jest.fn()
@@ -257,15 +258,29 @@ describe("authorizeFygaroTopup", () => {
     expect(res.reason).toBe("checkout-disabled")
   })
 
-  it("still authorises when the intent could not be stored", async () => {
-    // The signed amount and the webhook gate both still apply; only our own
-    // after-the-fact cross-check is missing. A Redis blip must not block a
-    // legitimate top-up.
+  it("still authorises when only the cross-check record could not be stored", async () => {
+    // The hold IS in place and the webhook gate still applies; only our own
+    // after-the-fact verification is missing. That must not block a legitimate
+    // top-up.
     mockSaveIntent.mockResolvedValue(new Error("redis down"))
     const res = await authorize()
 
     expect(res.authorized).toBe(true)
     expect(res.checkout.url).toContain("?jwt=")
+  })
+
+  it("refuses — and pages — when the RESERVATION could not be written", async () => {
+    // The read side of the reservation index fails closed. If the write side
+    // failed open, the hold would be invisible to the next request and the same
+    // allowance would be handed out twice: exactly the over-issue the
+    // reservation exists to stop.
+    mockSaveIntent.mockResolvedValue(new FygaroReservationWriteError("READONLY"))
+    const res = await authorize()
+
+    expect(res.authorized).toBe(false)
+    expect(res.reason).toBe("reservations-unavailable")
+    // Card top-ups being 100% unavailable must never be silent.
+    expect(mockAlertBridge).toHaveBeenCalledTimes(1)
   })
 
   it("asks the trailing-24h sum for the whole window, with nothing excluded", async () => {

--- a/test/flash/unit/app/fygaro/authorize-topup.spec.ts
+++ b/test/flash/unit/app/fygaro/authorize-topup.spec.ts
@@ -1,0 +1,224 @@
+import { AccountLevel } from "@domain/accounts"
+import { parseCustomReference } from "@services/fygaro/checkout"
+
+const mockGetFygaroSettings = jest.fn()
+const mockSumPrior = jest.fn()
+const mockSaveIntent = jest.fn()
+
+jest.mock("@services/fygaro/webhook-server/fygaro-settings", () => ({
+  getFygaroSettings: (...args: unknown[]) => mockGetFygaroSettings(...args),
+}))
+jest.mock("@services/frappe/BridgeTransferRequestWriter", () => ({
+  sumFygaroTopupGrossCentsLast24h: (...args: unknown[]) => mockSumPrior(...args),
+}))
+jest.mock("@services/fygaro/checkout-intent-store", () => ({
+  newIntentId: () => "intent-fixed",
+  saveIntent: (...args: unknown[]) => mockSaveIntent(...args),
+}))
+
+const CHECKOUT = {
+  enabled: true,
+  buttonUrl: "https://fygaro.com/en/pb/ABC123",
+  keyId: "key-1",
+  ttlSeconds: 900,
+}
+
+jest.mock("@config", () => ({
+  get FygaroConfig() {
+    return {
+      checkout: mockCheckoutConfig,
+      webhook: { secrets: { "key-1": "shared-secret" } },
+    }
+  },
+}))
+
+let mockCheckoutConfig: typeof CHECKOUT = { ...CHECKOUT }
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { authorizeFygaroTopup } = require("@app/fygaro/authorize-topup")
+
+const SETTINGS = {
+  autoCreditEnabled: true,
+  minimumTopup: 5, // USD
+  autoCreditLimit: 200, // USD, single payment
+  dailyTopupLimits: { 1: 100, 2: 500 },
+}
+
+const authorize = (overrides: Record<string, unknown> = {}) =>
+  authorizeFygaroTopup({
+    accountId: "acct-1",
+    username: "jaceth2009",
+    level: AccountLevel.One,
+    amountCents: 8000,
+    nowMs: 1_700_000_000_000,
+    ...overrides,
+  })
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  mockCheckoutConfig = { ...CHECKOUT }
+  mockGetFygaroSettings.mockResolvedValue({ ...SETTINGS })
+  mockSumPrior.mockResolvedValue(0)
+  mockSaveIntent.mockResolvedValue(true)
+})
+
+describe("authorizeFygaroTopup", () => {
+  it("authorises a clean request and signs the amount into the URL", async () => {
+    const res = await authorize()
+
+    expect(res.authorized).toBe(true)
+    expect(res.checkout.url).toContain("?jwt=")
+    // The editable query parameters are exactly what this change removes.
+    expect(res.checkout.url).not.toContain("amount=")
+    expect(res.checkout.url).not.toContain("custom_reference=")
+  })
+
+  it("stores the intent under the same reference it signed", async () => {
+    const res = await authorize()
+
+    const [{ intent }] = mockSaveIntent.mock.calls[0]
+    expect(intent).toMatchObject({
+      intentId: "intent-fixed",
+      accountId: "acct-1",
+      username: "jaceth2009",
+      amountCents: 8000,
+    })
+    // If these two ever diverge, the webhook cross-check silently stops matching.
+    const signed = JSON.parse(
+      Buffer.from(res.checkout.url.split("?jwt=")[1].split(".")[1], "base64").toString(),
+    )
+    expect(parseCustomReference(signed.custom_reference)).toEqual({
+      username: intent.username,
+      intentId: intent.intentId,
+    })
+  })
+
+  it("reports what is left after the authorised amount, not before it", async () => {
+    // $100 daily limit, $20 already spent, asking for $30 → $50 left after.
+    mockSumPrior.mockResolvedValue(2000)
+    const res = await authorize({ amountCents: 3000 })
+
+    expect(res.authorized).toBe(true)
+    expect(res.remainingAllowanceCents).toBe(5000)
+  })
+
+  it("refuses the amount that would have gone through before this change", async () => {
+    // The 2026-08-16 incident: allowance nearly used up, customer edits the
+    // amount in the webview, gets charged, and the webhook refuses the credit.
+    mockSumPrior.mockResolvedValue(9500)
+    const res = await authorize({ amountCents: 8000 })
+
+    expect(res.authorized).toBe(false)
+    expect(res.reason).toBe("exceeds-daily-allowance")
+    // The client needs the number to say "you can top up $5", not just "no".
+    expect(res.remainingAllowanceCents).toBe(500)
+    expect(res.limitCents).toBe(10000)
+  })
+
+  it("allows spending the allowance down to exactly zero", async () => {
+    mockSumPrior.mockResolvedValue(2000)
+    const res = await authorize({ amountCents: 8000 })
+
+    expect(res.authorized).toBe(true)
+    expect(res.remainingAllowanceCents).toBe(0)
+  })
+
+  it("never authorises when the 24h history cannot be read", async () => {
+    // Coercing an unreadable history to zero would hand every account its full
+    // allowance again for the duration of an ERPNext outage.
+    mockSumPrior.mockResolvedValue(new Error("erpnext down"))
+    const res = await authorize()
+
+    expect(res.authorized).toBe(false)
+    expect(res.reason).toBe("history-unavailable")
+    expect(mockSaveIntent).not.toHaveBeenCalled()
+  })
+
+  it("refuses when settings are unavailable", async () => {
+    mockGetFygaroSettings.mockResolvedValue(undefined)
+    const res = await authorize()
+
+    expect(res.authorized).toBe(false)
+    expect(res.reason).toBe("settings-unavailable")
+  })
+
+  it("refuses when auto-credit is off, rather than creating another stuck top-up", async () => {
+    mockGetFygaroSettings.mockResolvedValue({ ...SETTINGS, autoCreditEnabled: false })
+    const res = await authorize()
+
+    expect(res.authorized).toBe(false)
+    expect(res.reason).toBe("checkout-disabled")
+  })
+
+  it("refuses below the minimum, and says what the minimum is", async () => {
+    const res = await authorize({ amountCents: 400 })
+
+    expect(res.authorized).toBe(false)
+    expect(res.reason).toBe("below-minimum")
+    expect(res.minimumCents).toBe(500)
+  })
+
+  it("refuses above the single-payment auto-credit ceiling", async () => {
+    // Within the daily allowance is not enough: a payment over the single-payment
+    // ceiling is held for manual review, so authorising it would still strand funds.
+    mockGetFygaroSettings.mockResolvedValue({
+      ...SETTINGS,
+      autoCreditLimit: 50,
+      dailyTopupLimits: { 1: 1000 },
+    })
+    const res = await authorize({ amountCents: 8000 })
+
+    expect(res.authorized).toBe(false)
+    expect(res.reason).toBe("above-single-payment-limit")
+    expect(res.limitCents).toBe(5000)
+  })
+
+  it("refuses a level with no configured daily limit", async () => {
+    const res = await authorize({ level: 0 as AccountLevel })
+
+    expect(res.authorized).toBe(false)
+    expect(res.reason).toBe("no-daily-limit-for-level")
+  })
+
+  it("stays disabled until it is switched on", async () => {
+    mockCheckoutConfig = { ...CHECKOUT, enabled: false }
+    const res = await authorize()
+
+    expect(res.authorized).toBe(false)
+    expect(res.reason).toBe("checkout-disabled")
+    // Nothing downstream should be touched while the feature is off.
+    expect(mockGetFygaroSettings).not.toHaveBeenCalled()
+  })
+
+  it("refuses when the configured keyId has no signing secret", async () => {
+    // Signing with a missing secret would produce a token Fygaro rejects, so the
+    // customer would hit a dead end after we told them to pay.
+    mockCheckoutConfig = { ...CHECKOUT, keyId: "key-absent" }
+    const res = await authorize()
+
+    expect(res.authorized).toBe(false)
+    expect(res.reason).toBe("checkout-disabled")
+  })
+
+  it("still authorises when the intent could not be stored", async () => {
+    // The signed amount and the webhook gate both still apply; only our own
+    // after-the-fact cross-check is missing. A Redis blip must not block a
+    // legitimate top-up.
+    mockSaveIntent.mockResolvedValue(new Error("redis down"))
+    const res = await authorize()
+
+    expect(res.authorized).toBe(true)
+    expect(res.checkout.url).toContain("?jwt=")
+  })
+
+  it("excludes nothing real from the prior-24h sum", async () => {
+    // Nothing has been paid yet, so the exclusion must not match a live row —
+    // an accidental match would under-count the customer's spend.
+    await authorize()
+
+    const [{ excludeTransactionId, accountId }] = mockSumPrior.mock.calls[0]
+    expect(accountId).toBe("acct-1")
+    expect(excludeTransactionId).toContain("acct-1")
+    expect(excludeTransactionId).not.toBe("acct-1")
+  })
+})

--- a/test/flash/unit/graphql/public/root/mutation/fygaro-checkout-create.spec.ts
+++ b/test/flash/unit/graphql/public/root/mutation/fygaro-checkout-create.spec.ts
@@ -1,0 +1,216 @@
+// jest.mock calls are hoisted before imports
+
+jest.mock("@app/fygaro/authorize-topup", () => ({
+  authorizeFygaroTopup: (...args: unknown[]) => mockAuthorizeFygaroTopup(...args),
+}))
+
+jest.mock("@services/logger", () => ({
+  baseLogger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}))
+
+const mockAuthorizeFygaroTopup = jest.fn()
+
+import { AccountLevel } from "@domain/accounts"
+import { InputValidationError } from "@graphql/error"
+import FygaroCheckoutCreateMutation from "@graphql/public/root/mutation/fygaro-checkout-create"
+
+const ACCOUNT_ID = "account-001" as AccountId
+const EXPIRES_AT = new Date("2026-08-16T12:15:00Z")
+const CHECKOUT = {
+  url: "https://fygaro.com/en/pb/ABC123?jwt=header.payload.signature",
+  expiresAt: EXPIRES_AT,
+  customReference: "jaceth2009|intent-1",
+}
+
+type CheckoutCreateResult = {
+  errors: Array<{ code?: string; message?: string }>
+  checkout?: { url?: string; expiresAt?: Date; amount?: number }
+  remainingAllowance?: number
+}
+
+const ctx = (overrides: Record<string, unknown> = {}) =>
+  ({
+    domainAccount: {
+      id: ACCOUNT_ID,
+      level: AccountLevel.One,
+      username: "jaceth2009",
+      ...overrides,
+    },
+  }) as unknown as GraphQLPublicContextAuth
+
+const resolve = async (
+  amount: unknown,
+  context: GraphQLPublicContextAuth = ctx(),
+): Promise<CheckoutCreateResult> => {
+  const mutation = FygaroCheckoutCreateMutation as unknown as {
+    resolve: (
+      source: null,
+      args: { input: { amount: unknown } },
+      context: GraphQLPublicContextAuth,
+      info: never,
+    ) => Promise<CheckoutCreateResult>
+  }
+  return mutation.resolve(null, { input: { amount } }, context, {} as never)
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  mockAuthorizeFygaroTopup.mockResolvedValue({
+    authorized: true,
+    checkout: CHECKOUT,
+    remainingAllowanceCents: 2000,
+  })
+})
+
+describe("fygaroCheckoutCreate resolver", () => {
+  it("returns the signed checkout and what is left of today's allowance", async () => {
+    const result = await resolve(8000)
+
+    expect(mockAuthorizeFygaroTopup).toHaveBeenCalledWith({
+      accountId: ACCOUNT_ID,
+      username: "jaceth2009",
+      level: AccountLevel.One,
+      amountCents: 8000,
+    })
+    expect(result.errors).toEqual([])
+    expect(result.checkout).toEqual({
+      url: CHECKOUT.url,
+      expiresAt: EXPIRES_AT,
+      amount: 8000,
+    })
+    expect(result.remainingAllowance).toBe(2000)
+  })
+
+  it("hands expiresAt to the Timestamp scalar as a Date, not a pre-serialised value", async () => {
+    // Timestamp serializes from a Date; passing anything else through here
+    // surfaces as a scalar error at response time, not at resolve time.
+    const result = await resolve(8000)
+
+    expect(result.checkout?.expiresAt).toBeInstanceOf(Date)
+    expect(result.checkout?.expiresAt?.getTime()).toBe(EXPIRES_AT.getTime())
+  })
+
+  it("refuses before authorising when the account has no username", async () => {
+    // custom_reference is how the webhook attributes the payment. Without a
+    // username the payment would arrive unattributable — and the customer would
+    // already have been charged.
+    const result = await resolve(8000, ctx({ username: undefined }))
+
+    expect(mockAuthorizeFygaroTopup).not.toHaveBeenCalled()
+    expect(result.checkout).toBeUndefined()
+    expect(result.errors).toHaveLength(1)
+    expect(result.errors[0].code).toBe("FYGARO_CHECKOUT_DISABLED")
+    expect(result.errors[0].message).toContain("username")
+  })
+
+  it("returns the scalar's validation error without authorising", async () => {
+    // CentAmount hands the resolver an InputValidationError instead of a number
+    // for a negative/oversized amount; it must not reach the authorisation.
+    const result = await resolve(
+      new InputValidationError({ message: "Invalid value for CentAmount" }),
+    )
+
+    expect(mockAuthorizeFygaroTopup).not.toHaveBeenCalled()
+    expect(result.errors).toHaveLength(1)
+    expect(result.checkout).toBeUndefined()
+  })
+
+  it("still reports the remaining allowance on a refusal", async () => {
+    // A bare "no" leaves the client unable to say how much WOULD be accepted,
+    // which is the whole point of deciding before the charge.
+    mockAuthorizeFygaroTopup.mockResolvedValue({
+      authorized: false,
+      reason: "exceeds-daily-allowance",
+      remainingAllowanceCents: 500,
+      limitCents: 10000,
+    })
+
+    const result = await resolve(8000)
+
+    expect(result.checkout).toBeUndefined()
+    expect(result.remainingAllowance).toBe(500)
+    expect(result.errors[0].code).toBe("FYGARO_DAILY_ALLOWANCE_EXCEEDED")
+    expect(result.errors[0].message).toBe("You have $5.00 left of today's top-up limit")
+  })
+
+  it("names the minimum in the below-minimum message", async () => {
+    mockAuthorizeFygaroTopup.mockResolvedValue({
+      authorized: false,
+      reason: "below-minimum",
+      minimumCents: 500,
+    })
+
+    const result = await resolve(400)
+
+    expect(result.errors[0].code).toBe("FYGARO_BELOW_MINIMUM")
+    expect(result.errors[0].message).toBe("The minimum top-up is $5.00")
+  })
+
+  it("names the ceiling in the above-single-payment-limit message", async () => {
+    mockAuthorizeFygaroTopup.mockResolvedValue({
+      authorized: false,
+      reason: "above-single-payment-limit",
+      limitCents: 20000,
+    })
+
+    const result = await resolve(50000)
+
+    expect(result.errors[0].code).toBe("FYGARO_ABOVE_SINGLE_PAYMENT_LIMIT")
+    expect(result.errors[0].message).toBe(
+      "The most you can top up in one payment is $200.00",
+    )
+  })
+
+  it("tells a level with no allowance that it is not eligible, not that we are down", async () => {
+    // A level-0 account has no configured allowance and never will until it
+    // upgrades. Routing it to the two TRANSIENT failures below would tell it to
+    // try again later, forever, and send support chasing a phantom outage.
+    mockAuthorizeFygaroTopup.mockResolvedValue({
+      authorized: false,
+      reason: "no-daily-limit-for-level",
+    })
+
+    const result = await resolve(8000)
+
+    expect(result.errors[0].code).toBe("FYGARO_LEVEL_NOT_ELIGIBLE")
+    expect(result.errors[0].code).not.toBe("FYGARO_ALLOWANCE_UNAVAILABLE")
+    expect(result.errors[0].message).toContain("account level")
+  })
+
+  it.each([["settings-unavailable"], ["history-unavailable"]])(
+    "maps the transient %s to the allowance-unavailable error",
+    async (reason) => {
+      mockAuthorizeFygaroTopup.mockResolvedValue({ authorized: false, reason })
+
+      const result = await resolve(8000)
+
+      expect(result.errors[0].code).toBe("FYGARO_ALLOWANCE_UNAVAILABLE")
+      expect(result.remainingAllowance).toBeUndefined()
+    },
+  )
+
+  it("maps a fee-eaten amount to a too-small message, not a limit or an outage", async () => {
+    mockAuthorizeFygaroTopup.mockResolvedValue({
+      authorized: false,
+      reason: "non-positive-net",
+    })
+
+    const result = await resolve(600)
+
+    expect(result.errors[0].code).toBe("FYGARO_BELOW_MINIMUM")
+    expect(result.errors[0].message).toBe(
+      "That amount is too small to cover the payment fees",
+    )
+  })
+
+  it("maps checkout-disabled to its own code", async () => {
+    mockAuthorizeFygaroTopup.mockResolvedValue({
+      authorized: false,
+      reason: "checkout-disabled",
+    })
+
+    const result = await resolve(8000)
+
+    expect(result.errors[0].code).toBe("FYGARO_CHECKOUT_DISABLED")
+  })
+})

--- a/test/flash/unit/graphql/public/root/mutation/fygaro-checkout-create.spec.ts
+++ b/test/flash/unit/graphql/public/root/mutation/fygaro-checkout-create.spec.ts
@@ -8,9 +8,16 @@ jest.mock("@services/logger", () => ({
   baseLogger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
 }))
 
+jest.mock("@services/rate-limit", () => ({
+  consumeLimiter: (...args: unknown[]) => mockConsumeLimiter(...args),
+}))
+
 const mockAuthorizeFygaroTopup = jest.fn()
+const mockConsumeLimiter = jest.fn()
 
 import { AccountLevel } from "@domain/accounts"
+import { RateLimitConfig } from "@domain/rate-limit"
+import { FygaroCheckoutCreateRateLimiterExceededError } from "@domain/rate-limit/errors"
 import { InputValidationError } from "@graphql/error"
 import FygaroCheckoutCreateMutation from "@graphql/public/root/mutation/fygaro-checkout-create"
 
@@ -55,6 +62,7 @@ const resolve = async (
 
 beforeEach(() => {
   jest.clearAllMocks()
+  mockConsumeLimiter.mockResolvedValue(true)
   mockAuthorizeFygaroTopup.mockResolvedValue({
     authorized: true,
     checkout: CHECKOUT,
@@ -212,5 +220,85 @@ describe("fygaroCheckoutCreate resolver", () => {
     const result = await resolve(8000)
 
     expect(result.errors[0].code).toBe("FYGARO_CHECKOUT_DISABLED")
+  })
+
+  describe("an abandoned link is not a spent allowance", () => {
+    it("says the link is open — never that the allowance is gone", async () => {
+      // The refusal every abandoned checkout produces. Saying "you have $0.00
+      // left of today's top-up limit" to an account that has spent $0.00 today
+      // is a false statement, and it points the customer (and support) at the
+      // wrong thing entirely.
+      mockAuthorizeFygaroTopup.mockResolvedValue({
+        authorized: false,
+        reason: "checkout-already-open",
+        remainingAllowanceCents: 0,
+        limitCents: 12500,
+        holdExpiresAt: new Date(Date.now() + 12 * 60_000),
+        holdAmountCents: 12500,
+      })
+
+      const result = await resolve(12500)
+
+      expect(result.errors[0].code).toBe("FYGARO_CHECKOUT_ALREADY_OPEN")
+      expect(result.errors[0].code).not.toBe("FYGARO_DAILY_ALLOWANCE_EXCEEDED")
+      expect(result.errors[0].message).toContain("$125.00 card top-up link open")
+      // Relative, not a wall-clock time: the server is in UTC and the customer
+      // is not, so "HH:MM" here is a time they cannot act on.
+      expect(result.errors[0].message).toContain("expires in 12 minute(s)")
+      expect(result.errors[0].message).not.toContain("left of today")
+    })
+
+    it("still refuses usefully when the hold's expiry is unknown", async () => {
+      mockAuthorizeFygaroTopup.mockResolvedValue({
+        authorized: false,
+        reason: "checkout-already-open",
+      })
+
+      const result = await resolve(12500)
+
+      expect(result.errors[0].code).toBe("FYGARO_CHECKOUT_ALREADY_OPEN")
+      expect(result.errors[0].message).toContain("already have a card top-up link open")
+    })
+
+    it("maps an unreadable reservation index to the same client-facing outage", async () => {
+      // The Redis-vs-ERPNext distinction exists for the ALERT, not the client.
+      mockAuthorizeFygaroTopup.mockResolvedValue({
+        authorized: false,
+        reason: "reservations-unavailable",
+      })
+
+      const result = await resolve(8000)
+
+      expect(result.errors[0].code).toBe("FYGARO_ALLOWANCE_UNAVAILABLE")
+    })
+  })
+
+  describe("rate limiting", () => {
+    it("consumes the per-account limiter BEFORE authorising", async () => {
+      // Every call that gets past the cheap gates runs an ERPNext list query,
+      // and the two gates a spam client would trip (`under-minimum`,
+      // `non-positive-net`) sit AFTER the history gate — so an unbounded
+      // mutation is unbounded ERPNext load pointed at the exact read whose
+      // failure refuses card top-ups for every user.
+      await resolve(8000)
+
+      expect(mockConsumeLimiter).toHaveBeenCalledWith({
+        rateLimitConfig: RateLimitConfig.fygaroCheckoutCreate,
+        keyToConsume: ACCOUNT_ID,
+      })
+    })
+
+    it("refuses without touching ERPNext once the limiter is spent", async () => {
+      mockConsumeLimiter.mockResolvedValue(
+        new FygaroCheckoutCreateRateLimiterExceededError(),
+      )
+
+      const result = await resolve(1)
+
+      expect(mockAuthorizeFygaroTopup).not.toHaveBeenCalled()
+      expect(result.checkout).toBeUndefined()
+      expect(result.errors).toHaveLength(1)
+      expect(result.errors[0].code).toBe("TOO_MANY_REQUEST")
+    })
   })
 })

--- a/test/flash/unit/graphql/public/root/mutation/fygaro-checkout-create.spec.ts
+++ b/test/flash/unit/graphql/public/root/mutation/fygaro-checkout-create.spec.ts
@@ -17,7 +17,10 @@ const mockConsumeLimiter = jest.fn()
 
 import { AccountLevel } from "@domain/accounts"
 import { RateLimitConfig } from "@domain/rate-limit"
-import { FygaroCheckoutCreateRateLimiterExceededError } from "@domain/rate-limit/errors"
+import {
+  FygaroCheckoutCreateRateLimiterExceededError,
+  UnknownRateLimitServiceError,
+} from "@domain/rate-limit/errors"
 import { InputValidationError } from "@graphql/error"
 import FygaroCheckoutCreateMutation from "@graphql/public/root/mutation/fygaro-checkout-create"
 
@@ -299,6 +302,27 @@ describe("fygaroCheckoutCreate resolver", () => {
       expect(result.checkout).toBeUndefined()
       expect(result.errors).toHaveLength(1)
       expect(result.errors[0].code).toBe("TOO_MANY_REQUEST")
+    })
+
+    it("defers to the authorisation gate when the limiter STORE is down", async () => {
+      // A Redis outage rejects `limiter.consume` with a store error, not a
+      // RateLimiterRes. Reporting that as "too many attempts" would tell every
+      // customer they are rate limited on their first attempt of the day, and
+      // would page nobody — authorizeFygaroTopup, which fails closed on its own
+      // Redis read and alerts, would never be entered. No abuse window opens:
+      // no link can be minted while that same store is unreachable.
+      mockConsumeLimiter.mockResolvedValue(
+        new UnknownRateLimitServiceError("ECONNREFUSED"),
+      )
+      mockAuthorizeFygaroTopup.mockResolvedValue({
+        authorized: false,
+        reason: "reservations-unavailable",
+      })
+
+      const result = await resolve(8000)
+
+      expect(mockAuthorizeFygaroTopup).toHaveBeenCalled()
+      expect(result.errors[0].code).toBe("FYGARO_ALLOWANCE_UNAVAILABLE")
     })
   })
 })

--- a/test/flash/unit/services/frappe/BridgeTransferRequestWriter.spec.ts
+++ b/test/flash/unit/services/frappe/BridgeTransferRequestWriter.spec.ts
@@ -417,6 +417,22 @@ describe("BridgeTransferRequestWriter", () => {
       expect(since.getTime()).toBeLessThanOrEqual(after - dayMs)
     })
 
+    it("omits the exclusion filter entirely when there is no row of its own to skip", async () => {
+      // The pre-charge allowance check runs before any payment exists. Omitting
+      // the parameter is how it says so; a sentinel would make correctness rest
+      // on "this string can never collide with a real request_id".
+      sumSince.mockResolvedValue(2_500)
+
+      const result = await sumFygaroTopupGrossCentsLast24h({
+        accountId: "acct_123" as AccountId,
+      })
+
+      expect(result).toBe(2_500)
+      const args = sumSince.mock.calls[0][0]
+      expect(args.accountId).toBe("acct_123")
+      expect("excludeRequestId" in args).toBe(false)
+    })
+
     it("fails closed with FygaroTopupHistoryQueryError when the ERPNext client is not configured", async () => {
       const erpnext = ErpNext as unknown as {
         sumFygaroTopupGrossCentsSince?: jest.Mock

--- a/test/flash/unit/services/frappe/ErpNext.spec.ts
+++ b/test/flash/unit/services/frappe/ErpNext.spec.ts
@@ -560,6 +560,23 @@ describe("ErpNext.sumFygaroTopupGrossCentsSince", () => {
     ])
   })
 
+  it("drops the request_id filter entirely when no exclusion is given", async () => {
+    // The pre-charge allowance check has no row of its own yet. Sending a
+    // sentinel request_id instead would make the query's correctness depend on
+    // that string never colliding with a real one.
+    mockedAxios.get.mockResolvedValue({ data: { data: [] } })
+
+    await client.sumFygaroTopupGrossCentsSince({
+      accountId: params.accountId,
+      since: params.since,
+    })
+
+    const filters = JSON.parse(mockedAxios.get.mock.calls[0][1].params.filters)
+    expect(filters.some((f: unknown[]) => f[1] === "request_id")).toBe(false)
+    // Every other filter is untouched — the window must not widen.
+    expect(filters).toHaveLength(6)
+  })
+
   it("returns 0 for an empty window", async () => {
     mockedAxios.get.mockResolvedValue({ data: { data: [] } })
 

--- a/test/flash/unit/services/fygaro/checkout-intent-store.spec.ts
+++ b/test/flash/unit/services/fygaro/checkout-intent-store.spec.ts
@@ -29,12 +29,14 @@ jest.mock("@services/logger", () => ({
   baseLogger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
 }))
 
+import { CacheUndefinedError, UnknownCacheServiceError } from "@domain/cache"
+import { baseLogger } from "@services/logger"
 import {
   consumeIntent,
   readIntent,
+  readOutstandingReservations,
   releaseIntentReservation,
   saveIntent,
-  sumOutstandingAuthorizedCents,
 } from "@services/fygaro/checkout-intent-store"
 
 const NOW_MS = 1_700_000_000_000
@@ -47,6 +49,15 @@ const INTENT = {
   amountCents: 8000,
   currency: "USD",
   createdAtMs: NOW_MS,
+}
+
+const sumOutstanding = async () => {
+  const reservations = await readOutstandingReservations({
+    accountId: "acct-1",
+    nowMs: NOW_MS,
+  })
+  if (reservations instanceof Error) return reservations
+  return reservations.reduce((sum, r) => sum + r.amountCents, 0)
 }
 
 beforeEach(() => {
@@ -91,19 +102,45 @@ describe("saveIntent", () => {
   })
 })
 
-describe("sumOutstandingAuthorizedCents", () => {
+describe("readOutstandingReservations", () => {
   it("sums the live authorisations for the account", async () => {
-    mockZrange.mockResolvedValue(["8000:intent-1", "2500:intent-2"])
+    mockZrange.mockResolvedValue([
+      "8000:intent-1",
+      String(NOW_MS + 1000),
+      "2500:intent-2",
+      String(NOW_MS + 2000),
+    ])
+
+    expect(await sumOutstanding()).toBe(10500)
+  })
+
+  it("reports each hold's id and expiry, not just a total", async () => {
+    // A refusal that cannot say WHEN the hold lifts is a dead end, and handing
+    // an abandoned link back needs the intent id it is stored under.
+    mockZrange.mockResolvedValue(["8000:intent-1", String(NOW_MS + 900_000)])
 
     expect(
-      await sumOutstandingAuthorizedCents({ accountId: "acct-1", nowMs: NOW_MS }),
-    ).toBe(10500)
+      await readOutstandingReservations({ accountId: "acct-1", nowMs: NOW_MS }),
+    ).toEqual([
+      { intentId: "intent-1", amountCents: 8000, expiresAtMs: NOW_MS + 900_000 },
+    ])
+  })
+
+  it("reads the scores, or the expiry would be unknowable", async () => {
+    await readOutstandingReservations({ accountId: "acct-1", nowMs: NOW_MS })
+
+    expect(mockZrange).toHaveBeenCalledWith(
+      "fygaro-checkout-intents:acct-1",
+      0,
+      -1,
+      "WITHSCORES",
+    )
   })
 
   it("drops authorisations whose JWT has already expired before summing", async () => {
     // Holding an abandoned, no-longer-payable link against the allowance would
     // lock the customer out for the rest of the window for nothing.
-    await sumOutstandingAuthorizedCents({ accountId: "acct-1", nowMs: NOW_MS })
+    await readOutstandingReservations({ accountId: "acct-1", nowMs: NOW_MS })
 
     expect(mockZremrangebyscore).toHaveBeenCalledWith(
       "fygaro-checkout-intents:acct-1",
@@ -117,7 +154,7 @@ describe("sumOutstandingAuthorizedCents", () => {
     // full-allowance link be minted while the first is still payable.
     mockZrange.mockRejectedValue(new Error("redis down"))
 
-    const result = await sumOutstandingAuthorizedCents({
+    const result = await readOutstandingReservations({
       accountId: "acct-1",
       nowMs: NOW_MS,
     })
@@ -126,11 +163,14 @@ describe("sumOutstandingAuthorizedCents", () => {
   })
 
   it("ignores a member it cannot parse instead of summing NaN", async () => {
-    mockZrange.mockResolvedValue(["garbage", "2500:intent-2"])
+    mockZrange.mockResolvedValue([
+      "garbage",
+      String(NOW_MS + 1000),
+      "2500:intent-2",
+      String(NOW_MS + 2000),
+    ])
 
-    expect(
-      await sumOutstandingAuthorizedCents({ accountId: "acct-1", nowMs: NOW_MS }),
-    ).toBe(2500)
+    expect(await sumOutstanding()).toBe(2500)
   })
 })
 
@@ -151,6 +191,25 @@ describe("readIntent", () => {
     mockCacheGet.mockResolvedValue(new Error("redis down"))
 
     expect(await readIntent("intent-1")).toEqual({ found: false })
+  })
+
+  it("does NOT warn on an ordinary cache miss", async () => {
+    // RedisCacheService.get returns CacheUndefinedError for a plain miss, which
+    // is what EVERY expired, evicted or already-redeemed intent looks like —
+    // including every provider re-delivery after a successful redemption.
+    // Warning on those turns the one line that should mean "Redis is broken"
+    // into routine noise, and an unactionable line stops being read at all.
+    mockCacheGet.mockResolvedValue(new CacheUndefinedError())
+
+    expect(await readIntent("intent-1")).toEqual({ found: false })
+    expect(baseLogger.warn).not.toHaveBeenCalled()
+  })
+
+  it("still warns on a real cache fault", async () => {
+    mockCacheGet.mockResolvedValue(new UnknownCacheServiceError("redis down"))
+
+    expect(await readIntent("intent-1")).toEqual({ found: false })
+    expect(baseLogger.warn).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/test/flash/unit/services/fygaro/checkout-intent-store.spec.ts
+++ b/test/flash/unit/services/fygaro/checkout-intent-store.spec.ts
@@ -1,0 +1,219 @@
+const mockCacheSet = jest.fn()
+const mockCacheGet = jest.fn()
+const mockConsumeCacheKey = jest.fn()
+const mockZadd = jest.fn()
+const mockZrem = jest.fn()
+const mockZrange = jest.fn()
+const mockZremrangebyscore = jest.fn()
+const mockExpire = jest.fn()
+
+jest.mock("@services/cache", () => ({
+  RedisCacheService: () => ({
+    set: (...args: unknown[]) => mockCacheSet(...args),
+    get: (...args: unknown[]) => mockCacheGet(...args),
+  }),
+  consumeCacheKey: (...args: unknown[]) => mockConsumeCacheKey(...args),
+}))
+
+jest.mock("@services/redis", () => ({
+  redis: {
+    zadd: (...args: unknown[]) => mockZadd(...args),
+    zrem: (...args: unknown[]) => mockZrem(...args),
+    zrange: (...args: unknown[]) => mockZrange(...args),
+    zremrangebyscore: (...args: unknown[]) => mockZremrangebyscore(...args),
+    expire: (...args: unknown[]) => mockExpire(...args),
+  },
+}))
+
+jest.mock("@services/logger", () => ({
+  baseLogger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}))
+
+import {
+  consumeIntent,
+  readIntent,
+  releaseIntentReservation,
+  saveIntent,
+  sumOutstandingAuthorizedCents,
+} from "@services/fygaro/checkout-intent-store"
+
+const NOW_MS = 1_700_000_000_000
+const TTL = 900
+
+const INTENT = {
+  intentId: "intent-1",
+  accountId: "acct-1",
+  username: "jaceth2009",
+  amountCents: 8000,
+  currency: "USD",
+  createdAtMs: NOW_MS,
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  mockCacheSet.mockResolvedValue(INTENT)
+  mockCacheGet.mockResolvedValue(INTENT)
+  mockConsumeCacheKey.mockResolvedValue(true)
+  mockZadd.mockResolvedValue(1)
+  mockZrem.mockResolvedValue(1)
+  mockZrange.mockResolvedValue([])
+  mockZremrangebyscore.mockResolvedValue(0)
+  mockExpire.mockResolvedValue(1)
+})
+
+describe("saveIntent", () => {
+  it("stores the record for longer than the JWT so a late payment is still verifiable", async () => {
+    await saveIntent({ intent: INTENT, ttlSeconds: TTL })
+
+    expect(mockCacheSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        key: "fygaro-checkout-intent:intent-1",
+        value: INTENT,
+        ttlSecs: TTL + 3600,
+      }),
+    )
+  })
+
+  it("reserves the amount against the account, scored by when the JWT stops being payable", async () => {
+    await saveIntent({ intent: INTENT, ttlSeconds: TTL })
+
+    expect(mockZadd).toHaveBeenCalledWith(
+      "fygaro-checkout-intents:acct-1",
+      NOW_MS + TTL * 1000,
+      "8000:intent-1",
+    )
+  })
+
+  it("reports a failed reservation write so the caller knows there is no hold", async () => {
+    mockZadd.mockRejectedValue(new Error("redis down"))
+
+    expect(await saveIntent({ intent: INTENT, ttlSeconds: TTL })).toBeInstanceOf(Error)
+  })
+})
+
+describe("sumOutstandingAuthorizedCents", () => {
+  it("sums the live authorisations for the account", async () => {
+    mockZrange.mockResolvedValue(["8000:intent-1", "2500:intent-2"])
+
+    expect(
+      await sumOutstandingAuthorizedCents({ accountId: "acct-1", nowMs: NOW_MS }),
+    ).toBe(10500)
+  })
+
+  it("drops authorisations whose JWT has already expired before summing", async () => {
+    // Holding an abandoned, no-longer-payable link against the allowance would
+    // lock the customer out for the rest of the window for nothing.
+    await sumOutstandingAuthorizedCents({ accountId: "acct-1", nowMs: NOW_MS })
+
+    expect(mockZremrangebyscore).toHaveBeenCalledWith(
+      "fygaro-checkout-intents:acct-1",
+      "-inf",
+      NOW_MS,
+    )
+  })
+
+  it("fails closed rather than reporting nothing outstanding", async () => {
+    // "Nothing outstanding" is exactly the state that lets a second
+    // full-allowance link be minted while the first is still payable.
+    mockZrange.mockRejectedValue(new Error("redis down"))
+
+    const result = await sumOutstandingAuthorizedCents({
+      accountId: "acct-1",
+      nowMs: NOW_MS,
+    })
+
+    expect(result).toBeInstanceOf(Error)
+  })
+
+  it("ignores a member it cannot parse instead of summing NaN", async () => {
+    mockZrange.mockResolvedValue(["garbage", "2500:intent-2"])
+
+    expect(
+      await sumOutstandingAuthorizedCents({ accountId: "acct-1", nowMs: NOW_MS }),
+    ).toBe(2500)
+  })
+})
+
+describe("readIntent", () => {
+  it("does NOT invalidate the intent it read", async () => {
+    // The webhook consults this before it knows whether the delivery ends in a
+    // terminal answer or a 500 asking the provider to retry.
+    const lookup = await readIntent("intent-1")
+
+    expect(lookup).toEqual({ found: true, intent: INTENT })
+    expect(mockConsumeCacheKey).not.toHaveBeenCalled()
+    expect(mockZrem).not.toHaveBeenCalled()
+  })
+
+  it("degrades to found:false on a cache failure rather than blocking a credit", async () => {
+    // Failing the credit on a Redis blip would turn an outage into stuck
+    // customer funds — the outcome this whole workstream exists to avoid.
+    mockCacheGet.mockResolvedValue(new Error("redis down"))
+
+    expect(await readIntent("intent-1")).toEqual({ found: false })
+  })
+})
+
+describe("consumeIntent", () => {
+  it("gates redemption on the atomic DEL, not on a get-then-clear", async () => {
+    // `clear` discards the removed-count and always resolves true, so
+    // get-then-clear is a TOCTOU race in which every concurrent consumer
+    // "succeeds". Only the DEL removed-count picks a single winner.
+    const result = await consumeIntent("intent-1")
+
+    expect(mockConsumeCacheKey).toHaveBeenCalledWith({
+      key: "fygaro-checkout-intent:intent-1",
+    })
+    expect(result).toEqual({ consumed: true })
+  })
+
+  it("reports the loser of a concurrent redemption as not consumed", async () => {
+    mockConsumeCacheKey.mockResolvedValue(false)
+
+    expect(await consumeIntent("intent-1")).toEqual({ consumed: false })
+    // The winner releases the reservation; the loser must not touch it.
+    expect(mockZrem).not.toHaveBeenCalled()
+  })
+
+  it("releases the account's reservation when it wins the claim", async () => {
+    await consumeIntent("intent-1")
+
+    expect(mockZrem).toHaveBeenCalledWith(
+      "fygaro-checkout-intents:acct-1",
+      "8000:intent-1",
+    )
+  })
+
+  it("reports not-consumed when the claim itself errored", async () => {
+    mockConsumeCacheKey.mockResolvedValue(new Error("redis down"))
+
+    expect(await consumeIntent("intent-1")).toEqual({ consumed: false })
+  })
+})
+
+describe("releaseIntentReservation", () => {
+  it("removes only this authorisation's hold", async () => {
+    await releaseIntentReservation({
+      accountId: "acct-1",
+      intentId: "intent-1",
+      amountCents: 8000,
+    })
+
+    expect(mockZrem).toHaveBeenCalledWith(
+      "fygaro-checkout-intents:acct-1",
+      "8000:intent-1",
+    )
+  })
+
+  it("never throws — the hold expires with the JWT anyway", async () => {
+    mockZrem.mockRejectedValue(new Error("redis down"))
+
+    await expect(
+      releaseIntentReservation({
+        accountId: "acct-1",
+        intentId: "intent-1",
+        amountCents: 8000,
+      }),
+    ).resolves.toBeUndefined()
+  })
+})

--- a/test/flash/unit/services/fygaro/checkout.spec.ts
+++ b/test/flash/unit/services/fygaro/checkout.spec.ts
@@ -1,0 +1,190 @@
+import { createHmac } from "crypto"
+
+import {
+  buildCustomReference,
+  buildFygaroCheckout,
+  formatFygaroAmount,
+  parseCustomReference,
+  signFygaroCheckoutJwt,
+} from "@services/fygaro/checkout"
+
+const SECRET = "fygaro-shared-secret"
+const KEY_ID = "key-1"
+const BUTTON = "https://fygaro.com/en/pb/ABC123"
+
+const decodeSegment = (seg: string) =>
+  JSON.parse(Buffer.from(seg.replace(/-/g, "+").replace(/_/g, "/"), "base64").toString())
+
+describe("formatFygaroAmount", () => {
+  it("always renders two decimals", () => {
+    // Fygaro renders the string as-is; "80" or "80.5" are not valid amounts.
+    expect(formatFygaroAmount(8000)).toBe("80.00")
+    expect(formatFygaroAmount(8050)).toBe("80.50")
+    expect(formatFygaroAmount(7552)).toBe("75.52")
+    expect(formatFygaroAmount(1)).toBe("0.01")
+  })
+})
+
+describe("custom_reference round-trip", () => {
+  it("carries the intent id when there is one", () => {
+    expect(buildCustomReference({ username: "jaceth2009", intentId: "abc-123" })).toBe(
+      "jaceth2009|abc-123",
+    )
+    expect(parseCustomReference("jaceth2009|abc-123")).toEqual({
+      username: "jaceth2009",
+      intentId: "abc-123",
+    })
+  })
+
+  it("reads a bare username as legacy, with no intent", () => {
+    // Every app version before signed checkout sends this shape, and will keep
+    // sending it for months. It must stay attributable.
+    expect(buildCustomReference({ username: "jaceth2009" })).toBe("jaceth2009")
+    expect(parseCustomReference("jaceth2009")).toEqual({ username: "jaceth2009" })
+  })
+
+  it("never invents an intent from a malformed reference", () => {
+    // A reference we do not understand must degrade to legacy, never to a
+    // claim that the server authorised something.
+    for (const raw of [
+      "jaceth2009|",
+      "jaceth2009|   ",
+      "jaceth2009|a|b",
+      "jaceth2009||abc",
+    ]) {
+      expect(parseCustomReference(raw)?.intentId).toBeUndefined()
+      expect(parseCustomReference(raw)?.username).toBe("jaceth2009")
+    }
+  })
+
+  it("returns undefined when there is no usable username", () => {
+    for (const raw of ["", "   ", "|abc-123", undefined, null]) {
+      expect(parseCustomReference(raw)).toBeUndefined()
+    }
+  })
+
+  it("trims surrounding whitespace on both halves", () => {
+    expect(parseCustomReference("  jaceth2009 | abc-123  ")).toEqual({
+      username: "jaceth2009",
+      intentId: "abc-123",
+    })
+  })
+})
+
+describe("signFygaroCheckoutJwt", () => {
+  const payload = {
+    amount: "80.00",
+    currency: "USD",
+    custom_reference: "jaceth2009|abc-123",
+    nbf: 1_700_000_000,
+    exp: 1_700_000_900,
+  }
+
+  it("emits the header shape Fygaro documents, including kid", () => {
+    const [header] = signFygaroCheckoutJwt({
+      payload,
+      keyId: KEY_ID,
+      secret: SECRET,
+    }).split(".")
+    expect(decodeSegment(header)).toEqual({ alg: "HS256", typ: "JWT", kid: KEY_ID })
+  })
+
+  it("signs HS256 over base64url(header).base64url(payload)", () => {
+    const token = signFygaroCheckoutJwt({ payload, keyId: KEY_ID, secret: SECRET })
+    const [h, p, sig] = token.split(".")
+    const expected = createHmac("sha256", SECRET)
+      .update(`${h}.${p}`)
+      .digest("base64")
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "")
+    expect(sig).toBe(expected)
+  })
+
+  it("produces base64url with no padding — a padded token is rejected as malformed", () => {
+    const token = signFygaroCheckoutJwt({ payload, keyId: KEY_ID, secret: SECRET })
+    expect(token).not.toContain("=")
+    expect(token).not.toContain("+")
+    expect(token).not.toContain("/")
+    expect(token.split(".")).toHaveLength(3)
+  })
+
+  it("changes signature when the amount changes — the whole point", () => {
+    const a = signFygaroCheckoutJwt({ payload, keyId: KEY_ID, secret: SECRET })
+    const b = signFygaroCheckoutJwt({
+      payload: { ...payload, amount: "800.00" },
+      keyId: KEY_ID,
+      secret: SECRET,
+    })
+    expect(a).not.toBe(b)
+  })
+
+  it("changes signature when custom_reference changes", () => {
+    // custom_reference decides whose wallet is credited; it must be as
+    // tamper-evident as the amount.
+    const a = signFygaroCheckoutJwt({ payload, keyId: KEY_ID, secret: SECRET })
+    const b = signFygaroCheckoutJwt({
+      payload: { ...payload, custom_reference: "someone-else|abc-123" },
+      keyId: KEY_ID,
+      secret: SECRET,
+    })
+    expect(a).not.toBe(b)
+  })
+
+  it("cannot be re-signed with the wrong secret", () => {
+    const a = signFygaroCheckoutJwt({ payload, keyId: KEY_ID, secret: SECRET })
+    const b = signFygaroCheckoutJwt({ payload, keyId: KEY_ID, secret: "other-secret" })
+    expect(a).not.toBe(b)
+  })
+})
+
+describe("buildFygaroCheckout", () => {
+  const args = {
+    buttonUrl: BUTTON,
+    username: "jaceth2009",
+    intentId: "abc-123",
+    amountCents: 8000,
+    currency: "USD",
+    keyId: KEY_ID,
+    secret: SECRET,
+    ttlSeconds: 900,
+    nowMs: 1_700_000_000_000,
+  }
+
+  it("puts every payment parameter inside the token and none in the query", () => {
+    // An `amount=` alongside the jwt would reintroduce the editable value this
+    // change exists to remove.
+    const { url } = buildFygaroCheckout(args)
+    expect(url.startsWith(`${BUTTON}?jwt=`)).toBe(true)
+    expect(url).not.toContain("amount=")
+    expect(url).not.toContain("custom_reference=")
+
+    const payload = decodeSegment(url.split("?jwt=")[1].split(".")[1])
+    expect(payload).toEqual({
+      amount: "80.00",
+      currency: "USD",
+      custom_reference: "jaceth2009|abc-123",
+      nbf: 1_700_000_000,
+      exp: 1_700_000_900,
+    })
+  })
+
+  it("bounds the validity window so a captured URL cannot be paid later", () => {
+    const { expiresAt } = buildFygaroCheckout(args)
+    expect(expiresAt.getTime()).toBe(1_700_000_900_000)
+  })
+
+  it("appends with & when the button URL already has a query string", () => {
+    const { url } = buildFygaroCheckout({ ...args, buttonUrl: `${BUTTON}?lang=en` })
+    expect(url).toContain("?lang=en&jwt=")
+  })
+
+  it("returns the reference it signed, so the intent is stored under the same value", () => {
+    const { customReference } = buildFygaroCheckout(args)
+    expect(customReference).toBe("jaceth2009|abc-123")
+    expect(parseCustomReference(customReference)).toEqual({
+      username: "jaceth2009",
+      intentId: "abc-123",
+    })
+  })
+})

--- a/test/flash/unit/services/fygaro/checkout.spec.ts
+++ b/test/flash/unit/services/fygaro/checkout.spec.ts
@@ -4,6 +4,7 @@ import {
   buildCustomReference,
   buildFygaroCheckout,
   formatFygaroAmount,
+  NBF_SKEW_SECONDS,
   parseCustomReference,
   signFygaroCheckoutJwt,
 } from "@services/fygaro/checkout"
@@ -164,9 +165,23 @@ describe("buildFygaroCheckout", () => {
       amount: "80.00",
       currency: "USD",
       custom_reference: "jaceth2009|abc-123",
-      nbf: 1_700_000_000,
+      nbf: 1_700_000_000 - NBF_SKEW_SECONDS,
       exp: 1_700_000_900,
     })
+  })
+
+  it("backdates nbf so a clock a few seconds ahead does not dead-end the payer", () => {
+    // Fygaro validates the token against THEIR clock. `nbf: now` with zero
+    // leeway means a server running slightly fast mints a link Fygaro rejects
+    // as "not yet valid" — the customer hits a dead end at the payment page.
+    // Flash already tolerates 5 minutes of skew inbound; outbound must not be
+    // stricter. `exp` is what bounds replay, not `nbf`.
+    const payload = decodeSegment(
+      buildFygaroCheckout(args).url.split("?jwt=")[1].split(".")[1],
+    )
+    expect(NBF_SKEW_SECONDS).toBeGreaterThan(0)
+    expect(payload.nbf).toBeLessThan(Math.floor(args.nowMs / 1000))
+    expect(payload.nbf).toBe(Math.floor(args.nowMs / 1000) - NBF_SKEW_SECONDS)
   })
 
   it("bounds the validity window so a captured URL cannot be paid later", () => {

--- a/test/flash/unit/services/fygaro/webhook-server/payment.spec.ts
+++ b/test/flash/unit/services/fygaro/webhook-server/payment.spec.ts
@@ -84,6 +84,14 @@ jest.mock("@services/fygaro/webhook-server/fygaro-settings", () => ({
   getFygaroSettings: (...args: unknown[]) => mockGetFygaroSettings(...args),
 }))
 
+// Redis-backed store for the pre-charge authorisation. Read and redemption are
+// separate calls on purpose (a delivery that will be retried must not burn the
+// intent), so both are mocked and both are asserted on below.
+jest.mock("@services/fygaro/checkout-intent-store", () => ({
+  readIntent: (...args: unknown[]) => mockReadIntent(...args),
+  consumeIntent: (...args: unknown[]) => mockConsumeIntent(...args),
+}))
+
 const mockLockIdempotencyKey = jest.fn()
 const mockLockPaymentIdempotencyKey = jest.fn()
 const mockFindByUsername = jest.fn()
@@ -98,6 +106,8 @@ const mockNotifyOpsEvent = jest.fn()
 const mockCreditFygaroTopup = jest.fn()
 const mockGetFygaroSettings = jest.fn()
 const mockSumFygaroLast24h = jest.fn()
+const mockReadIntent = jest.fn()
+const mockConsumeIntent = jest.fn()
 
 // Canonical operator settings: 2.99% + $0.49 processor, 2.0% Flash margin,
 // $500 auto-credit limit, auto-credit on. For a $10.00 top-up this yields a
@@ -171,6 +181,9 @@ beforeEach(() => {
   mockCompleteFygaroTopup.mockResolvedValue(true)
   mockCreditFygaroTopup.mockResolvedValue({ walletId: WALLET_ID, status: "success" })
   mockGetFygaroSettings.mockResolvedValue({ ...DEFAULT_SETTINGS })
+  // Legacy default: the reference carries no intent, so nothing is looked up.
+  mockReadIntent.mockResolvedValue({ found: false })
+  mockConsumeIntent.mockResolvedValue({ consumed: true })
 })
 
 describe("fygaro paymentHandler", () => {
@@ -968,6 +981,214 @@ describe("fygaro paymentHandler", () => {
         expect.objectContaining({ severity: "warning" }),
       )
       expect(res.json).toHaveBeenCalledWith({ status: "success", credited: true })
+    })
+  })
+
+  // The pre-charge authorisation cross-check. This is the branch that decides
+  // whether a payment we cannot account for gets credited anyway, so every arm
+  // of it is pinned: match, both mismatch shapes, and the legacy fall-through.
+  describe("checkout intent cross-check", () => {
+    const INTENT_ID = "3f5a1c9e-2b7d-4a10-9f33-6c8e2d4b7a51"
+    const SIGNED_BODY = {
+      ...VALID_BODY,
+      customReference: `${VALID_BODY.customReference}|${INTENT_ID}`,
+    }
+    const intent = (overrides: Record<string, unknown> = {}) => ({
+      found: true,
+      intent: {
+        intentId: INTENT_ID,
+        accountId: ACCOUNT_ID as string,
+        username: VALID_BODY.customReference,
+        // $10.00, matching VALID_BODY.amount
+        amountCents: 1000,
+        currency: "USD",
+        createdAtMs: 1_700_000_000_000,
+        ...overrides,
+      },
+    })
+
+    beforeEach(() => {
+      mockFygaroConfig.credit = { enabled: true }
+    })
+
+    it("credits normally when the payment matches what was authorised", async () => {
+      mockReadIntent.mockResolvedValue(intent())
+      const res = makeRes()
+
+      await paymentHandler(makeReq(SIGNED_BODY), res)
+
+      expect(mockReadIntent).toHaveBeenCalledWith(INTENT_ID)
+      // $10.00 gross -> $0.79 processor + $0.20 flash -> $9.01 (901¢) net
+      expect(mockCreditFygaroTopup).toHaveBeenCalledWith(
+        expect.objectContaining({ recipientAccountId: ACCOUNT_ID, amountCents: 901 }),
+      )
+      expect(res.json).toHaveBeenCalledWith({ status: "success", credited: true })
+    })
+
+    it("resolves the account from the username half of a username|intentId reference", async () => {
+      mockReadIntent.mockResolvedValue(intent())
+      const res = makeRes()
+
+      await paymentHandler(makeReq(SIGNED_BODY), res)
+
+      // The whole reference must never reach findByUsername, or a signed
+      // checkout would be unattributable and land in the unattributed alert.
+      expect(mockFindByUsername).toHaveBeenCalledWith(VALID_BODY.customReference)
+      expect(mockWriteFygaroTopup).toHaveBeenCalledWith(
+        expect.objectContaining({ accountId: ACCOUNT_ID }),
+      )
+    })
+
+    it("records-only on an amount mismatch and names both numbers in the alert", async () => {
+      // The amount lives inside the signed JWT, so a mismatch cannot come from
+      // the customer — it means a bug or a replay on our side, and crediting a
+      // payment we cannot account for is the failure this whole change is about.
+      mockReadIntent.mockResolvedValue(intent({ amountCents: 2000 }))
+      const res = makeRes()
+
+      await paymentHandler(makeReq(SIGNED_BODY), res)
+
+      expect(mockCreditFygaroTopup).not.toHaveBeenCalled()
+      expect(mockCompleteFygaroTopup).not.toHaveBeenCalled()
+      expect(mockAlertBridge).toHaveBeenCalledWith(
+        expect.objectContaining({
+          severity: "warning",
+          title:
+            "Fygaro payment does not match the checkout Flash signed for it — not auto-credited",
+          // Without both numbers the alert says a payment was refused but not
+          // what it was refused against — the only thing that tells an operator
+          // whether to credit it by hand.
+          detail: expect.stringContaining("mismatch=authorised 2000c, paid 1000c"),
+          context: expect.objectContaining({
+            reason: "intent-mismatch",
+            intent_mismatch: "authorised 2000c, paid 1000c",
+          }),
+        }),
+      )
+      expect(res.status).toHaveBeenCalledWith(200)
+      expect(res.json).toHaveBeenCalledWith({ status: "recorded", credited: false })
+    })
+
+    it("records-only on an account mismatch and names both accounts in the alert", async () => {
+      mockReadIntent.mockResolvedValue(intent({ accountId: "account-someone-else" }))
+      const res = makeRes()
+
+      await paymentHandler(makeReq(SIGNED_BODY), res)
+
+      expect(mockCreditFygaroTopup).not.toHaveBeenCalled()
+      expect(mockAlertBridge).toHaveBeenCalledWith(
+        expect.objectContaining({
+          context: expect.objectContaining({
+            reason: "intent-mismatch",
+            intent_mismatch: `authorised for account account-someone-else, paid as ${ACCOUNT_ID}`,
+          }),
+        }),
+      )
+      expect(res.json).toHaveBeenCalledWith({ status: "recorded", credited: false })
+    })
+
+    it("overrides an otherwise-clean gate: a mismatch is never credited", async () => {
+      // The gate can only reason about the payment in front of it, not about
+      // whether we ever authorised it, so the mismatch must win outright.
+      mockReadIntent.mockResolvedValue(intent({ amountCents: 999 }))
+      const res = makeRes()
+
+      await paymentHandler(makeReq(SIGNED_BODY), res)
+
+      expect(mockCreditFygaroTopup).not.toHaveBeenCalled()
+      expect(mockNotifyOpsEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          phase: "fygaro-recorded",
+          meta: expect.objectContaining({ reason: "intent-mismatch" }),
+        }),
+      )
+    })
+
+    it("still credits through the legacy path when the intent is missing or expired", async () => {
+      // An intent that expired, was evicted, or was minted by another
+      // deployment is NOT a mismatch: it is the position every pre-signed-
+      // checkout payment is in, and the credit gate still applies in full.
+      // Failing it here would turn a Redis blip into stuck customer funds.
+      mockReadIntent.mockResolvedValue({ found: false })
+      const res = makeRes()
+
+      await paymentHandler(makeReq(SIGNED_BODY), res)
+
+      expect(mockCreditFygaroTopup).toHaveBeenCalledWith(
+        expect.objectContaining({ amountCents: 901 }),
+      )
+      expect(res.json).toHaveBeenCalledWith({ status: "success", credited: true })
+    })
+
+    it("never looks up an intent for a bare legacy reference", async () => {
+      const res = makeRes()
+
+      await paymentHandler(makeReq(VALID_BODY), res)
+
+      expect(mockReadIntent).not.toHaveBeenCalled()
+      expect(mockConsumeIntent).not.toHaveBeenCalled()
+    })
+
+    describe("redemption is terminal-only", () => {
+      it("redeems the authorisation once the credit has actually gone through", async () => {
+        mockReadIntent.mockResolvedValue(intent())
+        const res = makeRes()
+
+        await paymentHandler(makeReq(SIGNED_BODY), res)
+
+        expect(mockConsumeIntent).toHaveBeenCalledWith(INTENT_ID)
+      })
+
+      it("redeems the authorisation on a deterministic record-only ack", async () => {
+        // Nothing will change on retry, so the authorisation is spent and its
+        // hold on the account's daily allowance must be released.
+        mockReadIntent.mockResolvedValue(intent({ amountCents: 2000 }))
+        const res = makeRes()
+
+        await paymentHandler(makeReq(SIGNED_BODY), res)
+
+        expect(mockConsumeIntent).toHaveBeenCalledWith(INTENT_ID)
+      })
+
+      it("does NOT burn the authorisation on a transient 500 that asks for a retry", async () => {
+        // This is the whole reason read and redeem are separate calls. The
+        // retry that eventually credits the payment is the delivery most worth
+        // verifying; consuming here would leave it with nothing to check.
+        mockSumFygaroLast24h.mockResolvedValue(new Error("erpnext down"))
+        mockReadIntent.mockResolvedValue(intent())
+        const res = makeRes()
+
+        await paymentHandler(makeReq(SIGNED_BODY), res)
+
+        expect(res.status).toHaveBeenCalledWith(500)
+        expect(mockConsumeIntent).not.toHaveBeenCalled()
+      })
+
+      it("does NOT burn the authorisation when settings are unavailable", async () => {
+        mockGetFygaroSettings.mockResolvedValue(undefined)
+        mockReadIntent.mockResolvedValue(intent())
+        const res = makeRes()
+
+        await paymentHandler(makeReq(SIGNED_BODY), res)
+
+        expect(res.status).toHaveBeenCalledWith(500)
+        expect(mockConsumeIntent).not.toHaveBeenCalled()
+      })
+
+      it("does NOT burn the authorisation when the credit itself failed", async () => {
+        // That branch acks 200 but is deliberately retryable — a failed send is
+        // not cached, so the next delivery re-attempts the credit.
+        mockReadIntent.mockResolvedValue(intent())
+        mockCreditFygaroTopup.mockResolvedValue(
+          new FygaroCreditError("intraledger-send", "some send error"),
+        )
+        const res = makeRes()
+
+        await paymentHandler(makeReq(SIGNED_BODY), res)
+
+        expect(res.json).toHaveBeenCalledWith({ status: "recorded", credited: false })
+        expect(mockConsumeIntent).not.toHaveBeenCalled()
+      })
     })
   })
 })

--- a/test/flash/unit/services/fygaro/webhook-server/payment.spec.ts
+++ b/test/flash/unit/services/fygaro/webhook-server/payment.spec.ts
@@ -90,6 +90,7 @@ jest.mock("@services/fygaro/webhook-server/fygaro-settings", () => ({
 jest.mock("@services/fygaro/checkout-intent-store", () => ({
   readIntent: (...args: unknown[]) => mockReadIntent(...args),
   consumeIntent: (...args: unknown[]) => mockConsumeIntent(...args),
+  releaseIntentReservation: (...args: unknown[]) => mockReleaseIntentReservation(...args),
 }))
 
 const mockLockIdempotencyKey = jest.fn()
@@ -108,6 +109,7 @@ const mockGetFygaroSettings = jest.fn()
 const mockSumFygaroLast24h = jest.fn()
 const mockReadIntent = jest.fn()
 const mockConsumeIntent = jest.fn()
+const mockReleaseIntentReservation = jest.fn()
 
 // Canonical operator settings: 2.99% + $0.49 processor, 2.0% Flash margin,
 // $500 auto-credit limit, auto-credit on. For a $10.00 top-up this yields a
@@ -184,6 +186,7 @@ beforeEach(() => {
   // Legacy default: the reference carries no intent, so nothing is looked up.
   mockReadIntent.mockResolvedValue({ found: false })
   mockConsumeIntent.mockResolvedValue({ consumed: true })
+  mockReleaseIntentReservation.mockResolvedValue(undefined)
 })
 
 describe("fygaro paymentHandler", () => {
@@ -1188,6 +1191,84 @@ describe("fygaro paymentHandler", () => {
 
         expect(res.json).toHaveBeenCalledWith({ status: "recorded", credited: false })
         expect(mockConsumeIntent).not.toHaveBeenCalled()
+      })
+    })
+
+    // A hold left behind after the payment is already counted in ERPNext is a
+    // DOUBLE count: `sumFygaroTopupGrossCentsSince` includes the Fiat Received
+    // row the handler just wrote, so the same $50 is subtracted from the daily
+    // allowance twice for the rest of the JWT window — refusing the customer's
+    // next legitimate top-up on top of an already-bad event.
+    describe("the hold is released on terminal answers that did not credit", () => {
+      it("releases the reservation — but NOT the record — when the credit failed", async () => {
+        mockReadIntent.mockResolvedValue(intent())
+        mockCreditFygaroTopup.mockResolvedValue(
+          new FygaroCreditError("insufficient-treasury-float", "insufficient balance"),
+        )
+        const res = makeRes()
+
+        await paymentHandler(makeReq(SIGNED_BODY), res)
+
+        expect(mockReleaseIntentReservation).toHaveBeenCalledWith(
+          expect.objectContaining({
+            intentId: INTENT_ID,
+            accountId: ACCOUNT_ID,
+            amountCents: 1000,
+          }),
+        )
+        // The record survives: the manual credit this alert asks for still
+        // needs the cross-check of what was originally authorised, and the
+        // provider retry this branch invites still needs something to verify
+        // against.
+        expect(mockConsumeIntent).not.toHaveBeenCalled()
+        expect(res.json).toHaveBeenCalledWith({ status: "recorded", credited: false })
+      })
+
+      it("releases the reservation when a signed reference no longer resolves to an account", async () => {
+        // Terminal: the dedupe lock is non-releasing, so Fygaro's retries ack
+        // "already_processed" and this delivery is the only one that can let go
+        // of the hold.
+        mockFindByUsername.mockResolvedValue(
+          new CouldNotFindAccountFromUsernameError(VALID_BODY.customReference),
+        )
+        mockReadIntent.mockResolvedValue(intent())
+        const res = makeRes()
+
+        await paymentHandler(makeReq(SIGNED_BODY), res)
+
+        expect(res.json).toHaveBeenCalledWith({ status: "recorded", attributed: false })
+        expect(mockReleaseIntentReservation).toHaveBeenCalledWith(
+          expect.objectContaining({ intentId: INTENT_ID, amountCents: 1000 }),
+        )
+        expect(mockConsumeIntent).not.toHaveBeenCalled()
+      })
+
+      it("does NOT release the hold on a transient 500 that asks for a retry", async () => {
+        // The retry will re-run this handler and reach a terminal answer that
+        // releases it. Letting go early would let a second link be minted
+        // against an allowance this payment has already consumed.
+        mockSumFygaroLast24h.mockResolvedValue(new Error("erpnext down"))
+        mockReadIntent.mockResolvedValue(intent())
+        const res = makeRes()
+
+        await paymentHandler(makeReq(SIGNED_BODY), res)
+
+        expect(res.status).toHaveBeenCalledWith(500)
+        expect(mockReleaseIntentReservation).not.toHaveBeenCalled()
+        expect(mockConsumeIntent).not.toHaveBeenCalled()
+      })
+
+      it("leaves the release to consumeIntent on a successful credit", async () => {
+        // consumeIntent releases the hold itself once it wins the claim, so
+        // releasing here as well would be a second, redundant zrem.
+        mockReadIntent.mockResolvedValue(intent())
+        const res = makeRes()
+
+        await paymentHandler(makeReq(SIGNED_BODY), res)
+
+        expect(res.json).toHaveBeenCalledWith({ status: "success", credited: true })
+        expect(mockConsumeIntent).toHaveBeenCalledWith(INTENT_ID)
+        expect(mockReleaseIntentReservation).not.toHaveBeenCalled()
       })
     })
   })

--- a/test/flash/unit/services/rate-limit/consume-error-classes.spec.ts
+++ b/test/flash/unit/services/rate-limit/consume-error-classes.spec.ts
@@ -1,0 +1,85 @@
+import {
+  RateLimiterExceededError,
+  UnknownRateLimitServiceError,
+} from "@domain/rate-limit/errors"
+import { RateLimiterRes } from "rate-limiter-flexible"
+
+const mockConsume = jest.fn()
+
+jest.mock("rate-limiter-flexible", () => {
+  const actual = jest.requireActual("rate-limiter-flexible")
+  return {
+    ...actual,
+    RateLimiterRedis: jest.fn().mockImplementation(() => ({
+      consume: (...args: unknown[]) => mockConsume(...args),
+      delete: jest.fn(),
+      reward: jest.fn(),
+    })),
+  }
+})
+jest.mock("@services/redis", () => ({ redis: {} }))
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { RedisRateLimitService, consumeLimiter } = require("@services/rate-limit")
+
+const limiter = () =>
+  RedisRateLimitService({
+    keyPrefix: "test_prefix",
+    limitOptions: { points: 3, duration: 60, blockDuration: 300 },
+  })
+
+class TestExceededError extends RateLimiterExceededError {}
+
+beforeEach(() => jest.clearAllMocks())
+
+describe("rate limiter: a store fault is not a limit breach", () => {
+  it("reports a real breach as exceeded", async () => {
+    mockConsume.mockRejectedValue(new RateLimiterRes(0, 60_000, 3, false))
+
+    expect(await limiter().consume("key")).toBeInstanceOf(RateLimiterExceededError)
+  })
+
+  it("reports a Redis outage as a service error, NOT as exceeded", async () => {
+    // With no insuranceLimiter configured, rate-limiter-flexible rejects with
+    // the raw store error. Collapsing that into "exceeded" tells every user
+    // they are rate limited on their first request of the day and hides the
+    // outage from whoever is on call.
+    mockConsume.mockRejectedValue(new Error("MaxRetriesPerRequestError"))
+
+    const res = await limiter().consume("key")
+    expect(res).toBeInstanceOf(UnknownRateLimitServiceError)
+    expect(res).not.toBeInstanceOf(RateLimiterExceededError)
+  })
+
+  it("passes on success", async () => {
+    mockConsume.mockResolvedValue(undefined)
+
+    expect(await limiter().consume("key")).toBe(true)
+  })
+
+  describe("consumeLimiter", () => {
+    const config = {
+      key: "test_prefix",
+      limits: { points: 3, duration: 60, blockDuration: 300 },
+      error: TestExceededError,
+    }
+
+    it("translates a breach into the caller's own error", async () => {
+      mockConsume.mockRejectedValue(new RateLimiterRes(0, 60_000, 3, false))
+
+      expect(
+        await consumeLimiter({ rateLimitConfig: config, keyToConsume: "acct" }),
+      ).toBeInstanceOf(TestExceededError)
+    })
+
+    it("does not disguise a store fault as the caller's rate-limit error", async () => {
+      // The caller has to be able to tell the two apart to decide whether
+      // refusing is the honest answer.
+      mockConsume.mockRejectedValue(new Error("ECONNREFUSED"))
+
+      const res = await consumeLimiter({ rateLimitConfig: config, keyToConsume: "acct" })
+      expect(res).toBeInstanceOf(UnknownRateLimitServiceError)
+      expect(res).not.toBeInstanceOf(TestExceededError)
+    })
+  })
+})


### PR DESCRIPTION
## The incident this fixes

On 2026-08-16 an account with **\$4.48** of daily top-up allowance left paid **\$80** through Fygaro. Fygaro captured the card, the webhook correctly refused the credit, and the customer was left charged and empty-handed until it was credited by hand.

Two things made that possible:

1. **The app built the payment URL on the device**, with `?amount=` and `?custom_reference=` in the query string. Both are editable by the payer in the WebView before they pay — so the amount the app showed and the amount actually charged were never the same value.
2. **The daily limit was only checked in the webhook** — after the card was charged. That is the one moment at which saying "no" costs the customer money instead of nothing.

## What changes

**The decision moves in front of the charge.** A new `fygaroCheckoutCreate` mutation authorises an amount *before* the customer is handed to Fygaro. It does not reimplement the decision: it calls `evaluateCreditGate`, the same function the webhook runs after the charge, so the two answers cannot drift.

**Authorising is a reservation, not just a check.** Live unpaid links are held in a per-account index and subtracted from the allowance, then re-read after reserving so two racing requests both back out rather than both minting. Without this, N calls against a \$100 allowance each mint a \$100 link, and paying two captures \$200 while only one gets credited.

**The amount stops being the customer's to edit.** The returned URL carries every payment parameter inside an HS256 JWT (`?jwt=`) and nothing editable in the query string. `custom_reference` becomes `username|intentId` — still attributable, now also verifiable.

**Abandoning a checkout is not a lockout.** Opening a payment page and walking away is the most common thing a payer does. A retry for the same amount gets *that same link* back rather than a refusal, and a retry for a different amount is told what is being held and when it expires — not "you have \$0.00 left" to an account that has spent nothing.

**The webhook cross-checks what was paid against what we authorised.** A mismatch on amount or account records the payment and refuses the credit, with both numbers in the alert. Holds are released on every terminal non-crediting path, so a treasury-float failure does not leave the payment counted twice.

## Behaviour when a dependency is down

This is the part worth reading before an on-call page.

- **Redis is a hard dependency of *authorising*.** The reservation index fails closed on both read and write: if it is unreachable, `fygaroCheckoutCreate` refuses every request with `FYGARO_ALLOWANCE_UNAVAILABLE` and pages via `fygaro:authorize-unavailable:reservations-unavailable`. Card top-ups are unavailable rather than over-issued. (An earlier version of this description said a Redis failure never blocks a top-up. That was true before the reservation work and is **no longer true** — corrected here so nobody rules Redis out on my say-so.)
- **Redis is *not* a dependency of crediting.** The cross-check record stays fail-open: losing it degrades a payment to the legacy unverified path, where every payment lives today, and never blocks a credit.
- **A rate-limiter store fault is no longer reported as "too many attempts."** `RedisRateLimitService.consume` collapsed every rejection into the exceeded error, so an outage told users they were rate limited on their first attempt and paged nobody. Store faults are now `UnknownRateLimitServiceError`; only a real `RateLimiterRes` breach becomes the caller's rate-limit error. **This is shared infrastructure** — login, invoice create and invite are affected. All of them still refuse on a fault; they just stop misnaming it.
- **Unreadable ERPNext settings or history refuse the authorisation** rather than defaulting to zero prior spend, which would hand every account its full allowance again for the duration of an outage. All three transient refusals alert.

## What deliberately does not change

- **A missing, expired or already-redeemed intent is not a mismatch.** It is the legacy position — unverified — and the existing credit gate still applies in full. Every app version in the wild sends a bare username and must keep working for months.
- **The mutation is `BLOCKED` for API keys**, alongside the cashout and Bridge money-movement mutations: it mints a link that charges a card.

## Rollout

Off by default behind `fygaro.checkout.enabled`, and additionally refuses unless the `fygaro.enabled` and `fygaro.credit.enabled` master gates are both on — otherwise the first rollout state (checkout on, credit still off) would mint links that charge and never credit.

**The JWT link format requires a Fygaro plan that supports it (Pro or above)** — turning this on without the plan breaks checkout rather than degrading, so the plan tier needs confirming before the flag is set.

## Tests

194 suites / 1924 tests green. New coverage includes a direct replay of the incident (\$4.48 left, \$80 requested → refused with the remaining amount reported), the reservation race and rollback, abandoned-link reuse, hold release on each terminal webhook path, both master gates, the webhook cross-check (amount mismatch, account mismatch, matching intent, missing intent), and the rate-limiter fault-vs-breach split.

## Follow-ups (not in this PR)

- Client work to call the mutation, show the remaining allowance, and surface a "received, not yet credited" state.
- Confirming the Fygaro plan tier, and asking Fygaro to enable refund API access so an over-limit capture can be returned automatically rather than by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NEoz7nBtdtsHyuYG5wNPQV