### PR TITLE
feat(fygaro): notify the customer when a card top-up settles

### DIFF
--- a/src/app/bridge/send-deposit-notification.ts
+++ b/src/app/bridge/send-deposit-notification.ts
@@ -1,7 +1,6 @@
 import { BridgeConfig } from "@config"
 
 import {
-  sendOutcomeNotification,
   sendOutcomeNotificationBestEffort,
   type OutcomeNotificationArgs,
 } from "@app/notifications/send-outcome-notification"
@@ -34,10 +33,16 @@ const toOutcomeArgs = ({
   },
 })
 
-export const sendBridgeDepositNotification = async (
-  args: BridgeDepositNotificationArgs,
-): Promise<true | ApplicationError> => sendOutcomeNotification(toOutcomeArgs(args))
-
+/**
+ * The ONLY entry point, and best-effort by construction — same shape as the
+ * Fygaro top-up module.
+ *
+ * There is deliberately no throwing/error-returning variant: the caller is on a
+ * money path where the deposit has already landed, so a notification failure
+ * must never become the deposit's failure. An exported variant returning
+ * `true | ApplicationError` would be dead code inviting exactly the caller this
+ * must not have.
+ */
 export const sendBridgeDepositNotificationBestEffort = async (
   args: BridgeDepositNotificationArgs,
 ): Promise<void> => {

--- a/src/app/bridge/send-deposit-notification.ts
+++ b/src/app/bridge/send-deposit-notification.ts
@@ -1,104 +1,52 @@
-import { BridgeConfig, getI18nInstance } from "@config"
-import { checkedToAccountId } from "@domain/accounts"
-import { getLanguageOrDefault } from "@domain/locale"
-import {
-  DeviceTokensNotRegisteredNotificationsServiceError,
-  FlashNotificationCategories,
-  NotificationsServiceError,
-} from "@domain/notifications"
-import { removeDeviceTokens } from "@app/users/remove-device-tokens"
-import { baseLogger } from "@services/logger"
-import { AccountsRepository } from "@services/mongoose/accounts"
-import { UsersRepository } from "@services/mongoose/users"
-import {
-  PushNotificationsService,
-  SendFilteredPushNotificationStatus,
-} from "@services/notifications/push-notifications"
+import { BridgeConfig } from "@config"
 
-const i18n = getI18nInstance()
+import {
+  sendOutcomeNotification,
+  sendOutcomeNotificationBestEffort,
+  type OutcomeNotificationArgs,
+} from "@app/notifications/send-outcome-notification"
 
 const formatDepositAmount = (amount: string, currency: string): string =>
   `${amount} ${currency.toUpperCase()}`
 
 export type BridgeDepositNotificationOutcome = "received" | "processing" | "completed"
 
-export const sendBridgeDepositNotification = async ({
-  accountId: accountIdRaw,
-  amount,
-  currency,
-  outcome = "completed",
-}: {
+export type BridgeDepositNotificationArgs = {
   accountId: string
   amount: string
   currency: string
   outcome?: BridgeDepositNotificationOutcome
-}): Promise<true | ApplicationError> => {
-  const accountId = checkedToAccountId(accountIdRaw)
-  if (accountId instanceof Error) return accountId
-
-  const account = await AccountsRepository().findById(accountId)
-  if (account instanceof Error) return account
-
-  const user = await UsersRepository().findById(account.kratosUserId)
-  if (user instanceof Error) return user
-
-  const locale = getLanguageOrDefault(user.language)
-  const formattedAmount = formatDepositAmount(amount, currency)
-  const phraseBase = `notification.bridgeDeposit.${outcome}`
-
-  const title = i18n.__({ phrase: `${phraseBase}.title`, locale })
-  const body = i18n.__(
-    { phrase: `${phraseBase}.body`, locale },
-    { amount: formattedAmount },
-  )
-
-  const result = await PushNotificationsService().sendFilteredNotification({
-    deviceTokens: user.deviceTokens,
-    title,
-    body,
-    notificationCategory: FlashNotificationCategories.Payments,
-    notificationSettings: account.notificationSettings,
-    data: {
-      type: `bridge_deposit_${outcome}`,
-      amount,
-      currency: currency == "usdt" ? "USD" : currency.toUpperCase(),
-    },
-  })
-
-  if (result instanceof NotificationsServiceError) return result
-
-  if (result.status === SendFilteredPushNotificationStatus.Filtered) {
-    return true
-  }
-
-  return true
 }
 
+const toOutcomeArgs = ({
+  accountId,
+  amount,
+  currency,
+  outcome = "completed",
+}: BridgeDepositNotificationArgs): OutcomeNotificationArgs => ({
+  accountId,
+  phraseBase: `notification.bridgeDeposit.${outcome}`,
+  dataType: `bridge_deposit_${outcome}`,
+  amountArg: formatDepositAmount(amount, currency),
+  extraData: {
+    amount,
+    currency: currency == "usdt" ? "USD" : currency.toUpperCase(),
+  },
+})
+
+export const sendBridgeDepositNotification = async (
+  args: BridgeDepositNotificationArgs,
+): Promise<true | ApplicationError> => sendOutcomeNotification(toOutcomeArgs(args))
+
 export const sendBridgeDepositNotificationBestEffort = async (
-  args: Parameters<typeof sendBridgeDepositNotification>[0],
+  args: BridgeDepositNotificationArgs,
 ): Promise<void> => {
   // ENG-466: never push a Bridge deposit notification when the feature is off.
   if (!BridgeConfig.enabled) return
-  const result = await sendBridgeDepositNotification(args)
 
-  if (result instanceof DeviceTokensNotRegisteredNotificationsServiceError) {
-    const accountId = checkedToAccountId(args.accountId)
-    if (accountId instanceof Error) return
-
-    const account = await AccountsRepository().findById(accountId)
-    if (account instanceof Error) return
-
-    await removeDeviceTokens({
-      userId: account.kratosUserId,
-      deviceTokens: result.tokens,
-    })
-    return
-  }
-
-  if (result instanceof Error) {
-    baseLogger.warn(
-      { accountId: args.accountId, outcome: args.outcome ?? "completed", error: result },
-      "Failed to send Bridge deposit push notification",
-    )
-  }
+  return sendOutcomeNotificationBestEffort({
+    ...toOutcomeArgs(args),
+    logMessage: "Failed to send Bridge deposit push notification",
+    logContext: { accountId: args.accountId, outcome: args.outcome ?? "completed" },
+  })
 }

--- a/src/app/fygaro/send-topup-notification.ts
+++ b/src/app/fygaro/send-topup-notification.ts
@@ -19,7 +19,20 @@ import {
  * not credited, who is otherwise left watching a screen that said we would be
  * in touch.
  */
-export type FygaroTopupNotificationOutcome = "credited" | "heldForReview"
+export type FygaroTopupNotificationOutcome =
+  | "credited"
+  // The send is in flight — IBEX reporting IN_FLIGHT is the vendor's own
+  // documented 200, so this is an ordinary outcome, not an edge case. Too weak
+  // for the `credited` copy ("has been added to your wallet"), which would send
+  // the customer to a balance that has not moved; but silence here leaves the
+  // very customer this feature exists for with nothing at all.
+  //
+  // Its copy deliberately promises NO follow-up message. Nothing re-notifies
+  // when an in-flight send settles asynchronously, so "we'll let you know when
+  // it lands" would be exactly the unkeepable promise this PR was written to
+  // retire.
+  | "crediting"
+  | "heldForReview"
 
 export type FygaroTopupNotificationArgs = {
   accountId: string

--- a/src/app/fygaro/send-topup-notification.ts
+++ b/src/app/fygaro/send-topup-notification.ts
@@ -12,11 +12,11 @@ import {
  * transient webhook paths deliberately 500 so Fygaro retries, which can take
  * minutes. Without this, that sentence is a promise nothing keeps.
  *
- * BOTH terminal outcomes notify, and that is deliberate. Sending only on
- * success would keep the promise exactly when it costs nothing and break it in
- * the case that actually matters — the customer whose money was captured and
- * not credited, who is otherwise left watching a screen that said we would be
- * in touch.
+ * EVERY outcome notifies — the two terminal ones and the in-flight one — and
+ * that is deliberate. Sending only on success would keep the promise exactly
+ * when it costs nothing and break it in the case that actually matters — the
+ * customer whose money was captured and not credited, who is otherwise left
+ * watching a screen that said we would be in touch.
  */
 export type FygaroTopupNotificationOutcome =
   | "credited"
@@ -36,9 +36,11 @@ export type FygaroTopupNotificationOutcome =
 export type FygaroTopupNotificationArgs = {
   accountId: string
   outcome: FygaroTopupNotificationOutcome
-  // The NET credited for `credited`, the gross captured for `heldForReview` —
-  // in both cases the number the customer would recognise as "the amount this
-  // is about".
+  // The NET for `credited` and `crediting` (what landed, or is on its way to
+  // landing, in the wallet); the GROSS captured for `heldForReview` (what their
+  // card statement shows, since nothing has been credited to net against). In
+  // every case the number the customer would recognise as "the amount this is
+  // about".
   amountCents: number
   // The currency the payment was actually captured in, NOT an assumption. The
   // `heldForReview` push fires on refusals that include `non-usd`, so hardcoding

--- a/src/app/fygaro/send-topup-notification.ts
+++ b/src/app/fygaro/send-topup-notification.ts
@@ -1,5 +1,4 @@
 import {
-  sendOutcomeNotification,
   sendOutcomeNotificationBestEffort,
   type OutcomeNotificationArgs,
 } from "@app/notifications/send-outcome-notification"
@@ -52,6 +51,24 @@ export type FygaroTopupNotificationArgs = {
 // ISO code, so one convention covers every currency without a per-symbol table.
 const formatMajorUnits = (amountCents: number): string => (amountCents / 100).toFixed(2)
 
+/**
+ * The `data.type` the mobile app switches on. Spelled out per outcome rather
+ * than interpolated from it, because the two vocabularies differ: outcomes are
+ * camelCase TypeScript identifiers, wire types are snake_case
+ * (`bridge_deposit_completed`, `bridge_deposit_processing`). Deriving one from
+ * the other shipped `fygaro_topup_heldForReview` — a snake prefix welded to a
+ * camel suffix — into a cross-repo contract where correcting it later costs a
+ * coordinated release with flash-mobile.
+ *
+ * Exhaustive by TYPE: a new outcome without an entry here is a compile error,
+ * not a push whose casing is silently wrong.
+ */
+const DATA_TYPE_BY_OUTCOME: Record<FygaroTopupNotificationOutcome, string> = {
+  credited: "fygaro_topup_credited",
+  crediting: "fygaro_topup_crediting",
+  heldForReview: "fygaro_topup_held_for_review",
+}
+
 const toOutcomeArgs = ({
   accountId,
   outcome,
@@ -60,7 +77,7 @@ const toOutcomeArgs = ({
 }: FygaroTopupNotificationArgs): OutcomeNotificationArgs => ({
   accountId,
   phraseBase: `notification.fygaroTopup.${outcome}`,
-  dataType: `fygaro_topup_${outcome}`,
+  dataType: DATA_TYPE_BY_OUTCOME[outcome],
   amountArg: `${formatMajorUnits(amountCents)} ${currency}`,
   extraData: {
     // MAJOR units, matching `data.amount` on the Bridge deposit push. Sending
@@ -71,10 +88,15 @@ const toOutcomeArgs = ({
   },
 })
 
-export const sendFygaroTopupNotification = async (
-  args: FygaroTopupNotificationArgs,
-): Promise<true | ApplicationError> => sendOutcomeNotification(toOutcomeArgs(args))
-
+/**
+ * The ONLY entry point, and best-effort by construction.
+ *
+ * There is deliberately no throwing/error-returning variant: every caller is on
+ * a money path where the payment has already been captured, so a notification
+ * failure must never become the payment's failure. An exported variant that
+ * returns `true | ApplicationError` would be dead code inviting exactly the
+ * caller this must not have.
+ */
 export const sendFygaroTopupNotificationBestEffort = async (
   args: FygaroTopupNotificationArgs,
 ): Promise<void> =>

--- a/src/app/fygaro/send-topup-notification.ts
+++ b/src/app/fygaro/send-topup-notification.ts
@@ -1,21 +1,8 @@
-import { getI18nInstance } from "@config"
-import { checkedToAccountId } from "@domain/accounts"
-import { getLanguageOrDefault } from "@domain/locale"
 import {
-  DeviceTokensNotRegisteredNotificationsServiceError,
-  FlashNotificationCategories,
-  NotificationsServiceError,
-} from "@domain/notifications"
-import { removeDeviceTokens } from "@app/users/remove-device-tokens"
-import { baseLogger } from "@services/logger"
-import { AccountsRepository } from "@services/mongoose/accounts"
-import { UsersRepository } from "@services/mongoose/users"
-import {
-  PushNotificationsService,
-  SendFilteredPushNotificationStatus,
-} from "@services/notifications/push-notifications"
-
-const i18n = getI18nInstance()
+  sendOutcomeNotification,
+  sendOutcomeNotificationBestEffort,
+  type OutcomeNotificationArgs,
+} from "@app/notifications/send-outcome-notification"
 
 /**
  * Tell the customer how their card top-up ended.
@@ -34,94 +21,52 @@ const i18n = getI18nInstance()
  */
 export type FygaroTopupNotificationOutcome = "credited" | "heldForReview"
 
-const formatUsd = (cents: number): string => `$${(cents / 100).toFixed(2)}`
-
-export const sendFygaroTopupNotification = async ({
-  accountId: accountIdRaw,
-  outcome,
-  amountCents,
-}: {
+export type FygaroTopupNotificationArgs = {
   accountId: string
   outcome: FygaroTopupNotificationOutcome
   // The NET credited for `credited`, the gross captured for `heldForReview` —
   // in both cases the number the customer would recognise as "the amount this
   // is about".
   amountCents: number
-}): Promise<true | ApplicationError> => {
-  const accountId = checkedToAccountId(accountIdRaw)
-  if (accountId instanceof Error) return accountId
-
-  const account = await AccountsRepository().findById(accountId)
-  if (account instanceof Error) return account
-
-  const user = await UsersRepository().findById(account.kratosUserId)
-  if (user instanceof Error) return user
-
-  const locale = getLanguageOrDefault(user.language)
-  const phraseBase = `notification.fygaroTopup.${outcome}`
-
-  const title = i18n.__({ phrase: `${phraseBase}.title`, locale })
-  const body = i18n.__(
-    { phrase: `${phraseBase}.body`, locale },
-    { amount: formatUsd(amountCents) },
-  )
-
-  const result = await PushNotificationsService().sendFilteredNotification({
-    deviceTokens: user.deviceTokens,
-    title,
-    body,
-    notificationCategory: FlashNotificationCategories.Payments,
-    notificationSettings: account.notificationSettings,
-    data: {
-      type: `fygaro_topup_${outcome}`,
-      amount: String(amountCents),
-      currency: "USD",
-    },
-  })
-
-  if (result instanceof NotificationsServiceError) return result
-
-  if (result.status === SendFilteredPushNotificationStatus.Filtered) {
-    return true
-  }
-
-  return true
+  // The currency the payment was actually captured in, NOT an assumption. The
+  // `heldForReview` push fires on refusals that include `non-usd`, so hardcoding
+  // USD here rendered a J$6,000 payment as "$6000.00" — a ~150x overstatement in
+  // the one message whose whole point is telling the customer what we hold.
+  currency: string
 }
 
-/**
- * Fire-and-forget wrapper for the webhook, which must never fail a credit over
- * a notification.
- *
- * The money has already moved by the time this runs. A push that cannot be
- * delivered is a worse experience, not a worse outcome, and turning it into an
- * error would put a delivered credit back into Fygaro's retry loop.
- */
+// Matches the Bridge deposit push (`formatDepositAmount`): major units plus the
+// ISO code, so one convention covers every currency without a per-symbol table.
+const formatMajorUnits = (amountCents: number): string => (amountCents / 100).toFixed(2)
+
+const toOutcomeArgs = ({
+  accountId,
+  outcome,
+  amountCents,
+  currency,
+}: FygaroTopupNotificationArgs): OutcomeNotificationArgs => ({
+  accountId,
+  phraseBase: `notification.fygaroTopup.${outcome}`,
+  dataType: `fygaro_topup_${outcome}`,
+  amountArg: `${formatMajorUnits(amountCents)} ${currency}`,
+  extraData: {
+    // MAJOR units, matching `data.amount` on the Bridge deposit push. Sending
+    // cents under this key would render a $56.52 credit as $5,652 in any mobile
+    // handler that treats `amount` the way every other Payments push does.
+    amount: formatMajorUnits(amountCents),
+    currency,
+  },
+})
+
+export const sendFygaroTopupNotification = async (
+  args: FygaroTopupNotificationArgs,
+): Promise<true | ApplicationError> => sendOutcomeNotification(toOutcomeArgs(args))
+
 export const sendFygaroTopupNotificationBestEffort = async (
-  args: Parameters<typeof sendFygaroTopupNotification>[0],
-): Promise<void> => {
-  const result = await sendFygaroTopupNotification(args)
-
-  if (result instanceof DeviceTokensNotRegisteredNotificationsServiceError) {
-    // Stale tokens from a reinstalled or handed-on device. Prune them, exactly
-    // as the Bridge deposit path does, so the next notification is not sent
-    // into the same void.
-    const accountId = checkedToAccountId(args.accountId)
-    if (accountId instanceof Error) return
-
-    const account = await AccountsRepository().findById(accountId)
-    if (account instanceof Error) return
-
-    await removeDeviceTokens({
-      userId: account.kratosUserId,
-      deviceTokens: result.tokens,
-    })
-    return
-  }
-
-  if (result instanceof Error) {
-    baseLogger.warn(
-      { accountId: args.accountId, outcome: args.outcome, error: result },
-      "Failed to send Fygaro top-up push notification",
-    )
-  }
-}
+  args: FygaroTopupNotificationArgs,
+): Promise<void> =>
+  sendOutcomeNotificationBestEffort({
+    ...toOutcomeArgs(args),
+    logMessage: "Failed to send Fygaro top-up push notification",
+    logContext: { accountId: args.accountId, outcome: args.outcome },
+  })

--- a/src/app/fygaro/send-topup-notification.ts
+++ b/src/app/fygaro/send-topup-notification.ts
@@ -1,0 +1,127 @@
+import { getI18nInstance } from "@config"
+import { checkedToAccountId } from "@domain/accounts"
+import { getLanguageOrDefault } from "@domain/locale"
+import {
+  DeviceTokensNotRegisteredNotificationsServiceError,
+  FlashNotificationCategories,
+  NotificationsServiceError,
+} from "@domain/notifications"
+import { removeDeviceTokens } from "@app/users/remove-device-tokens"
+import { baseLogger } from "@services/logger"
+import { AccountsRepository } from "@services/mongoose/accounts"
+import { UsersRepository } from "@services/mongoose/users"
+import {
+  PushNotificationsService,
+  SendFilteredPushNotificationStatus,
+} from "@services/notifications/push-notifications"
+
+const i18n = getI18nInstance()
+
+/**
+ * Tell the customer how their card top-up ended.
+ *
+ * This exists to make an app promise true. After a payment the app now says
+ * "We've received your payment and are crediting your wallet — we'll let you
+ * know as soon as it lands", because a credit can outlive the screen: the
+ * transient webhook paths deliberately 500 so Fygaro retries, which can take
+ * minutes. Without this, that sentence is a promise nothing keeps.
+ *
+ * BOTH terminal outcomes notify, and that is deliberate. Sending only on
+ * success would keep the promise exactly when it costs nothing and break it in
+ * the case that actually matters — the customer whose money was captured and
+ * not credited, who is otherwise left watching a screen that said we would be
+ * in touch.
+ */
+export type FygaroTopupNotificationOutcome = "credited" | "heldForReview"
+
+const formatUsd = (cents: number): string => `$${(cents / 100).toFixed(2)}`
+
+export const sendFygaroTopupNotification = async ({
+  accountId: accountIdRaw,
+  outcome,
+  amountCents,
+}: {
+  accountId: string
+  outcome: FygaroTopupNotificationOutcome
+  // The NET credited for `credited`, the gross captured for `heldForReview` —
+  // in both cases the number the customer would recognise as "the amount this
+  // is about".
+  amountCents: number
+}): Promise<true | ApplicationError> => {
+  const accountId = checkedToAccountId(accountIdRaw)
+  if (accountId instanceof Error) return accountId
+
+  const account = await AccountsRepository().findById(accountId)
+  if (account instanceof Error) return account
+
+  const user = await UsersRepository().findById(account.kratosUserId)
+  if (user instanceof Error) return user
+
+  const locale = getLanguageOrDefault(user.language)
+  const phraseBase = `notification.fygaroTopup.${outcome}`
+
+  const title = i18n.__({ phrase: `${phraseBase}.title`, locale })
+  const body = i18n.__(
+    { phrase: `${phraseBase}.body`, locale },
+    { amount: formatUsd(amountCents) },
+  )
+
+  const result = await PushNotificationsService().sendFilteredNotification({
+    deviceTokens: user.deviceTokens,
+    title,
+    body,
+    notificationCategory: FlashNotificationCategories.Payments,
+    notificationSettings: account.notificationSettings,
+    data: {
+      type: `fygaro_topup_${outcome}`,
+      amount: String(amountCents),
+      currency: "USD",
+    },
+  })
+
+  if (result instanceof NotificationsServiceError) return result
+
+  if (result.status === SendFilteredPushNotificationStatus.Filtered) {
+    return true
+  }
+
+  return true
+}
+
+/**
+ * Fire-and-forget wrapper for the webhook, which must never fail a credit over
+ * a notification.
+ *
+ * The money has already moved by the time this runs. A push that cannot be
+ * delivered is a worse experience, not a worse outcome, and turning it into an
+ * error would put a delivered credit back into Fygaro's retry loop.
+ */
+export const sendFygaroTopupNotificationBestEffort = async (
+  args: Parameters<typeof sendFygaroTopupNotification>[0],
+): Promise<void> => {
+  const result = await sendFygaroTopupNotification(args)
+
+  if (result instanceof DeviceTokensNotRegisteredNotificationsServiceError) {
+    // Stale tokens from a reinstalled or handed-on device. Prune them, exactly
+    // as the Bridge deposit path does, so the next notification is not sent
+    // into the same void.
+    const accountId = checkedToAccountId(args.accountId)
+    if (accountId instanceof Error) return
+
+    const account = await AccountsRepository().findById(accountId)
+    if (account instanceof Error) return
+
+    await removeDeviceTokens({
+      userId: account.kratosUserId,
+      deviceTokens: result.tokens,
+    })
+    return
+  }
+
+  if (result instanceof Error) {
+    baseLogger.warn(
+      { accountId: args.accountId, outcome: args.outcome, error: result },
+      "Failed to send Fygaro top-up push notification",
+    )
+  }
+}

--- a/src/app/notifications/send-outcome-notification.ts
+++ b/src/app/notifications/send-outcome-notification.ts
@@ -94,6 +94,27 @@ export const sendOutcomeNotificationBestEffort = async ({
   logMessage: string
   logContext: Record<string, unknown>
 }): Promise<void> => {
+  try {
+    await sendOutcomeNotificationOrPrune({ logMessage, logContext, ...args })
+  } catch (error) {
+    // "Best effort" has to be a property of THIS function, not of today's
+    // callees. Its caller awaits it on the money path and relies on it never
+    // throwing — a guarantee that otherwise holds only because every repository
+    // in the chain currently returns errors rather than raising them. One
+    // future `throw` anywhere below would turn a delivered credit into a 500
+    // and hand it back to the provider's retry loop.
+    baseLogger.warn({ ...logContext, error }, logMessage)
+  }
+}
+
+const sendOutcomeNotificationOrPrune = async ({
+  logMessage,
+  logContext,
+  ...args
+}: OutcomeNotificationArgs & {
+  logMessage: string
+  logContext: Record<string, unknown>
+}): Promise<void> => {
   const result = await sendOutcomeNotification(args)
 
   if (result instanceof DeviceTokensNotRegisteredNotificationsServiceError) {

--- a/src/app/notifications/send-outcome-notification.ts
+++ b/src/app/notifications/send-outcome-notification.ts
@@ -1,0 +1,118 @@
+import { getI18nInstance } from "@config"
+import { checkedToAccountId } from "@domain/accounts"
+import { getLanguageOrDefault } from "@domain/locale"
+import {
+  DeviceTokensNotRegisteredNotificationsServiceError,
+  FlashNotificationCategories,
+  NotificationsServiceError,
+} from "@domain/notifications"
+import { removeDeviceTokens } from "@app/users/remove-device-tokens"
+import { baseLogger } from "@services/logger"
+import { AccountsRepository } from "@services/mongoose/accounts"
+import { UsersRepository } from "@services/mongoose/users"
+import { PushNotificationsService } from "@services/notifications/push-notifications"
+
+const i18n = getI18nInstance()
+
+/**
+ * The shared body behind every "here is how your money movement ended" push
+ * (Bridge deposits, Fygaro card top-ups, and whatever comes next).
+ *
+ * Each of those flows differs only in its i18n key prefix, its `data.type`, and
+ * how it formats the amount — the account/user lookup, locale resolution, send,
+ * and stale-token pruning are identical. They used to be copied per flow, which
+ * meant a fix to token pruning or locale handling had to be made in every copy
+ * and whoever made it in one would not know about the others.
+ */
+export type OutcomeNotificationArgs = {
+  accountId: string
+  // i18n key prefix: `${phraseBase}.title` and `${phraseBase}.body` must exist
+  // in every shipped locale.
+  phraseBase: string
+  // The `type` the mobile app switches on to route/render the push.
+  dataType: string
+  // Already display-formatted, interpolated into `${phraseBase}.body` as
+  // {{amount}}. Formatting stays with the caller because each flow knows what
+  // its number means (gross vs net, which currency).
+  amountArg: string
+  // Merged into the FCM `data` payload alongside `type`. Keys are conventional
+  // across flows: `amount` is MAJOR units ("56.52"), `currency` an ISO code.
+  extraData?: Record<string, string>
+}
+
+export const sendOutcomeNotification = async ({
+  accountId: accountIdRaw,
+  phraseBase,
+  dataType,
+  amountArg,
+  extraData,
+}: OutcomeNotificationArgs): Promise<true | ApplicationError> => {
+  const accountId = checkedToAccountId(accountIdRaw)
+  if (accountId instanceof Error) return accountId
+
+  const account = await AccountsRepository().findById(accountId)
+  if (account instanceof Error) return account
+
+  const user = await UsersRepository().findById(account.kratosUserId)
+  if (user instanceof Error) return user
+
+  const locale = getLanguageOrDefault(user.language)
+
+  const title = i18n.__({ phrase: `${phraseBase}.title`, locale })
+  const body = i18n.__({ phrase: `${phraseBase}.body`, locale }, { amount: amountArg })
+
+  const result = await PushNotificationsService().sendFilteredNotification({
+    deviceTokens: user.deviceTokens,
+    title,
+    body,
+    notificationCategory: FlashNotificationCategories.Payments,
+    notificationSettings: account.notificationSettings,
+    data: {
+      type: dataType,
+      ...extraData,
+    },
+  })
+
+  if (result instanceof NotificationsServiceError) return result
+
+  return true
+}
+
+/**
+ * Fire-and-forget wrapper for callers on a money path, which must never fail a
+ * settled payment over a notification.
+ *
+ * The money has already moved by the time this runs. A push that cannot be
+ * delivered is a worse experience, not a worse outcome, and turning it into an
+ * error would put a delivered credit back into the provider's retry loop.
+ */
+export const sendOutcomeNotificationBestEffort = async ({
+  logMessage,
+  logContext,
+  ...args
+}: OutcomeNotificationArgs & {
+  logMessage: string
+  logContext: Record<string, unknown>
+}): Promise<void> => {
+  const result = await sendOutcomeNotification(args)
+
+  if (result instanceof DeviceTokensNotRegisteredNotificationsServiceError) {
+    // Stale tokens from a reinstalled or handed-on device. Prune them so the
+    // next notification is not sent into the same void.
+    const accountId = checkedToAccountId(args.accountId)
+    if (accountId instanceof Error) return
+
+    const account = await AccountsRepository().findById(accountId)
+    if (account instanceof Error) return
+
+    await removeDeviceTokens({
+      userId: account.kratosUserId,
+      deviceTokens: result.tokens,
+    })
+    return
+  }
+
+  if (result instanceof Error) {
+    baseLogger.warn({ ...logContext, error: result }, logMessage)
+  }
+}

--- a/src/app/notifications/send-outcome-notification.ts
+++ b/src/app/notifications/send-outcome-notification.ts
@@ -40,7 +40,14 @@ export type OutcomeNotificationArgs = {
   extraData?: Record<string, string>
 }
 
-export const sendOutcomeNotification = async ({
+/**
+ * Deliberately NOT exported. Every caller of this module is on a money path
+ * where the payment has already been captured, so a notification failure must
+ * never become the payment's failure — which is what an error-returning variant
+ * in reach of a caller eventually becomes. `sendOutcomeNotificationBestEffort`
+ * is the module's only entry point; this stays private to it.
+ */
+const sendOutcomeNotification = async ({
   accountId: accountIdRaw,
   phraseBase,
   dataType,

--- a/src/config/locales/en.json
+++ b/src/config/locales/en.json
@@ -129,6 +129,10 @@
       "heldForReview": {
         "title": "Top-up needs a moment",
         "body": "We have your {{amount}} payment and are completing it manually. We'll let you know when it lands."
+      },
+      "crediting": {
+        "title": "Top-up on its way",
+        "body": "We're crediting {{amount}} to your wallet now. It should appear shortly."
       }
     }
   }

--- a/src/config/locales/en.json
+++ b/src/config/locales/en.json
@@ -128,7 +128,7 @@
       },
       "heldForReview": {
         "title": "Top-up needs a moment",
-        "body": "We have your {{amount}} payment and are completing it manually. We'll let you know when it lands."
+        "body": "We have your {{amount}} payment and are completing it manually."
       },
       "crediting": {
         "title": "Top-up on its way",

--- a/src/config/locales/en.json
+++ b/src/config/locales/en.json
@@ -120,6 +120,16 @@
         "title": "Welcome reward received",
         "body": "US${{amount}} was credited to your wallet for joining through an invite."
       }
+    },
+    "fygaroTopup": {
+      "credited": {
+        "title": "Top-up complete",
+        "body": "{{amount}} has been added to your wallet."
+      },
+      "heldForReview": {
+        "title": "Top-up needs a moment",
+        "body": "We have your {{amount}} payment and are completing it manually. We'll let you know when it lands."
+      }
     }
   }
 }

--- a/src/config/locales/es.json
+++ b/src/config/locales/es.json
@@ -116,6 +116,16 @@
         "title": "Recompensa de bienvenida",
         "body": "Se acreditaron US${{amount}} a tu billetera por unirte con una invitación."
       }
+    },
+    "fygaroTopup": {
+      "credited": {
+        "title": "Recarga completada",
+        "body": "{{amount}} se ha añadido a tu billetera."
+      },
+      "heldForReview": {
+        "title": "Tu recarga necesita un momento",
+        "body": "Tenemos tu pago de {{amount}} y lo estamos completando manualmente. Te avisaremos cuando se acredite."
+      }
     }
   }
 }

--- a/src/config/locales/es.json
+++ b/src/config/locales/es.json
@@ -124,7 +124,7 @@
       },
       "heldForReview": {
         "title": "Tu recarga necesita un momento",
-        "body": "Tenemos tu pago de {{amount}} y lo estamos completando manualmente. Te avisaremos cuando se acredite."
+        "body": "Tenemos tu pago de {{amount}} y lo estamos completando manualmente."
       },
       "crediting": {
         "title": "Tu recarga está en camino",

--- a/src/config/locales/es.json
+++ b/src/config/locales/es.json
@@ -125,6 +125,10 @@
       "heldForReview": {
         "title": "Tu recarga necesita un momento",
         "body": "Tenemos tu pago de {{amount}} y lo estamos completando manualmente. Te avisaremos cuando se acredite."
+      },
+      "crediting": {
+        "title": "Tu recarga está en camino",
+        "body": "Estamos acreditando {{amount}} a tu billetera. Debería aparecer en breve."
       }
     }
   }

--- a/src/services/alerts/dedup-key.ts
+++ b/src/services/alerts/dedup-key.ts
@@ -61,6 +61,13 @@ export const generateDedupKey = {
   // incident as an ERPNext one and get triaged as the wrong system.
   fygaroAuthorizeUnavailable: (reason: string) =>
     `fygaro:authorize-unavailable:${reason}`,
+  // The fygaro-webhook workload booted without a usable Firebase messaging
+  // client, so every top-up push is a SILENT no-op (push-notifications.ts
+  // returns `true` when `messaging` is null). Static: this is one broken
+  // deployment, not a per-payment anomaly, and it must page once rather than
+  // per webhook. Fires at boot, so the feature is never quietly dead for a
+  // whole release because a secret mount regressed in a chart bump.
+  fygaroPushUnavailable: () => "fygaro:push-unavailable",
 }
 
 export const normalizeDedupKey = (key: string): string =>

--- a/src/services/fygaro/webhook-server/index.ts
+++ b/src/services/fygaro/webhook-server/index.ts
@@ -11,7 +11,9 @@ import express from "express"
 import rateLimitMiddleware from "express-rate-limit"
 
 import { FygaroConfig } from "@config"
+import { alertBridge, generateDedupKey } from "@services/alerts"
 import { baseLogger } from "@services/logger"
+import { messaging } from "@services/notifications/firebase"
 
 import { verifyFygaroSignature } from "./middleware/verify-signature"
 import { fygaroEnabledGuard } from "./middleware/enabled-guard"
@@ -66,6 +68,26 @@ export const startFygaroWebhookServer = () => {
     baseLogger.warn(
       "No Fygaro webhook secrets configured (fygaro.webhook.secrets) — /payment will reject all requests with 401",
     )
+  }
+
+  // Top-up pushes fail SILENTLY without Firebase: firebase.ts leaves `messaging`
+  // null when GOOGLE_APPLICATION_CREDENTIALS is unset or the credential fails to
+  // load, and push-notifications.ts then returns `true` anyway (its own
+  // "FIXME: should return an error?"). Every layer above — including the
+  // best-effort wrapper on the money path — reads that as a delivered push, so
+  // a regressed secret mount in a chart bump would leave this whole feature dead
+  // in prod with no signal but one boot-time warn nobody watches. Page instead.
+  // Static dedup key: one broken deployment, one incident.
+  if (!messaging) {
+    alertBridge({
+      dedupKey: generateDedupKey.fygaroPushUnavailable(),
+      source: "fygaro-webhook",
+      severity: "critical",
+      title:
+        "Fygaro webhook: Firebase messaging unavailable — top-up notifications will silently no-op",
+      detail:
+        "GOOGLE_APPLICATION_CREDENTIALS is unset or the credential failed to load in this workload; every customer top-up push is a no-op that reports success.",
+    })
   }
 
   // Start server

--- a/src/services/fygaro/webhook-server/index.ts
+++ b/src/services/fygaro/webhook-server/index.ts
@@ -78,7 +78,16 @@ export const startFygaroWebhookServer = () => {
   // a regressed secret mount in a chart bump would leave this whole feature dead
   // in prod with no signal but one boot-time warn nobody watches. Page instead.
   // Static dedup key: one broken deployment, one incident.
-  if (!messaging) {
+  //
+  // Gated on `credit.enabled` because that flag decides whether ANY push is
+  // reachable from this server. It defaults to false and is the very first
+  // rollout state; with credit off the gate answers `credit-disabled`, which
+  // REFUSAL_NOTIFIES_CUSTOMER deliberately keeps silent, and the credit path is
+  // never entered — so there is nothing for a missing credential to break.
+  // Paging anyway would fire a CRITICAL, on every pod restart and rolling
+  // deploy, with no auto-resolve, about a feature that is switched off by
+  // design.
+  if (FygaroConfig.credit?.enabled && !messaging) {
     alertBridge({
       dedupKey: generateDedupKey.fygaroPushUnavailable(),
       source: "fygaro-webhook",

--- a/src/services/fygaro/webhook-server/routes/payment.ts
+++ b/src/services/fygaro/webhook-server/routes/payment.ts
@@ -36,6 +36,17 @@ import {
 } from "@services/frappe/BridgeTransferRequestWriter"
 import { alertBridge, generateDedupKey } from "@services/alerts"
 import { notifyOpsEvent } from "@services/alerts/ops-events"
+// FCM from the fygaro-webhook workload. Nothing reachable from this server
+// pushed before, and a missing GOOGLE_APPLICATION_CREDENTIALS fails SILENTLY —
+// firebase.ts leaves `messaging` null, push-notifications.ts returns `true`
+// anyway, and the only signal is one boot-time warn nobody watches. Verified
+// wired for this workload, not inherited from the api pod: lnflash/charts
+// `charts/flash/templates/fygaro-webhook-deployment.yaml` sets
+// GOOGLE_APPLICATION_CREDENTIALS and mounts the galoyapp-firebase-serviceaccount
+// secret under `.Values.galoy.api.firebaseNotifications.enabled` (chart >= 3.2.54;
+// deployments pins 3.2.63), and lnflash/deployments
+// `tf-modules/flash/flash-values.tmpl.yaml` sets that flag true for test + prod.
+// Any new workload that imports this must be checked the same way.
 import { sendFygaroTopupNotificationBestEffort } from "@app/fygaro/send-topup-notification"
 
 import {
@@ -160,12 +171,6 @@ const REFUSAL_NOTIFIES_CUSTOMER: Record<RecordOnlyReason, boolean> = {
   "daily-limit-exceeded": true,
   "under-minimum": true,
 }
-
-const NOTIFIABLE_REFUSALS: ReadonlySet<RecordOnlyReason> = new Set(
-  (Object.keys(REFUSAL_NOTIFIES_CUSTOMER) as RecordOnlyReason[]).filter(
-    (reason) => REFUSAL_NOTIFIES_CUSTOMER[reason],
-  ),
-)
 
 export const paymentHandler = async (req: Request, res: Response) => {
   const payload = (req.body ?? {}) as FygaroPaymentPayload
@@ -621,9 +626,9 @@ export const paymentHandler = async (req: Request, res: Response) => {
       // for the person whose payment was captured and not credited — who is
       // otherwise left on a screen that said we would be in touch. Only for the
       // reasons where a human really does finish the payment by hand
-      // (NOTIFIABLE_REFUSALS above); the rest would be promising something that
-      // is not going to happen.
-      if (NOTIFIABLE_REFUSALS.has(gate.reason)) {
+      // (REFUSAL_NOTIFIES_CUSTOMER above); the rest would be promising something
+      // that is not going to happen.
+      if (REFUSAL_NOTIFIES_CUSTOMER[gate.reason]) {
         await sendFygaroTopupNotificationBestEffort({
           accountId,
           outcome: "heldForReview",
@@ -797,14 +802,26 @@ export const paymentHandler = async (req: Request, res: Response) => {
         // refusing the customer's next top-up with `daily-limit-exceeded`.
         // Costs the push nothing: `consumeIntent` reports failure by return
         // value, never a throw, so it cannot skip what follows it.
-        await sendFygaroTopupNotificationBestEffort({
-          accountId: creditAccountId,
-          outcome: "credited",
-          // NET: what actually landed in the wallet. Naming the gross would
-          // overstate the balance change by the fees.
-          amountCents: fees.netCents,
-          currency,
-        })
+        //
+        // ONLY on `success`. `creditFygaroTopup` also returns `pending`, whose
+        // own comment reads "money has PROBABLY left the treasury: report
+        // credited, never re-pay" — a deliberately weaker claim than "N USD has
+        // been added to your wallet", which is what this copy asserts. Pushing
+        // it on `pending` sends the customer to a balance that has not moved
+        // yet, i.e. manufactures the support ticket this notification exists to
+        // prevent. The pending case stays visible to ops through `creditStatus`
+        // on the feed line above; telling the customer about it needs its own
+        // phrase, not this one overloaded.
+        if (creditResult.status === "success") {
+          await sendFygaroTopupNotificationBestEffort({
+            accountId: creditAccountId,
+            outcome: "credited",
+            // NET: what actually landed in the wallet. Naming the gross would
+            // overstate the balance change by the fees.
+            amountCents: fees.netCents,
+            currency,
+          })
+        }
 
         return { code: 200, body: { status: "success", credited: true } }
       },

--- a/src/services/fygaro/webhook-server/routes/payment.ts
+++ b/src/services/fygaro/webhook-server/routes/payment.ts
@@ -812,16 +812,18 @@ export const paymentHandler = async (req: Request, res: Response) => {
         // prevent. The pending case stays visible to ops through `creditStatus`
         // on the feed line above; telling the customer about it needs its own
         // phrase, not this one overloaded.
-        if (creditResult.status === "success") {
-          await sendFygaroTopupNotificationBestEffort({
-            accountId: creditAccountId,
-            outcome: "credited",
-            // NET: what actually landed in the wallet. Naming the gross would
-            // overstate the balance change by the fees.
-            amountCents: fees.netCents,
-            currency,
-          })
-        }
+        await sendFygaroTopupNotificationBestEffort({
+          accountId: creditAccountId,
+          // `pending` gets its OWN phrase rather than the credited one or
+          // nothing at all. IBEX reporting IN_FLIGHT is the vendor's documented
+          // 200, so this is a routine outcome — and leaving it silent stranded
+          // exactly the customer this notification exists for.
+          outcome: creditResult.status === "success" ? "credited" : "crediting",
+          // NET: what actually landed in the wallet (or is on its way to it).
+          // Naming the gross would overstate the balance change by the fees.
+          amountCents: fees.netCents,
+          currency,
+        })
 
         return { code: 200, body: { status: "success", credited: true } }
       },

--- a/src/services/fygaro/webhook-server/routes/payment.ts
+++ b/src/services/fygaro/webhook-server/routes/payment.ts
@@ -36,6 +36,7 @@ import {
 } from "@services/frappe/BridgeTransferRequestWriter"
 import { alertBridge, generateDedupKey } from "@services/alerts"
 import { notifyOpsEvent } from "@services/alerts/ops-events"
+import { sendFygaroTopupNotificationBestEffort } from "@app/fygaro/send-topup-notification"
 
 import {
   creditFygaroTopup,
@@ -571,6 +572,20 @@ export const paymentHandler = async (req: Request, res: Response) => {
       // Terminal: this reason will not change on retry, so the authorisation is
       // spent and its hold on the daily allowance must be released.
       await redeemIntent()
+      // Notify on the REFUSAL too. Telling the customer only when the money
+      // arrives keeps the promise exactly when it costs nothing and breaks it
+      // for the person whose payment was captured and not credited — who is
+      // otherwise left on a screen that said we would be in touch.
+      // `credit-disabled` is the silent deploy-level master gate: it records
+      // without crediting by design, and pushing for it would notify every
+      // customer during a rollout.
+      if (accountId && gate.reason !== "credit-disabled") {
+        await sendFygaroTopupNotificationBestEffort({
+          accountId,
+          outcome: "heldForReview",
+          amountCents: grossCents,
+        })
+      }
       return res.status(200).json({ status: "recorded", credited: false })
     }
 
@@ -682,6 +697,22 @@ export const paymentHandler = async (req: Request, res: Response) => {
             context: { transaction_id: transactionId },
           })
         }
+
+        // The app told this customer "we'll let you know as soon as it lands".
+        // A credit can outlive the screen — the transient paths deliberately
+        // 500 so Fygaro retries — so this is what makes that sentence true.
+        // Best-effort by construction: the money has already moved, and a
+        // failed push must never put a delivered credit back into the retry
+        // loop.
+        // Awaited, matching the Bridge deposit path: the helper swallows every
+        // failure internally, so awaiting cannot fail the credit, and NOT
+        // awaiting would leave a dangling promise that a recycled pod can drop
+        // — losing exactly the notification the app told the customer to expect.
+        await sendFygaroTopupNotificationBestEffort({
+          accountId: creditAccountId,
+          outcome: "credited",
+          amountCents: fees.netCents,
+        })
 
         notifyOpsEvent({
           flow: "deposit",

--- a/src/services/fygaro/webhook-server/routes/payment.ts
+++ b/src/services/fygaro/webhook-server/routes/payment.ts
@@ -38,16 +38,21 @@ import { alertBridge, generateDedupKey } from "@services/alerts"
 import { notifyOpsEvent } from "@services/alerts/ops-events"
 // FCM from the fygaro-webhook workload. Nothing reachable from this server
 // pushed before, and a missing GOOGLE_APPLICATION_CREDENTIALS fails SILENTLY —
-// firebase.ts leaves `messaging` null, push-notifications.ts returns `true`
-// anyway, and the only signal is one boot-time warn nobody watches. Verified
-// wired for this workload, not inherited from the api pod: lnflash/charts
+// firebase.ts leaves `messaging` null and push-notifications.ts returns `true`
+// anyway, so nothing here can tell a delivered push from a discarded one. The
+// server's boot path now pages a critical on that (see `if (!messaging)` in
+// ../index.ts), which is the only place it CAN be detected. Verified wired for
+// this workload, not inherited from the api pod: lnflash/charts
 // `charts/flash/templates/fygaro-webhook-deployment.yaml` sets
 // GOOGLE_APPLICATION_CREDENTIALS and mounts the galoyapp-firebase-serviceaccount
 // secret under `.Values.galoy.api.firebaseNotifications.enabled` (chart >= 3.2.54;
 // deployments pins 3.2.63), and lnflash/deployments
 // `tf-modules/flash/flash-values.tmpl.yaml` sets that flag true for test + prod.
 // Any new workload that imports this must be checked the same way.
-import { sendFygaroTopupNotificationBestEffort } from "@app/fygaro/send-topup-notification"
+import {
+  sendFygaroTopupNotificationBestEffort,
+  type FygaroTopupNotificationOutcome,
+} from "@app/fygaro/send-topup-notification"
 
 import {
   creditFygaroTopup,
@@ -170,6 +175,36 @@ const REFUSAL_NOTIFIES_CUSTOMER: Record<RecordOnlyReason, boolean> = {
   "no-daily-limit-for-level": true,
   "daily-limit-exceeded": true,
   "under-minimum": true,
+}
+
+// Read off `creditFygaroTopup` itself rather than restated as a literal union:
+// a restated one stays "complete" when the source grows a status, and the only
+// thing left to catch it would be an out-of-range index — which this repo
+// compiles with `noImplicitAny: false` and therefore does not report.
+type FygaroCreditStatus = Exclude<
+  Awaited<ReturnType<typeof creditFygaroTopup>>,
+  FygaroCreditError
+>["status"]
+
+/**
+ * Which push a successful credit path earns, keyed by what the send actually
+ * reported.
+ *
+ * A Record rather than a ternary, for the same reason REFUSAL_NOTIFIES_CUSTOMER
+ * above is one: the difference between "N USD has been added to your wallet"
+ * and "we're crediting it now" is a claim about the customer's balance, and a
+ * ternary hands every future status the fallback arm silently. Add a status to
+ * `creditFygaroTopup` and this object is missing a key — a compile error, not a
+ * customer told their money landed when it did not.
+ */
+const OUTCOME_BY_CREDIT_STATUS: Record<
+  FygaroCreditStatus,
+  FygaroTopupNotificationOutcome
+> = {
+  success: "credited",
+  // IBEX reporting IN_FLIGHT is the vendor's documented 200, so this is a
+  // routine outcome — too weak for the credited copy, too real for silence.
+  pending: "crediting",
 }
 
 export const paymentHandler = async (req: Request, res: Response) => {
@@ -628,7 +663,22 @@ export const paymentHandler = async (req: Request, res: Response) => {
       // reasons where a human really does finish the payment by hand
       // (REFUSAL_NOTIFIES_CUSTOMER above); the rest would be promising something
       // that is not going to happen.
-      if (REFUSAL_NOTIFIES_CUSTOMER[gate.reason]) {
+      //
+      // ...and only for a SERVER-VERIFIED reference. `authorizedIntent` is set
+      // only when the reference carries an intentId that Flash itself minted
+      // and signed for this account and this amount (see readIntent above; a
+      // mismatch on either lands as `intent-mismatch`, which this allowlist
+      // refuses anyway). On the legacy unsigned clients still in the wild,
+      // `customReference` is free text the PAYER types — so without this gate
+      // anyone could pay J$1, or $2 against the $10 minimum, with a stranger's
+      // username on it and have the bank's own app tell that stranger we are
+      // holding a payment of theirs. That is a ready-made pretext for a
+      // follow-up scam call, and it costs the attacker a dollar. The `credited`
+      // push is not gated the same way because abusing it means paying the
+      // victim real money, which makes it self-defeating; a refusal push has no
+      // such offsetting cost. Legacy clients simply keep the pre-PR behaviour
+      // (ops alert only, no push) until they are out of the wild.
+      if (authorizedIntent && REFUSAL_NOTIFIES_CUSTOMER[gate.reason]) {
         await sendFygaroTopupNotificationBestEffort({
           accountId,
           outcome: "heldForReview",
@@ -815,10 +865,10 @@ export const paymentHandler = async (req: Request, res: Response) => {
         await sendFygaroTopupNotificationBestEffort({
           accountId: creditAccountId,
           // `pending` gets its OWN phrase rather than the credited one or
-          // nothing at all. IBEX reporting IN_FLIGHT is the vendor's documented
-          // 200, so this is a routine outcome — and leaving it silent stranded
-          // exactly the customer this notification exists for.
-          outcome: creditResult.status === "success" ? "credited" : "crediting",
+          // nothing at all. Looked up in OUTCOME_BY_CREDIT_STATUS (above)
+          // rather than branched on inline, so a third send status cannot
+          // silently inherit either claim.
+          outcome: OUTCOME_BY_CREDIT_STATUS[creditResult.status],
           // NET: what actually landed in the wallet (or is on its way to it).
           // Naming the gross would overstate the balance change by the fees.
           amountCents: fees.netCents,

--- a/src/services/fygaro/webhook-server/routes/payment.ts
+++ b/src/services/fygaro/webhook-server/routes/payment.ts
@@ -914,18 +914,48 @@ export const paymentHandler = async (req: Request, res: Response) => {
         // refusing the customer's next top-up with `daily-limit-exceeded`.
         // Costs the push nothing: `consumeIntent` reports failure by return
         // value, never a throw, so it cannot skip what follows it.
-        await sendFygaroTopupNotificationBestEffort({
-          accountId: creditAccountId,
-          // `pending` gets its OWN phrase rather than the credited one or
-          // nothing at all. Looked up in OUTCOME_BY_CREDIT_STATUS (above)
-          // rather than branched on inline, so a third send status cannot
-          // silently inherit either claim.
-          outcome: OUTCOME_BY_CREDIT_STATUS[creditResult.status],
-          // NET: what actually landed in the wallet (or is on its way to it).
-          // Naming the gross would overstate the balance change by the fees.
-          amountCents: fees.netCents,
-          currency,
-        })
+        // ONCE PER PAYMENT, and keyed on the TRANSACTION.
+        //
+        // This block is deliberately re-enterable: the Completed row is the
+        // processed marker, and it is exactly what is missing after the
+        // promotion failure alerted on above (money in the wallet, row still
+        // Fiat Received), as it also is whenever `readFygaroTopupCompletion`
+        // degrades to "not completed" on a transient lookup. Delivery 2 then
+        // replays the cached send and arrives here for a top-up already paid.
+        // A second "+$9.01 added" on a payments app's lock screen reads as a
+        // second charge, and unlike a stale status screen it cannot be walked
+        // back.
+        //
+        // The non-releasing timelock under its own key is the marker that
+        // survives all of it. NOT the intent: `authorizedIntent` is undefined
+        // for every payment whose custom_reference is a bare username — the
+        // legacy shape, and the only shape in production while signed checkout
+        // is off — so an intent-keyed guard protects nobody on the traffic that
+        // actually exists. Its own key, because the record-only path's
+        // `fygaro-payment:` lock is never taken on the credit path.
+        const pushClaim = await LockService().lockIdempotencyKey(
+          `fygaro-credit-push:${transactionId}` as IdempotencyKey,
+        )
+        if (pushClaim instanceof Error) {
+          baseLogger.info(
+            { transactionId },
+            "Fygaro credit already announced to the customer — not re-announcing",
+          )
+        } else {
+          await sendFygaroTopupNotificationBestEffort({
+            accountId: creditAccountId,
+            // `pending` gets its OWN phrase rather than the credited one or
+            // nothing at all. Looked up in OUTCOME_BY_CREDIT_STATUS (above)
+            // rather than branched on inline, so a third send status cannot
+            // silently inherit either claim.
+            outcome: OUTCOME_BY_CREDIT_STATUS[creditResult.status],
+            // NET: what actually landed in the wallet (or is on its way to
+            // it). Naming the gross would overstate the balance change by the
+            // fees.
+            amountCents: fees.netCents,
+            currency,
+          })
+        }
 
         return { code: 200, body: { status: "success", credited: true } }
       },

--- a/src/services/fygaro/webhook-server/routes/payment.ts
+++ b/src/services/fygaro/webhook-server/routes/payment.ts
@@ -123,6 +123,50 @@ const RECORD_ONLY_ALERT_TITLE: Record<
   "non-positive-net": "Fygaro payment net after fees is not positive — not auto-credited",
 }
 
+/**
+ * Which refusals earn the customer the "we have your payment and are completing
+ * it manually — we'll let you know when it lands" push.
+ *
+ * Exhaustive by TYPE, not by omission: adding a `RecordOnlyReason` without a
+ * value here is a compile error, so a new gate can never silently inherit a
+ * promise about what happens next. The copy is a commitment that a human will
+ * hand-credit this payment, so a reason only belongs here when that is the real
+ * outcome.
+ */
+const REFUSAL_NOTIFIES_CUSTOMER: Record<RecordOnlyReason, boolean> = {
+  // The deploy-level master gate. Records without crediting BY DESIGN, so
+  // pushing here would notify every paying customer during a rollout.
+  "credit-disabled": false,
+  // The operator's ERPNext runtime kill switch — the one ops actually flips
+  // during an incident. Same mass-push problem as the master gate.
+  "auto-credit-disabled": false,
+  // Transient: the route answers 500 and never reaches this branch. Listed so
+  // the record stays exhaustive.
+  "settings-unavailable": false,
+  "history-unavailable": false,
+  // Fees already meet or exceed the gross — nothing will ever land, so
+  // promising that it will is a lie.
+  "non-positive-net": false,
+  // The payment does not match the checkout we signed. That is a refund or an
+  // escalation, not a hand-credit, and we should not commit to crediting a
+  // payment we cannot account for.
+  "intent-mismatch": false,
+  // Captured fiat that a human has to finish by hand — exactly what the copy
+  // says. `non-usd` included: the push now names the payment's real currency
+  // (see FygaroTopupNotificationArgs), so it reads truthfully off USD.
+  "non-usd": true,
+  "over-limit": true,
+  "no-daily-limit-for-level": true,
+  "daily-limit-exceeded": true,
+  "under-minimum": true,
+}
+
+const NOTIFIABLE_REFUSALS: ReadonlySet<RecordOnlyReason> = new Set(
+  (Object.keys(REFUSAL_NOTIFIES_CUSTOMER) as RecordOnlyReason[]).filter(
+    (reason) => REFUSAL_NOTIFIES_CUSTOMER[reason],
+  ),
+)
+
 export const paymentHandler = async (req: Request, res: Response) => {
   const payload = (req.body ?? {}) as FygaroPaymentPayload
   const { transactionId, createdAt } = payload
@@ -575,15 +619,18 @@ export const paymentHandler = async (req: Request, res: Response) => {
       // Notify on the REFUSAL too. Telling the customer only when the money
       // arrives keeps the promise exactly when it costs nothing and breaks it
       // for the person whose payment was captured and not credited — who is
-      // otherwise left on a screen that said we would be in touch.
-      // `credit-disabled` is the silent deploy-level master gate: it records
-      // without crediting by design, and pushing for it would notify every
-      // customer during a rollout.
-      if (accountId && gate.reason !== "credit-disabled") {
+      // otherwise left on a screen that said we would be in touch. Only for the
+      // reasons where a human really does finish the payment by hand
+      // (NOTIFIABLE_REFUSALS above); the rest would be promising something that
+      // is not going to happen.
+      if (NOTIFIABLE_REFUSALS.has(gate.reason)) {
         await sendFygaroTopupNotificationBestEffort({
           accountId,
           outcome: "heldForReview",
+          // GROSS: what the card was actually charged, which is the number the
+          // customer is looking at on their statement.
           amountCents: grossCents,
+          currency,
         })
       }
       return res.status(200).json({ status: "recorded", credited: false })
@@ -664,6 +711,22 @@ export const paymentHandler = async (req: Request, res: Response) => {
           // and so a provider retry (which this branch invites) can still
           // verify the payment.
           await releaseAuthorizedHold()
+          // The one terminal outcome this notification exists for: money
+          // captured, credit FAILED. Ops has a CRITICAL asking them to credit
+          // it by hand and this response is a 200, so Fygaro stops retrying —
+          // without this push the customer is silent forever, while someone
+          // refused by the far more benign `under-minimum` gets told. The copy
+          // ("completing it manually") is literally what the alert asks ops to
+          // do. Currency is USD by construction here: the gate refuses non-USD
+          // long before the credit path. Repeats on any provider retry that
+          // re-attempts and re-fails the credit — same cadence as the ops-feed
+          // line above, and each one is a fresh true statement.
+          await sendFygaroTopupNotificationBestEffort({
+            accountId: creditAccountId,
+            outcome: "heldForReview",
+            amountCents: fees.grossCents,
+            currency,
+          })
           return { code: 200, body: { status: "recorded", credited: false } }
         }
 
@@ -698,22 +761,6 @@ export const paymentHandler = async (req: Request, res: Response) => {
           })
         }
 
-        // The app told this customer "we'll let you know as soon as it lands".
-        // A credit can outlive the screen — the transient paths deliberately
-        // 500 so Fygaro retries — so this is what makes that sentence true.
-        // Best-effort by construction: the money has already moved, and a
-        // failed push must never put a delivered credit back into the retry
-        // loop.
-        // Awaited, matching the Bridge deposit path: the helper swallows every
-        // failure internally, so awaiting cannot fail the credit, and NOT
-        // awaiting would leave a dangling promise that a recycled pod can drop
-        // — losing exactly the notification the app told the customer to expect.
-        await sendFygaroTopupNotificationBestEffort({
-          accountId: creditAccountId,
-          outcome: "credited",
-          amountCents: fees.netCents,
-        })
-
         notifyOpsEvent({
           flow: "deposit",
           phase: "succeeded",
@@ -732,6 +779,32 @@ export const paymentHandler = async (req: Request, res: Response) => {
         // The money moved: the authorisation is spent. Not done on the credit-
         // FAILURE branch above, which is deliberately retryable.
         await redeemIntent()
+
+        // The app told this customer "we'll let you know as soon as it lands".
+        // A credit can outlive the screen — the transient paths deliberately
+        // 500 so Fygaro retries — so this is what makes that sentence true.
+        // Best-effort by construction: the money has already moved, and a
+        // failed push must never put a delivered credit back into the retry
+        // loop.
+        // Awaited, matching the Bridge deposit path: the helper swallows every
+        // failure internally, so awaiting cannot fail the credit, and NOT
+        // awaiting would leave a dangling promise that a recycled pod can drop
+        // — losing exactly the notification the app told the customer to expect.
+        // Sequenced AFTER redeemIntent deliberately: a pod recycle during the
+        // FCM round trip would otherwise leave the authorisation unconsumed, so
+        // its hold keeps sitting on the daily allowance that the (already
+        // promoted) ERPNext row counts too — double-counting one payment and
+        // refusing the customer's next top-up with `daily-limit-exceeded`.
+        // Costs the push nothing: `consumeIntent` reports failure by return
+        // value, never a throw, so it cannot skip what follows it.
+        await sendFygaroTopupNotificationBestEffort({
+          accountId: creditAccountId,
+          outcome: "credited",
+          // NET: what actually landed in the wallet. Naming the gross would
+          // overstate the balance change by the fees.
+          amountCents: fees.netCents,
+          currency,
+        })
 
         return { code: 200, body: { status: "success", credited: true } }
       },

--- a/src/services/fygaro/webhook-server/routes/payment.ts
+++ b/src/services/fygaro/webhook-server/routes/payment.ts
@@ -148,6 +148,15 @@ const RECORD_ONLY_ALERT_TITLE: Record<
  * promise about what happens next. The copy is a commitment that a human will
  * hand-credit this payment, so a reason only belongs here when that is the real
  * outcome.
+ *
+ * DEPENDS ON `fygaro.checkout.enabled`. This table says which reasons MAY push;
+ * REFUSAL_NEEDS_VERIFIED_REFERENCE below says which ones additionally need a
+ * server-signed reference, and a signed reference only exists when server-side
+ * checkout is on — the flag defaults to `false` (config/schema.ts) and turning
+ * it on needs a Fygaro Pro-or-above plan. So with checkout OFF, or for any
+ * legacy app build still in the wild, the only refusal that actually reaches a
+ * customer is the one marked `false` in that second table. Read the two
+ * together; neither is the whole answer on its own.
  */
 const REFUSAL_NOTIFIES_CUSTOMER: Record<RecordOnlyReason, boolean> = {
   // The deploy-level master gate. Records without crediting BY DESIGN, so
@@ -175,6 +184,53 @@ const REFUSAL_NOTIFIES_CUSTOMER: Record<RecordOnlyReason, boolean> = {
   "no-daily-limit-for-level": true,
   "daily-limit-exceeded": true,
   "under-minimum": true,
+}
+
+/**
+ * Which of those refusals ALSO require a server-verified reference before the
+ * push goes out.
+ *
+ * On legacy unsigned clients `customReference` is free text the PAYER types, so
+ * anyone can pay with a stranger's username on it and have the bank's own app
+ * tell that stranger we are holding a payment of theirs — a ready-made pretext
+ * for a follow-up scam call. What makes that worth blocking is the PRICE: the
+ * gates below all trip on amounts an attacker is happy to spend.
+ *
+ * `over-limit` is the exception, and the reason this is a per-reason table
+ * rather than one blanket `authorizedIntent &&`. It trips only when the gross
+ * EXCEEDS the operator's single-payment auto-credit limit (fees.ts), so buying
+ * that push costs the attacker more than the limit — real money that ops then
+ * hand-credits to the VICTIM. That is the same self-defeating economics that
+ * leaves the `credited` push ungated, and gating it bought nothing while
+ * silencing the reason most likely to be the one a real customer hits.
+ *
+ * The rest stay gated because they are cheap: `under-minimum` costs whatever is
+ * below the operator minimum, `non-usd` costs a single Jamaican dollar, and
+ * `daily-limit-exceeded` / `no-daily-limit-for-level` cost nothing at all when
+ * the victim already sits at their cap (both are checked before the minimum
+ * gate). Legacy clients keep the pre-PR behaviour for those — ops alert only,
+ * no push — until they are out of the wild.
+ *
+ * Exhaustive by TYPE for the same reason as the table above: a new gate must
+ * make this call explicitly rather than inherit either answer.
+ */
+const REFUSAL_NEEDS_VERIFIED_REFERENCE: Record<RecordOnlyReason, boolean> = {
+  // Costs the attacker more than the auto-credit limit, paid to the victim.
+  "over-limit": false,
+  // Cheap enough to be a scam pretext — a signed reference is required.
+  "non-usd": true,
+  "under-minimum": true,
+  "daily-limit-exceeded": true,
+  "no-daily-limit-for-level": true,
+  // Never push at all (REFUSAL_NOTIFIES_CUSTOMER above), so this value is
+  // unreachable. Listed so the record stays exhaustive and a reason promoted to
+  // notifying cannot arrive here without an answer.
+  "credit-disabled": true,
+  "auto-credit-disabled": true,
+  "settings-unavailable": true,
+  "history-unavailable": true,
+  "non-positive-net": true,
+  "intent-mismatch": true,
 }
 
 // Read off `creditFygaroTopup` itself rather than restated as a literal union:
@@ -664,21 +720,27 @@ export const paymentHandler = async (req: Request, res: Response) => {
       // (REFUSAL_NOTIFIES_CUSTOMER above); the rest would be promising something
       // that is not going to happen.
       //
-      // ...and only for a SERVER-VERIFIED reference. `authorizedIntent` is set
-      // only when the reference carries an intentId that Flash itself minted
-      // and signed for this account and this amount (see readIntent above; a
-      // mismatch on either lands as `intent-mismatch`, which this allowlist
-      // refuses anyway). On the legacy unsigned clients still in the wild,
-      // `customReference` is free text the PAYER types — so without this gate
-      // anyone could pay J$1, or $2 against the $10 minimum, with a stranger's
-      // username on it and have the bank's own app tell that stranger we are
-      // holding a payment of theirs. That is a ready-made pretext for a
-      // follow-up scam call, and it costs the attacker a dollar. The `credited`
-      // push is not gated the same way because abusing it means paying the
-      // victim real money, which makes it self-defeating; a refusal push has no
-      // such offsetting cost. Legacy clients simply keep the pre-PR behaviour
-      // (ops alert only, no push) until they are out of the wild.
-      if (authorizedIntent && REFUSAL_NOTIFIES_CUSTOMER[gate.reason]) {
+      // ...and, for the CHEAP reasons, only against a SERVER-VERIFIED
+      // reference. `authorizedIntent` is set only when the reference carries an
+      // intentId that Flash itself minted and signed for this account and this
+      // amount (see readIntent above; a mismatch on either lands as
+      // `intent-mismatch`, which the allowlist refuses anyway). On the legacy
+      // unsigned clients still in the wild — and on EVERY client while
+      // `fygaro.checkout.enabled` is false, which is its default — the
+      // reference is free text the PAYER types, so anyone could pay J$1, or $2
+      // against the $10 minimum, with a stranger's username on it and have the
+      // bank's own app tell that stranger we are holding a payment of theirs.
+      //
+      // Which is a price argument, not a blanket one, so the price decides:
+      // REFUSAL_NEEDS_VERIFIED_REFERENCE exempts `over-limit`, whose trigger
+      // costs the attacker MORE than the auto-credit limit and hands it to the
+      // victim — the same self-defeating economics that leaves the `credited`
+      // push ungated. Gating that one bought nothing and, with signed checkout
+      // off, silenced the whole refusal half of this feature.
+      if (
+        REFUSAL_NOTIFIES_CUSTOMER[gate.reason] &&
+        (authorizedIntent || !REFUSAL_NEEDS_VERIFIED_REFERENCE[gate.reason])
+      ) {
         await sendFygaroTopupNotificationBestEffort({
           accountId,
           outcome: "heldForReview",
@@ -852,16 +914,6 @@ export const paymentHandler = async (req: Request, res: Response) => {
         // refusing the customer's next top-up with `daily-limit-exceeded`.
         // Costs the push nothing: `consumeIntent` reports failure by return
         // value, never a throw, so it cannot skip what follows it.
-        //
-        // ONLY on `success`. `creditFygaroTopup` also returns `pending`, whose
-        // own comment reads "money has PROBABLY left the treasury: report
-        // credited, never re-pay" — a deliberately weaker claim than "N USD has
-        // been added to your wallet", which is what this copy asserts. Pushing
-        // it on `pending` sends the customer to a balance that has not moved
-        // yet, i.e. manufactures the support ticket this notification exists to
-        // prevent. The pending case stays visible to ops through `creditStatus`
-        // on the feed line above; telling the customer about it needs its own
-        // phrase, not this one overloaded.
         await sendFygaroTopupNotificationBestEffort({
           accountId: creditAccountId,
           // `pending` gets its OWN phrase rather than the credited one or

--- a/test/flash/unit/app/bridge/send-deposit-notification.spec.ts
+++ b/test/flash/unit/app/bridge/send-deposit-notification.spec.ts
@@ -1,18 +1,30 @@
 const config = { enabled: true }
 
+// Only BridgeConfig is faked. `getI18nInstance` is the REAL one so the content
+// test below renders the shipped en.json phrase instead of asserting against a
+// stub of itself.
 jest.mock("@config", () => ({
   get BridgeConfig() {
     return config
   },
-  getI18nInstance: jest.fn(),
+  getI18nInstance: (...a: unknown[]) =>
+    jest.requireActual("@config").getI18nInstance(...a),
 }))
 
 const findById = jest.fn()
+const findUserById = jest.fn()
+const mockSendFiltered = jest.fn()
 jest.mock("@services/mongoose/accounts", () => ({
   AccountsRepository: () => ({ findById }),
 }))
 jest.mock("@services/mongoose/users", () => ({
-  UsersRepository: () => ({ findById: jest.fn() }),
+  UsersRepository: () => ({ findById: (...a: unknown[]) => findUserById(...a) }),
+}))
+jest.mock("@services/notifications/push-notifications", () => ({
+  PushNotificationsService: () => ({
+    sendFilteredNotification: (...a: unknown[]) => mockSendFiltered(...a),
+  }),
+  SendFilteredPushNotificationStatus: { Sent: "Sent", Filtered: "Filtered" },
 }))
 jest.mock("@app/users/remove-device-tokens", () => ({
   removeDeviceTokens: jest.fn(),
@@ -30,6 +42,21 @@ jest.mock("@services/logger", () => {
 
 import { sendBridgeDepositNotificationBestEffort } from "@app/bridge/send-deposit-notification"
 
+const ACCOUNT_ID = "507f1f77bcf86cd799439011"
+
+beforeEach(() => {
+  // Explicit defaults, not just clearAllMocks: `mockResolvedValue` survives
+  // `clearAllMocks` (that only wipes calls), so a leftover implementation from
+  // an earlier test would otherwise leak into this one.
+  findById.mockResolvedValue({
+    id: ACCOUNT_ID,
+    kratosUserId: "kratos-1",
+    notificationSettings: {},
+  })
+  findUserById.mockResolvedValue({ deviceTokens: ["tok-1"], language: "en" })
+  mockSendFiltered.mockResolvedValue({ status: "Sent" })
+})
+
 describe("sendBridgeDepositNotificationBestEffort — bridge.enabled gate (ENG-466)", () => {
   afterEach(() => {
     config.enabled = true
@@ -39,7 +66,7 @@ describe("sendBridgeDepositNotificationBestEffort — bridge.enabled gate (ENG-4
   it("no-ops without touching the account repo when bridge is disabled", async () => {
     config.enabled = false
     await sendBridgeDepositNotificationBestEffort({
-      accountId: "507f1f77bcf86cd799439011",
+      accountId: ACCOUNT_ID,
       amount: "10",
       currency: "USD",
     })
@@ -49,10 +76,62 @@ describe("sendBridgeDepositNotificationBestEffort — bridge.enabled gate (ENG-4
   it("proceeds (reaches the account lookup) when bridge is enabled", async () => {
     findById.mockResolvedValue(new Error("stop-after-lookup"))
     await sendBridgeDepositNotificationBestEffort({
-      accountId: "507f1f77bcf86cd799439011",
+      accountId: ACCOUNT_ID,
       amount: "10",
       currency: "USD",
     })
     expect(findById).toHaveBeenCalled()
+  })
+})
+
+describe("sendBridgeDepositNotificationBestEffort — payload content", () => {
+  afterEach(() => {
+    config.enabled = true
+    jest.clearAllMocks()
+  })
+
+  // The push body, `data.type` and the usdt->USD mapping used to live in this
+  // module; they now come from the shared `send-outcome-notification`, which
+  // Fygaro (and whatever lands next) also drives. Without this test the only
+  // Bridge assertion is "findById was called", so a change made to the shared
+  // module's `data` merge or `amountArg` contract for a THIRD caller breaks
+  // Bridge's live money-path push with a fully green Bridge suite.
+  it("renders the deposit body and data payload the mobile app switches on", async () => {
+    await sendBridgeDepositNotificationBestEffort({
+      accountId: ACCOUNT_ID,
+      amount: "10",
+      currency: "usdt",
+    })
+
+    const [args] = mockSendFiltered.mock.calls[0]
+    expect(args.title).toBe("Deposit received")
+    expect(args.body).toContain("10 USDT")
+    // `usdt` is the on-chain asset; the app shows the wallet currency. Major
+    // units under `amount`, matching every other Payments push.
+    expect(args.data).toEqual({
+      type: "bridge_deposit_completed",
+      amount: "10",
+      currency: "USD",
+    })
+  })
+
+  it("routes non-default outcomes to their own phrase and type", async () => {
+    // `outcome` defaults to "completed"; the other two are real Bridge states,
+    // and each must keep its own i18n key + `data.type` through the shared path.
+    await sendBridgeDepositNotificationBestEffort({
+      accountId: ACCOUNT_ID,
+      amount: "25.50",
+      currency: "usd",
+      outcome: "processing",
+    })
+
+    const [args] = mockSendFiltered.mock.calls[0]
+    expect(args.title).toBe("Deposit processing")
+    expect(args.body).toContain("25.50 USD")
+    expect(args.data).toEqual({
+      type: "bridge_deposit_processing",
+      amount: "25.50",
+      currency: "USD",
+    })
   })
 })

--- a/test/flash/unit/app/fygaro/send-topup-notification.spec.ts
+++ b/test/flash/unit/app/fygaro/send-topup-notification.spec.ts
@@ -23,12 +23,10 @@ jest.mock("@app/users/remove-device-tokens", () => ({
   removeDeviceTokens: (...a: unknown[]) => mockRemoveDeviceTokens(...a),
 }))
 
-/* eslint-disable @typescript-eslint/no-var-requires */
-const {
+import {
   sendFygaroTopupNotification,
   sendFygaroTopupNotificationBestEffort,
-} = require("@app/fygaro/send-topup-notification")
-/* eslint-enable @typescript-eslint/no-var-requires */
+} from "@app/fygaro/send-topup-notification"
 
 const ACCOUNT_ID = "6a8203ce490716aa69381454"
 
@@ -51,11 +49,26 @@ describe("sendFygaroTopupNotification", () => {
       accountId: ACCOUNT_ID,
       outcome: "credited",
       amountCents: 5652,
+      currency: "USD",
     })
 
     const [args] = mockSendFiltered.mock.calls[0]
-    expect(args.body).toContain("$56.52")
+    expect(args.body).toContain("56.52 USD")
     expect(args.data).toMatchObject({ type: "fygaro_topup_credited", currency: "USD" })
+  })
+
+  it("sends data.amount in MAJOR units, the way every other Payments push does", async () => {
+    // `amount` is the Bridge-deposit convention (major units); the referral
+    // sender uses a different key, `amountCents`, precisely because it is cents.
+    // Cents under this key renders a $56.52 credit as $5,652 in the app.
+    await sendFygaroTopupNotification({
+      accountId: ACCOUNT_ID,
+      outcome: "credited",
+      amountCents: 5652,
+      currency: "USD",
+    })
+
+    expect(mockSendFiltered.mock.calls[0][0].data.amount).toBe("56.52")
   })
 
   it("also notifies when the payment was captured and NOT credited", async () => {
@@ -65,13 +78,31 @@ describe("sendFygaroTopupNotification", () => {
       accountId: ACCOUNT_ID,
       outcome: "heldForReview",
       amountCents: 6000,
+      currency: "USD",
     })
 
     const [args] = mockSendFiltered.mock.calls[0]
-    expect(args.body).toContain("$60.00")
+    expect(args.body).toContain("60.00 USD")
     expect(args.data).toMatchObject({ type: "fygaro_topup_heldForReview" })
     // Not a dead end: ops is already paged by the gate that produced this.
     expect(args.body.toLowerCase()).toContain("completing it manually")
+  })
+
+  it("names the currency the payment was actually captured in", async () => {
+    // The heldForReview push fires on refusals that include `non-usd`. Assuming
+    // USD rendered a J$6,000 payment as "$6000.00" — a ~150x overstatement in
+    // the one message whose entire job is telling the customer what we hold.
+    await sendFygaroTopupNotification({
+      accountId: ACCOUNT_ID,
+      outcome: "heldForReview",
+      amountCents: 600000,
+      currency: "JMD",
+    })
+
+    const [args] = mockSendFiltered.mock.calls[0]
+    expect(args.body).toContain("6000.00 JMD")
+    expect(args.body).not.toContain("USD")
+    expect(args.data).toMatchObject({ amount: "6000.00", currency: "JMD" })
   })
 
   it("sends in the user's language", async () => {
@@ -81,6 +112,7 @@ describe("sendFygaroTopupNotification", () => {
       accountId: ACCOUNT_ID,
       outcome: "credited",
       amountCents: 5652,
+      currency: "USD",
     })
 
     expect(mockSendFiltered.mock.calls[0][0].title).toBe("Recarga completada")
@@ -93,6 +125,7 @@ describe("sendFygaroTopupNotification", () => {
       accountId: ACCOUNT_ID,
       outcome: "credited",
       amountCents: 5652,
+      currency: "USD",
     })
 
     expect(res).toBeInstanceOf(Error)
@@ -111,6 +144,7 @@ describe("sendFygaroTopupNotificationBestEffort", () => {
         accountId: ACCOUNT_ID,
         outcome: "credited",
         amountCents: 5652,
+        currency: "USD",
       }),
     ).resolves.toBeUndefined()
   })
@@ -126,6 +160,7 @@ describe("sendFygaroTopupNotificationBestEffort", () => {
       accountId: ACCOUNT_ID,
       outcome: "credited",
       amountCents: 5652,
+      currency: "USD",
     })
 
     expect(mockRemoveDeviceTokens).toHaveBeenCalledWith({
@@ -142,6 +177,7 @@ describe("sendFygaroTopupNotificationBestEffort", () => {
         accountId: ACCOUNT_ID,
         outcome: "heldForReview",
         amountCents: 6000,
+        currency: "USD",
       }),
     ).resolves.toBeUndefined()
   })

--- a/test/flash/unit/app/fygaro/send-topup-notification.spec.ts
+++ b/test/flash/unit/app/fygaro/send-topup-notification.spec.ts
@@ -1,0 +1,148 @@
+import { DeviceTokensNotRegisteredNotificationsServiceError } from "@domain/notifications"
+
+const mockFindAccountById = jest.fn()
+const mockFindUserById = jest.fn()
+const mockSendFiltered = jest.fn()
+const mockRemoveDeviceTokens = jest.fn()
+
+jest.mock("@services/mongoose/accounts", () => ({
+  AccountsRepository: () => ({
+    findById: (...a: unknown[]) => mockFindAccountById(...a),
+  }),
+}))
+jest.mock("@services/mongoose/users", () => ({
+  UsersRepository: () => ({ findById: (...a: unknown[]) => mockFindUserById(...a) }),
+}))
+jest.mock("@services/notifications/push-notifications", () => ({
+  PushNotificationsService: () => ({
+    sendFilteredNotification: (...a: unknown[]) => mockSendFiltered(...a),
+  }),
+  SendFilteredPushNotificationStatus: { Sent: "Sent", Filtered: "Filtered" },
+}))
+jest.mock("@app/users/remove-device-tokens", () => ({
+  removeDeviceTokens: (...a: unknown[]) => mockRemoveDeviceTokens(...a),
+}))
+
+/* eslint-disable @typescript-eslint/no-var-requires */
+const {
+  sendFygaroTopupNotification,
+  sendFygaroTopupNotificationBestEffort,
+} = require("@app/fygaro/send-topup-notification")
+/* eslint-enable @typescript-eslint/no-var-requires */
+
+const ACCOUNT_ID = "6a8203ce490716aa69381454"
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  mockFindAccountById.mockResolvedValue({
+    id: ACCOUNT_ID,
+    kratosUserId: "kratos-1",
+    notificationSettings: {},
+  })
+  mockFindUserById.mockResolvedValue({ deviceTokens: ["tok-1"], language: "en" })
+  mockSendFiltered.mockResolvedValue({ status: "Sent" })
+})
+
+describe("sendFygaroTopupNotification", () => {
+  it("tells the customer the NET that landed, not the gross they paid", async () => {
+    // $60 paid, $56.52 credited. Naming the gross would overstate the balance
+    // change and invite a support ticket about the missing $3.48.
+    await sendFygaroTopupNotification({
+      accountId: ACCOUNT_ID,
+      outcome: "credited",
+      amountCents: 5652,
+    })
+
+    const [args] = mockSendFiltered.mock.calls[0]
+    expect(args.body).toContain("$56.52")
+    expect(args.data).toMatchObject({ type: "fygaro_topup_credited", currency: "USD" })
+  })
+
+  it("also notifies when the payment was captured and NOT credited", async () => {
+    // The case that actually matters. Notifying only on success keeps the
+    // promise exactly when it costs nothing.
+    await sendFygaroTopupNotification({
+      accountId: ACCOUNT_ID,
+      outcome: "heldForReview",
+      amountCents: 6000,
+    })
+
+    const [args] = mockSendFiltered.mock.calls[0]
+    expect(args.body).toContain("$60.00")
+    expect(args.data).toMatchObject({ type: "fygaro_topup_heldForReview" })
+    // Not a dead end: ops is already paged by the gate that produced this.
+    expect(args.body.toLowerCase()).toContain("completing it manually")
+  })
+
+  it("sends in the user's language", async () => {
+    mockFindUserById.mockResolvedValue({ deviceTokens: ["tok-1"], language: "es" })
+
+    await sendFygaroTopupNotification({
+      accountId: ACCOUNT_ID,
+      outcome: "credited",
+      amountCents: 5652,
+    })
+
+    expect(mockSendFiltered.mock.calls[0][0].title).toBe("Recarga completada")
+  })
+
+  it("returns the error rather than throwing when the account cannot be read", async () => {
+    mockFindAccountById.mockResolvedValue(new Error("mongo down"))
+
+    const res = await sendFygaroTopupNotification({
+      accountId: ACCOUNT_ID,
+      outcome: "credited",
+      amountCents: 5652,
+    })
+
+    expect(res).toBeInstanceOf(Error)
+    expect(mockSendFiltered).not.toHaveBeenCalled()
+  })
+})
+
+describe("sendFygaroTopupNotificationBestEffort", () => {
+  it("never throws when the push fails — the money has already moved", async () => {
+    // Turning a failed notification into an error would put a DELIVERED credit
+    // back into Fygaro's retry loop.
+    mockSendFiltered.mockResolvedValue(new Error("fcm unavailable"))
+
+    await expect(
+      sendFygaroTopupNotificationBestEffort({
+        accountId: ACCOUNT_ID,
+        outcome: "credited",
+        amountCents: 5652,
+      }),
+    ).resolves.toBeUndefined()
+  })
+
+  it("prunes device tokens that are no longer registered", async () => {
+    // Reinstalled or handed-on devices, so the next notification is not sent
+    // into the same void.
+    mockSendFiltered.mockResolvedValue(
+      new DeviceTokensNotRegisteredNotificationsServiceError(["stale-1" as DeviceToken]),
+    )
+
+    await sendFygaroTopupNotificationBestEffort({
+      accountId: ACCOUNT_ID,
+      outcome: "credited",
+      amountCents: 5652,
+    })
+
+    expect(mockRemoveDeviceTokens).toHaveBeenCalledWith({
+      userId: "kratos-1",
+      deviceTokens: ["stale-1"],
+    })
+  })
+
+  it("swallows an unreadable account without throwing", async () => {
+    mockFindAccountById.mockResolvedValue(new Error("mongo down"))
+
+    await expect(
+      sendFygaroTopupNotificationBestEffort({
+        accountId: ACCOUNT_ID,
+        outcome: "heldForReview",
+        amountCents: 6000,
+      }),
+    ).resolves.toBeUndefined()
+  })
+})

--- a/test/flash/unit/app/fygaro/send-topup-notification.spec.ts
+++ b/test/flash/unit/app/fygaro/send-topup-notification.spec.ts
@@ -23,10 +23,11 @@ jest.mock("@app/users/remove-device-tokens", () => ({
   removeDeviceTokens: (...a: unknown[]) => mockRemoveDeviceTokens(...a),
 }))
 
-import {
-  sendFygaroTopupNotification,
-  sendFygaroTopupNotificationBestEffort,
-} from "@app/fygaro/send-topup-notification"
+// The best-effort wrapper is the ONLY export, and the only thing payment.ts
+// calls. Testing the content through it — rather than through a parallel
+// error-returning entry point production never executes — means these
+// assertions cover the code path that actually reaches a customer's phone.
+import { sendFygaroTopupNotificationBestEffort } from "@app/fygaro/send-topup-notification"
 
 const ACCOUNT_ID = "6a8203ce490716aa69381454"
 
@@ -41,11 +42,11 @@ beforeEach(() => {
   mockSendFiltered.mockResolvedValue({ status: "Sent" })
 })
 
-describe("sendFygaroTopupNotification", () => {
+describe("sendFygaroTopupNotificationBestEffort", () => {
   it("tells the customer the NET that landed, not the gross they paid", async () => {
     // $60 paid, $56.52 credited. Naming the gross would overstate the balance
     // change and invite a support ticket about the missing $3.48.
-    await sendFygaroTopupNotification({
+    await sendFygaroTopupNotificationBestEffort({
       accountId: ACCOUNT_ID,
       outcome: "credited",
       amountCents: 5652,
@@ -53,6 +54,7 @@ describe("sendFygaroTopupNotification", () => {
     })
 
     const [args] = mockSendFiltered.mock.calls[0]
+    expect(args.title).toBe("Top-up complete")
     expect(args.body).toContain("56.52 USD")
     expect(args.data).toMatchObject({ type: "fygaro_topup_credited", currency: "USD" })
   })
@@ -61,7 +63,7 @@ describe("sendFygaroTopupNotification", () => {
     // `amount` is the Bridge-deposit convention (major units); the referral
     // sender uses a different key, `amountCents`, precisely because it is cents.
     // Cents under this key renders a $56.52 credit as $5,652 in the app.
-    await sendFygaroTopupNotification({
+    await sendFygaroTopupNotificationBestEffort({
       accountId: ACCOUNT_ID,
       outcome: "credited",
       amountCents: 5652,
@@ -74,7 +76,7 @@ describe("sendFygaroTopupNotification", () => {
   it("also notifies when the payment was captured and NOT credited", async () => {
     // The case that actually matters. Notifying only on success keeps the
     // promise exactly when it costs nothing.
-    await sendFygaroTopupNotification({
+    await sendFygaroTopupNotificationBestEffort({
       accountId: ACCOUNT_ID,
       outcome: "heldForReview",
       amountCents: 6000,
@@ -82,17 +84,38 @@ describe("sendFygaroTopupNotification", () => {
     })
 
     const [args] = mockSendFiltered.mock.calls[0]
+    expect(args.title).toBe("Top-up needs a moment")
     expect(args.body).toContain("60.00 USD")
-    expect(args.data).toMatchObject({ type: "fygaro_topup_heldForReview" })
     // Not a dead end: ops is already paged by the gate that produced this.
     expect(args.body.toLowerCase()).toContain("completing it manually")
+  })
+
+  it("promises no follow-up it cannot keep on a hand-credited payment", async () => {
+    // Nothing in this codebase re-notifies when ops finishes the credit by hand
+    // — that is an intraledger send, and `intraLedgerTxReceived` is on the
+    // notifications service with no call site anywhere in this fork (grep it:
+    // definition and export only). "We'll let you know when it lands" is the
+    // exact unkeepable promise this whole feature was written to retire, with
+    // an explicit broken commitment attached: a $500.01 over-limit payment
+    // hand-credited three days later would leave the customer in the same
+    // silence, now having been told otherwise.
+    await sendFygaroTopupNotificationBestEffort({
+      accountId: ACCOUNT_ID,
+      outcome: "heldForReview",
+      amountCents: 50001,
+      currency: "USD",
+    })
+
+    const [args] = mockSendFiltered.mock.calls[0]
+    expect(args.body.toLowerCase()).not.toContain("let you know")
+    expect(args.body.toLowerCase()).not.toContain("when it lands")
   })
 
   it("names the currency the payment was actually captured in", async () => {
     // The heldForReview push fires on refusals that include `non-usd`. Assuming
     // USD rendered a J$6,000 payment as "$6000.00" — a ~150x overstatement in
     // the one message whose entire job is telling the customer what we hold.
-    await sendFygaroTopupNotification({
+    await sendFygaroTopupNotificationBestEffort({
       accountId: ACCOUNT_ID,
       outcome: "heldForReview",
       amountCents: 600000,
@@ -105,35 +128,93 @@ describe("sendFygaroTopupNotification", () => {
     expect(args.data).toMatchObject({ amount: "6000.00", currency: "JMD" })
   })
 
-  it("sends in the user's language", async () => {
+  it("tells an in-flight credit's customer it is on the way, in words that render", async () => {
+    // The `crediting` copy is the newest customer-visible string here, and i18n
+    // is configured `updateFiles: false`, so a dropped, renamed or mistyped key
+    // ships the literal `notification.fygaroTopup.crediting.body` to a lock
+    // screen with a fully green suite. Asserting it against a mocked
+    // notification module — which is all payment.spec.ts can do — would not
+    // catch that. Render it.
+    await sendFygaroTopupNotificationBestEffort({
+      accountId: ACCOUNT_ID,
+      outcome: "crediting",
+      amountCents: 5652,
+      currency: "USD",
+    })
+
+    const [args] = mockSendFiltered.mock.calls[0]
+    expect(args.title).toBe("Top-up on its way")
+    expect(args.body).toContain("56.52 USD")
+    expect(args.body).toContain("should appear shortly")
+    // Deliberately weaker than the credited copy: nothing has landed yet.
+    expect(args.body).not.toContain("has been added")
+  })
+
+  it.each([
+    ["credited", "Recarga completada"],
+    ["crediting", "Tu recarga está en camino"],
+  ] as const)("sends %s in the user's language", async (outcome, title) => {
     mockFindUserById.mockResolvedValue({ deviceTokens: ["tok-1"], language: "es" })
 
-    await sendFygaroTopupNotification({
+    await sendFygaroTopupNotificationBestEffort({
       accountId: ACCOUNT_ID,
-      outcome: "credited",
+      outcome,
       amountCents: 5652,
       currency: "USD",
     })
 
-    expect(mockSendFiltered.mock.calls[0][0].title).toBe("Recarga completada")
+    expect(mockSendFiltered.mock.calls[0][0].title).toBe(title)
   })
 
-  it("returns the error rather than throwing when the account cannot be read", async () => {
-    mockFindAccountById.mockResolvedValue(new Error("mongo down"))
+  it("makes the same manual-credit commitment in Spanish, and no more", async () => {
+    // Asserted by substring rather than the whole sentence on purpose: the
+    // Spanish title is the one string in this file the repo's spell checker
+    // reads against an English dictionary (see typos.toml — es.json is excluded
+    // for exactly this, test files are not). These two substrings are what
+    // actually carries meaning: that a human finishes the payment, and that we
+    // do NOT promise a second message when it lands, because nothing sends one.
+    mockFindUserById.mockResolvedValue({ deviceTokens: ["tok-1"], language: "es" })
 
-    const res = await sendFygaroTopupNotification({
+    await sendFygaroTopupNotificationBestEffort({
       accountId: ACCOUNT_ID,
-      outcome: "credited",
-      amountCents: 5652,
+      outcome: "heldForReview",
+      amountCents: 50001,
       currency: "USD",
     })
 
-    expect(res).toBeInstanceOf(Error)
-    expect(mockSendFiltered).not.toHaveBeenCalled()
+    const [args] = mockSendFiltered.mock.calls[0]
+    expect(args.body).toContain("500.01 USD")
+    expect(args.body).toContain("manualmente")
+    expect(args.body.toLowerCase()).not.toContain("cuando se acredite")
   })
-})
 
-describe("sendFygaroTopupNotificationBestEffort", () => {
+  it.each([
+    ["credited", "fygaro_topup_credited"],
+    ["crediting", "fygaro_topup_crediting"],
+    ["heldForReview", "fygaro_topup_held_for_review"],
+  ] as const)(
+    "sends %s under a fully snake_case data.type",
+    async (outcome, dataType) => {
+      // The wire contract flash-mobile switches on, alongside
+      // `bridge_deposit_completed` / `bridge_deposit_processing`. Interpolating
+      // the camelCase outcome into a snake_case prefix produced
+      // `fygaro_topup_heldForReview`; once a mobile release ships against that,
+      // correcting it costs a coordinated change across two repos.
+      await sendFygaroTopupNotificationBestEffort({
+        accountId: ACCOUNT_ID,
+        outcome,
+        amountCents: 5652,
+        currency: "USD",
+      })
+
+      const actual = mockSendFiltered.mock.calls[0][0].data.type
+      expect(actual).toBe(dataType)
+      // Guards the CONVENTION, not just today's three strings: any future outcome
+      // whose wire type picks up a camelCase segment fails here too.
+      expect(actual).toBe(actual.toLowerCase())
+    },
+  )
+
   it("never throws when the push fails — the money has already moved", async () => {
     // Turning a failed notification into an error would put a DELIVERED credit
     // back into Fygaro's retry loop.
@@ -169,7 +250,7 @@ describe("sendFygaroTopupNotificationBestEffort", () => {
     })
   })
 
-  it("swallows an unreadable account without throwing", async () => {
+  it("swallows an unreadable account without throwing, and sends nothing", async () => {
     mockFindAccountById.mockResolvedValue(new Error("mongo down"))
 
     await expect(
@@ -177,6 +258,42 @@ describe("sendFygaroTopupNotificationBestEffort", () => {
         accountId: ACCOUNT_ID,
         outcome: "heldForReview",
         amountCents: 6000,
+        currency: "USD",
+      }),
+    ).resolves.toBeUndefined()
+    expect(mockSendFiltered).not.toHaveBeenCalled()
+  })
+
+  // The two cases below are the ONLY ones that exercise the try/catch in
+  // `sendOutcomeNotificationBestEffort`, which is the entire justification for
+  // awaiting this call on the money path. A repository that RETURNS an error
+  // (above) is handled without any catch at all; a repository that THROWS —
+  // a Mongoose connection error, an FCM client blowing up — is what the catch
+  // is for. Without these, deleting the catch keeps the suite green while an
+  // already-credited payment starts answering 500 with a CRITICAL alert,
+  // because the throw propagates out of the redlock callback and payment.ts
+  // rethrows it.
+  it("swallows a repository that THROWS rather than returning an error", async () => {
+    mockFindAccountById.mockRejectedValue(new Error("mongo down"))
+
+    await expect(
+      sendFygaroTopupNotificationBestEffort({
+        accountId: ACCOUNT_ID,
+        outcome: "credited",
+        amountCents: 5652,
+        currency: "USD",
+      }),
+    ).resolves.toBeUndefined()
+  })
+
+  it("swallows a push client that THROWS after the credit already landed", async () => {
+    mockSendFiltered.mockRejectedValue(new Error("fcm exploded"))
+
+    await expect(
+      sendFygaroTopupNotificationBestEffort({
+        accountId: ACCOUNT_ID,
+        outcome: "credited",
+        amountCents: 5652,
         currency: "USD",
       }),
     ).resolves.toBeUndefined()

--- a/test/flash/unit/services/fygaro/webhook-server/index.spec.ts
+++ b/test/flash/unit/services/fygaro/webhook-server/index.spec.ts
@@ -1,7 +1,10 @@
 const mockFygaroConfig = {
   enabled: true,
   webhook: { port: 4010, secrets: { default: "s3cret" }, timestampSkewMs: 300000 },
-  credit: { enabled: false },
+  // Mutated per test: `credit.enabled` is what decides whether any push is
+  // reachable from this server at all, so it decides whether a missing Firebase
+  // credential is an incident or a non-event.
+  credit: { enabled: true },
 }
 
 // `messaging` is a module-level binding in firebase.ts — null when
@@ -71,10 +74,11 @@ import { startFygaroWebhookServer } from "@services/fygaro/webhook-server"
 beforeEach(() => {
   jest.clearAllMocks()
   mockMessaging = {}
+  mockFygaroConfig.credit.enabled = true
 })
 
 describe("startFygaroWebhookServer", () => {
-  it("pages when Firebase messaging is unavailable — otherwise every push is a silent no-op", () => {
+  it("pages when credit is ON and Firebase messaging is unavailable — otherwise every push is a silent no-op", () => {
     // firebase.ts leaves `messaging` null when the credential is missing, and
     // push-notifications.ts then returns `true` anyway (its own "FIXME: should
     // return an error?"). Every layer above — including the best-effort wrapper
@@ -96,6 +100,22 @@ describe("startFygaroWebhookServer", () => {
   })
 
   it("stays quiet when Firebase messaging loaded", () => {
+    startFygaroWebhookServer()
+
+    expect(mockAlertBridge).not.toHaveBeenCalled()
+  })
+
+  it("stays quiet with no messaging when credit is disabled — nothing could push anyway", () => {
+    // `fygaro.credit.enabled` defaults to false and is the first rollout state.
+    // With it off the gate answers `credit-disabled`, which
+    // REFUSAL_NOTIFIES_CUSTOMER keeps deliberately silent, and the credit path
+    // is never entered — so no push is reachable and a missing credential
+    // breaks nothing. Paging here would mean a CRITICAL on every pod restart
+    // and rolling deploy, with no auto-resolve, about a feature switched off by
+    // design.
+    mockFygaroConfig.credit.enabled = false
+    mockMessaging = null
+
     startFygaroWebhookServer()
 
     expect(mockAlertBridge).not.toHaveBeenCalled()

--- a/test/flash/unit/services/fygaro/webhook-server/index.spec.ts
+++ b/test/flash/unit/services/fygaro/webhook-server/index.spec.ts
@@ -1,0 +1,119 @@
+const mockFygaroConfig = {
+  enabled: true,
+  webhook: { port: 4010, secrets: { default: "s3cret" }, timestampSkewMs: 300000 },
+  credit: { enabled: false },
+}
+
+// `messaging` is a module-level binding in firebase.ts — null when
+// GOOGLE_APPLICATION_CREDENTIALS is unset or the credential fails to load.
+// Exposed through a getter so each test picks its value before boot runs; a
+// named import is read as a property of the module object at each use site, so
+// the getter fires inside startFygaroWebhookServer, not at import time.
+let mockMessaging: unknown = {}
+const mockAlertBridge = jest.fn()
+
+const mockApp = {
+  set: jest.fn(),
+  use: jest.fn(),
+  get: jest.fn(),
+  post: jest.fn(),
+  listen: jest.fn(),
+}
+
+jest.mock("@config", () => ({
+  get FygaroConfig() {
+    return mockFygaroConfig
+  },
+}))
+
+jest.mock("@services/logger", () => ({
+  baseLogger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}))
+
+jest.mock("@services/notifications/firebase", () => ({
+  get messaging() {
+    return mockMessaging
+  },
+}))
+
+jest.mock("@services/alerts", () => ({
+  alertBridge: (...args: unknown[]) => mockAlertBridge(...args),
+  // The real key generator, so the static-vs-per-transaction choice this alert
+  // depends on is pinned rather than stubbed to a constant.
+  generateDedupKey: jest.requireActual("@services/alerts/dedup-key").generateDedupKey,
+}))
+
+// The route and middleware are wired, not exercised, by this spec — stubbing
+// them keeps the boot path off the Mongo/Kratos/ERPNext import graph.
+jest.mock("@services/fygaro/webhook-server/routes/payment", () => ({
+  paymentHandler: jest.fn(),
+}))
+jest.mock("@services/fygaro/webhook-server/middleware/verify-signature", () => ({
+  verifyFygaroSignature: jest.fn(),
+}))
+jest.mock("@services/fygaro/webhook-server/middleware/enabled-guard", () => ({
+  fygaroEnabledGuard: jest.fn(),
+}))
+
+jest.mock("express", () => {
+  const express = jest.fn(() => mockApp)
+  ;(express as unknown as { json: unknown }).json = jest.fn(() => "json-middleware")
+  return { __esModule: true, default: express }
+})
+
+jest.mock("express-rate-limit", () => ({
+  __esModule: true,
+  default: jest.fn(() => "rate-limit-middleware"),
+}))
+
+import { startFygaroWebhookServer } from "@services/fygaro/webhook-server"
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  mockMessaging = {}
+})
+
+describe("startFygaroWebhookServer", () => {
+  it("pages when Firebase messaging is unavailable — otherwise every push is a silent no-op", () => {
+    // firebase.ts leaves `messaging` null when the credential is missing, and
+    // push-notifications.ts then returns `true` anyway (its own "FIXME: should
+    // return an error?"). Every layer above — including the best-effort wrapper
+    // on the money path — reads that as a delivered push, so a regressed secret
+    // mount in a chart bump would kill this whole feature for a release with no
+    // signal but one boot-time warn nobody watches.
+    mockMessaging = null
+
+    startFygaroWebhookServer()
+
+    expect(mockAlertBridge).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: "fygaro-webhook",
+        severity: "critical",
+        // Static: one broken deployment is one incident, not one per webhook.
+        dedupKey: "fygaro:push-unavailable",
+      }),
+    )
+  })
+
+  it("stays quiet when Firebase messaging loaded", () => {
+    startFygaroWebhookServer()
+
+    expect(mockAlertBridge).not.toHaveBeenCalled()
+  })
+
+  it("still serves /payment when messaging is unavailable", () => {
+    // The alert is a signal, not a refusal: the payments themselves must keep
+    // being recorded and credited even when nobody can be notified about them.
+    mockMessaging = null
+
+    startFygaroWebhookServer()
+
+    expect(mockApp.post).toHaveBeenCalledWith(
+      "/payment",
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+    )
+    expect(mockApp.listen).toHaveBeenCalledWith(4010, expect.any(Function))
+  })
+})

--- a/test/flash/unit/services/fygaro/webhook-server/payment.spec.ts
+++ b/test/flash/unit/services/fygaro/webhook-server/payment.spec.ts
@@ -634,6 +634,28 @@ describe("fygaro paymentHandler", () => {
         currency: "USD",
       })
     })
+    it("announces a landed credit ONCE, however many times Fygaro re-delivers", async () => {
+      // This block is deliberately re-enterable — the Completed row is the
+      // processed marker, and it is exactly what is missing after a promotion
+      // failure (money in the wallet, row still Fiat Received). Delivery 2
+      // replays the cached send and arrives here for a top-up already paid. A
+      // second "+$9.01 added" on a lock screen reads as a second charge, and
+      // unlike a stale status screen it cannot be walked back.
+      //
+      // Keyed on the TRANSACTION: an intent-keyed guard is undefined for every
+      // payment whose custom_reference is a bare username, which is the only
+      // shape in production while signed checkout is off.
+      mockLockIdempotencyKey.mockResolvedValue(new Error("already claimed"))
+      const res = makeRes()
+
+      await paymentHandler(makeReq(VALID_BODY), res)
+
+      expect(mockSendTopupNotification).not.toHaveBeenCalled()
+      // The credit itself is still replayed and the row still re-promoted —
+      // only the announcement is suppressed.
+      expect(mockCompleteFygaroTopup).toHaveBeenCalled()
+      expect(res.json).toHaveBeenCalledWith({ status: "success", credited: true })
+    })
 
     it("tells the customer an in-flight credit is on its way, not that it landed", async () => {
       // IBEX reporting IN_FLIGHT is the vendor's own documented 200, so this is

--- a/test/flash/unit/services/fygaro/webhook-server/payment.spec.ts
+++ b/test/flash/unit/services/fygaro/webhook-server/payment.spec.ts
@@ -1126,25 +1126,47 @@ describe("fygaro paymentHandler", () => {
       )
 
       it.each([
-        ["under-minimum", "2.00", "USD"],
+        ["under-minimum", "2.00", "USD", () => undefined],
         // A single Jamaican dollar: the cheapest possible way to put a message
         // on someone else's lock screen.
-        ["non-usd", "1.00", "JMD"],
-        ["over-limit", "500.01", "USD"],
+        ["non-usd", "1.00", "JMD", () => undefined],
+        // Free once the victim already sits at their cap: ANY amount trips it,
+        // so the attacker pays the smallest top-up the operator allows.
+        [
+          "daily-limit-exceeded",
+          "30.00",
+          "USD",
+          () => mockSumFygaroLast24h.mockResolvedValue(10000),
+        ],
+        // Likewise free — a level-0 account refuses every amount.
+        [
+          "no-daily-limit-for-level",
+          "10.00",
+          "USD",
+          () =>
+            mockFindByUsername.mockResolvedValue({
+              id: ACCOUNT_ID,
+              level: 0,
+              username: VALID_BODY.customReference,
+            }),
+        ],
       ])(
         "refuses to push at a PAYER-TYPED reference (%s) — that is a scam pretext, not a notification",
-        async (reason, amount, currency) => {
-          // On legacy unsigned clients `customReference` is free text the payer
-          // types (there is no intentId to verify it against), so an attacker
-          // can pay a trivial amount with a STRANGER's username on it. Without
-          // this gate the bank's own app then tells that stranger we are holding
-          // a payment of theirs — a ready-made pretext for a follow-up scam
-          // call, bought for a dollar. Unlike the `credited` push, whose abuse
-          // means paying the victim real money, nothing here makes it
-          // self-defeating.
+        async (reason, amount, currency, arrange) => {
+          // On unsigned clients `customReference` is free text the payer types
+          // (there is no intentId to verify it against), so an attacker can pay
+          // a trivial amount — or nothing above the victim's spent cap — with a
+          // STRANGER's username on it. Without this gate the bank's own app
+          // then tells that stranger we are holding a payment of theirs: a
+          // ready-made pretext for a follow-up scam call, bought for a dollar.
+          // Unlike the `credited` push, whose abuse means paying the victim
+          // real money, nothing about THESE reasons makes it self-defeating —
+          // which is exactly what separates them from `over-limit` below.
+          arrange()
           const res = makeRes()
 
-          // No `|intentId`: exactly what a pre-signed-checkout build sends.
+          // No `|intentId`: what a pre-signed-checkout build sends, and what
+          // EVERY build sends while `fygaro.checkout.enabled` is false.
           await paymentHandler(makeReq({ ...VALID_BODY, amount, currency }), res)
 
           // The payment is still recorded and ops is still paged — the money is
@@ -1161,6 +1183,37 @@ describe("fygaro paymentHandler", () => {
           expect(mockSendTopupNotification).not.toHaveBeenCalled()
         },
       )
+
+      it("still pushes an UNSIGNED over-limit refusal — forging that one costs the attacker more than the limit", async () => {
+        // The verified-reference gate is a PRICE argument, so it must not
+        // extend to the expensive reason. `over-limit` trips only ABOVE the
+        // operator's $500 single-payment limit, so forging it means paying
+        // >$500 that ops then hand-credits TO THE VICTIM — the same
+        // self-defeating economics that leaves the `credited` push ungated.
+        //
+        // And it is the reason a real customer is most likely to hit while
+        // `fygaro.checkout.enabled` is false — its default, and a Fygaro
+        // Pro-plan dependency — when no client can produce a signed reference
+        // at all. Gate this one too and the entire refusal half of this feature
+        // is dead in the default configuration.
+        const res = makeRes()
+
+        // No `|intentId`, exactly as above.
+        await paymentHandler(makeReq({ ...VALID_BODY, amount: "500.01" }), res)
+
+        expect(mockNotifyOpsEvent).toHaveBeenCalledWith(
+          expect.objectContaining({
+            meta: expect.objectContaining({ reason: "over-limit" }),
+          }),
+        )
+        expect(mockSendTopupNotification).toHaveBeenCalledWith({
+          accountId: ACCOUNT_ID,
+          outcome: "heldForReview",
+          // The GROSS captured, which is what their card statement shows.
+          amountCents: 50001,
+          currency: "USD",
+        })
+      })
     })
 
     it("returns 500 for settings-unavailable so Fygaro retries (transient), without acking or spamming the feed", async () => {

--- a/test/flash/unit/services/fygaro/webhook-server/payment.spec.ts
+++ b/test/flash/unit/services/fygaro/webhook-server/payment.spec.ts
@@ -605,13 +605,33 @@ describe("fygaro paymentHandler", () => {
       })
     })
 
-    it("stays silent on a PENDING credit — the money has not provably landed", async () => {
+    it("tells the customer an in-flight credit is on its way, not that it landed", async () => {
+      // IBEX reporting IN_FLIGHT is the vendor's own documented 200, so this is
+      // routine. `credited` ("has been added to your wallet") would send them to
+      // a balance that has not moved; silence — which is what this branch did —
+      // leaves the customer this whole feature exists for with nothing.
+      mockCreditFygaroTopup.mockResolvedValue({
+        status: "pending",
+        walletId: "wallet-1",
+      })
+      const res = makeRes()
+
+      await paymentHandler(makeReq(VALID_BODY), res)
+
+      expect(mockSendTopupNotification).toHaveBeenCalledWith(
+        expect.objectContaining({ outcome: "crediting" }),
+      )
+    })
+
+    it("does not claim a LANDED credit on a PENDING send", async () => {
       // `creditFygaroTopup` returns `pending` when the intraledger send came
       // back Pending: "money has PROBABLY left the treasury: report credited,
-      // never re-pay". That is a deliberately weaker claim than the push's
-      // "X USD has been added to your wallet". Sending it here walks the
-      // customer to an unchanged balance and files the support ticket this
-      // notification exists to prevent.
+      // never re-pay". That is a deliberately weaker claim than the credited
+      // push's "X has been added to your wallet", which would walk the customer
+      // to an unchanged balance. But silence is not the answer either — IBEX
+      // reporting IN_FLIGHT is the vendor's documented 200, so this is routine,
+      // and saying nothing strands the customer this feature exists for. It
+      // gets its own phrase instead.
       mockCreditFygaroTopup.mockResolvedValue({ walletId: WALLET_ID, status: "pending" })
       const res = makeRes()
 
@@ -629,7 +649,12 @@ describe("fygaro paymentHandler", () => {
           meta: expect.objectContaining({ creditStatus: "pending" }),
         }),
       )
-      expect(mockSendTopupNotification).not.toHaveBeenCalled()
+      expect(mockSendTopupNotification).toHaveBeenCalledWith(
+        expect.objectContaining({ outcome: "crediting" }),
+      )
+      expect(mockSendTopupNotification).not.toHaveBeenCalledWith(
+        expect.objectContaining({ outcome: "credited" }),
+      )
     })
 
     it("sends the credited push only AFTER the authorisation is redeemed", async () => {

--- a/test/flash/unit/services/fygaro/webhook-server/payment.spec.ts
+++ b/test/flash/unit/services/fygaro/webhook-server/payment.spec.ts
@@ -605,6 +605,33 @@ describe("fygaro paymentHandler", () => {
       })
     })
 
+    it("stays silent on a PENDING credit — the money has not provably landed", async () => {
+      // `creditFygaroTopup` returns `pending` when the intraledger send came
+      // back Pending: "money has PROBABLY left the treasury: report credited,
+      // never re-pay". That is a deliberately weaker claim than the push's
+      // "X USD has been added to your wallet". Sending it here walks the
+      // customer to an unchanged balance and files the support ticket this
+      // notification exists to prevent.
+      mockCreditFygaroTopup.mockResolvedValue({ walletId: WALLET_ID, status: "pending" })
+      const res = makeRes()
+
+      await paymentHandler(makeReq(VALID_BODY), res)
+
+      // Still credited-and-done as far as idempotency goes: the row is promoted
+      // and the response acks, so Fygaro must not retry and re-pay.
+      expect(mockCompleteFygaroTopup).toHaveBeenCalledTimes(1)
+      expect(res.json).toHaveBeenCalledWith({ status: "success", credited: true })
+      // ...and ops can still see it, so it is not lost — just not asserted to
+      // the customer as a completed credit.
+      expect(mockNotifyOpsEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          phase: "succeeded",
+          meta: expect.objectContaining({ creditStatus: "pending" }),
+        }),
+      )
+      expect(mockSendTopupNotification).not.toHaveBeenCalled()
+    })
+
     it("sends the credited push only AFTER the authorisation is redeemed", async () => {
       // A pod recycle during the FCM round trip must not leave the intent
       // unconsumed: the ERPNext row already counts this payment towards the
@@ -952,12 +979,24 @@ describe("fygaro paymentHandler", () => {
         ],
       ])(
         "tells the customer their captured payment is being finished by hand (%s)",
-        async (_reason, mutateBody, arrange, expected) => {
+        async (reason, mutateBody, arrange, expected) => {
           arrange()
           const res = makeRes()
 
           await paymentHandler(makeReq(mutateBody(VALID_BODY)), res)
 
+          // Pin the gate this case actually tripped, the way the silent block
+          // below does. Without it the case name is decoration: nudge
+          // DEFAULT_SETTINGS.minimumTopup past autoCreditLimit and the
+          // "under-minimum" row starts refusing on `over-limit` instead, with
+          // byte-identical push args — the test stays green under a name that
+          // has become a lie, and the allowlist it is guarding is no longer
+          // covered where it claims to be.
+          expect(mockNotifyOpsEvent).toHaveBeenCalledWith(
+            expect.objectContaining({
+              meta: expect.objectContaining({ reason }),
+            }),
+          )
           // The GROSS captured, which is what their card statement shows.
           expect(mockSendTopupNotification).toHaveBeenCalledWith({
             accountId: ACCOUNT_ID,

--- a/test/flash/unit/services/fygaro/webhook-server/payment.spec.ts
+++ b/test/flash/unit/services/fygaro/webhook-server/payment.spec.ts
@@ -237,6 +237,10 @@ describe("fygaro paymentHandler", () => {
     expect(mockNotifyOpsEvent).toHaveBeenCalledWith(
       expect.objectContaining({ phase: "fygaro-recorded", status: "pending" }),
     )
+    // `credit-disabled` is the deploy-level master gate: it records without
+    // crediting BY DESIGN. Pushing "we're completing it manually" here would
+    // notify every paying customer for the whole of a rollout.
+    expect(mockSendTopupNotification).not.toHaveBeenCalled()
     expect(res.status).toHaveBeenCalledWith(200)
     expect(res.json).toHaveBeenCalledWith({ status: "recorded", credited: false })
   })
@@ -589,13 +593,71 @@ describe("fygaro paymentHandler", () => {
 
       await paymentHandler(makeReq(VALID_BODY), res)
 
-      expect(mockSendTopupNotification).toHaveBeenCalledWith(
-        expect.objectContaining({ outcome: "credited" }),
-      )
-      const [args] = mockSendTopupNotification.mock.calls[0]
       // The NET, not the gross: naming what they paid overstates the balance
-      // change by the fees.
-      expect(args.amountCents).toBeLessThan(Math.round(Number(VALID_BODY.amount) * 100))
+      // change by the fees. $10.00 gross -> $0.79 processor + $0.20 flash ->
+      // 901¢ — the exact number the credit itself is asserted against above, so
+      // "some number smaller than gross" would not pin it.
+      expect(mockSendTopupNotification).toHaveBeenCalledWith({
+        accountId: ACCOUNT_ID,
+        outcome: "credited",
+        amountCents: 901,
+        currency: "USD",
+      })
+    })
+
+    it("sends the credited push only AFTER the authorisation is redeemed", async () => {
+      // A pod recycle during the FCM round trip must not leave the intent
+      // unconsumed: the ERPNext row already counts this payment towards the
+      // daily cap, so a surviving hold double-counts it and refuses the
+      // customer's next top-up with `daily-limit-exceeded`.
+      const SIGNED = {
+        ...VALID_BODY,
+        customReference: `${VALID_BODY.customReference}|8c1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f`,
+      }
+      mockReadIntent.mockResolvedValue({
+        found: true,
+        intent: {
+          intentId: "8c1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f",
+          accountId: ACCOUNT_ID as string,
+          username: VALID_BODY.customReference,
+          amountCents: 1000,
+          currency: "USD",
+          createdAtMs: 1_700_000_000_000,
+        },
+      })
+      const res = makeRes()
+
+      await paymentHandler(makeReq(SIGNED), res)
+
+      expect(res.json).toHaveBeenCalledWith({ status: "success", credited: true })
+      expect(mockConsumeIntent).toHaveBeenCalledTimes(1)
+      expect(mockSendTopupNotification).toHaveBeenCalledTimes(1)
+      expect(mockSendTopupNotification.mock.invocationCallOrder[0]).toBeGreaterThan(
+        mockConsumeIntent.mock.invocationCallOrder[0],
+      )
+    })
+
+    it("tells the customer when the money was captured and the credit FAILED", async () => {
+      // The outcome this notification exists for. Ops gets a CRITICAL asking
+      // them to credit it by hand and the response is a 200, so Fygaro stops
+      // retrying — without a push the customer is silent forever, while someone
+      // refused by the far more benign `under-minimum` does get told.
+      mockCreditFygaroTopup.mockResolvedValue(
+        new FygaroCreditError("insufficient-treasury-float", "insufficient balance"),
+      )
+      const res = makeRes()
+
+      await paymentHandler(makeReq(VALID_BODY), res)
+
+      expect(res.json).toHaveBeenCalledWith({ status: "recorded", credited: false })
+      // GROSS ($10.00), not the net that never landed: the customer is looking
+      // at what their card was charged.
+      expect(mockSendTopupNotification).toHaveBeenCalledWith({
+        accountId: ACCOUNT_ID,
+        outcome: "heldForReview",
+        amountCents: 1000,
+        currency: "USD",
+      })
     })
 
     it("credits with a discounted flash fee and promotes the discounted breakdown", async () => {
@@ -844,6 +906,126 @@ describe("fygaro paymentHandler", () => {
       },
     )
 
+    // "We have your $X payment and are completing it manually. We'll let you
+    // know when it lands" is a COMMITMENT that a human finishes this payment.
+    // It must go out only for the reasons where that is the real outcome — an
+    // exclusion list of one silently hands the same promise to every gate added
+    // later, including ones where nothing is ever going to land.
+    describe("the held-for-review push is an allowlist, not a denylist", () => {
+      it.each([
+        [
+          "over-limit",
+          (body: Record<string, unknown>) => ({ ...body, amount: "500.01" }),
+          () => undefined,
+          { amountCents: 50001, currency: "USD" },
+        ],
+        [
+          "under-minimum",
+          (body: Record<string, unknown>) => ({ ...body, amount: "2.00" }),
+          () => undefined,
+          { amountCents: 200, currency: "USD" },
+        ],
+        [
+          "daily-limit-exceeded",
+          (body: Record<string, unknown>) => ({ ...body, amount: "30.00" }),
+          () => mockSumFygaroLast24h.mockResolvedValue(10000),
+          { amountCents: 3000, currency: "USD" },
+        ],
+        [
+          "no-daily-limit-for-level",
+          (body: Record<string, unknown>) => body,
+          () => mockFindByUsername.mockResolvedValue({ id: ACCOUNT_ID, level: 0 }),
+          { amountCents: 1000, currency: "USD" },
+        ],
+        [
+          // The push names the payment's REAL currency. Assuming USD rendered a
+          // J$6,000 payment as "$6000.00" — a ~150x overstatement in the one
+          // message whose job is telling the customer what we are holding.
+          "non-usd",
+          (body: Record<string, unknown>) => ({
+            ...body,
+            amount: "6000.00",
+            currency: "JMD",
+          }),
+          () => undefined,
+          { amountCents: 600000, currency: "JMD" },
+        ],
+      ])(
+        "tells the customer their captured payment is being finished by hand (%s)",
+        async (_reason, mutateBody, arrange, expected) => {
+          arrange()
+          const res = makeRes()
+
+          await paymentHandler(makeReq(mutateBody(VALID_BODY)), res)
+
+          // The GROSS captured, which is what their card statement shows.
+          expect(mockSendTopupNotification).toHaveBeenCalledWith({
+            accountId: ACCOUNT_ID,
+            outcome: "heldForReview",
+            ...expected,
+          })
+        },
+      )
+
+      it.each([
+        [
+          // The operator's ERPNext runtime kill switch — the one ops flips
+          // during an incident. Pushing here mass-notifies every paying
+          // customer exactly when nobody wants more traffic.
+          "auto-credit-disabled",
+          (body: Record<string, unknown>) => body,
+          () =>
+            mockGetFygaroSettings.mockResolvedValue({
+              ...DEFAULT_SETTINGS,
+              autoCreditEnabled: false,
+            }),
+        ],
+        [
+          // Fees already meet or exceed the gross: nothing will ever land, so
+          // promising that it will is simply untrue.
+          "non-positive-net",
+          (body: Record<string, unknown>) => ({ ...body, amount: "0.10" }),
+          () => undefined,
+        ],
+        [
+          // The payment does not match the checkout we signed. That is a refund
+          // or an escalation, not a hand-credit.
+          "intent-mismatch",
+          (body: Record<string, unknown>) => ({
+            ...body,
+            customReference: `${VALID_BODY.customReference}|1a2b3c4d-5e6f-4a1b-8c2d-3e4f5a6b7c8d`,
+          }),
+          () =>
+            mockReadIntent.mockResolvedValue({
+              found: true,
+              intent: {
+                intentId: "1a2b3c4d-5e6f-4a1b-8c2d-3e4f5a6b7c8d",
+                accountId: ACCOUNT_ID as string,
+                username: VALID_BODY.customReference,
+                amountCents: 2000,
+                currency: "USD",
+                createdAtMs: 1_700_000_000_000,
+              },
+            }),
+        ],
+      ])(
+        "stays silent on %s — no hand-credit is coming",
+        async (reason, mutateBody, arrange) => {
+          arrange()
+          const res = makeRes()
+
+          await paymentHandler(makeReq(mutateBody(VALID_BODY)), res)
+
+          // The refusal still happened and ops was still paged...
+          expect(mockNotifyOpsEvent).toHaveBeenCalledWith(
+            expect.objectContaining({ meta: expect.objectContaining({ reason }) }),
+          )
+          // ...the customer just is not promised something that will not happen.
+          expect(mockSendTopupNotification).not.toHaveBeenCalled()
+        },
+      )
+    })
+
     it("returns 500 for settings-unavailable so Fygaro retries (transient), without acking or spamming the feed", async () => {
       // A brief ERPNext blip caches settings as undefined for up to 60s. That
       // must NOT permanently downgrade the payment to manual credit: return 500
@@ -868,6 +1050,9 @@ describe("fygaro paymentHandler", () => {
         }),
       )
       expect(mockNotifyOpsEvent).not.toHaveBeenCalled()
+      // Nothing is terminal yet — a retry seconds later credits cleanly, so
+      // telling the customer it needs manual work would be wrong and unretractable.
+      expect(mockSendTopupNotification).not.toHaveBeenCalled()
       expect(res.status).toHaveBeenCalledWith(500)
     })
 
@@ -890,6 +1075,7 @@ describe("fygaro paymentHandler", () => {
         }),
       )
       expect(mockNotifyOpsEvent).not.toHaveBeenCalled()
+      expect(mockSendTopupNotification).not.toHaveBeenCalled()
       expect(res.status).toHaveBeenCalledWith(500)
     })
 

--- a/test/flash/unit/services/fygaro/webhook-server/payment.spec.ts
+++ b/test/flash/unit/services/fygaro/webhook-server/payment.spec.ts
@@ -58,6 +58,12 @@ jest.mock("@services/alerts", () => ({
   generateDedupKey: jest.requireActual("@services/alerts/dedup-key").generateDedupKey,
 }))
 
+jest.mock("@app/fygaro/send-topup-notification", () => ({
+  sendFygaroTopupNotificationBestEffort: (...args: unknown[]) =>
+    mockSendTopupNotification(...args),
+}))
+const mockSendTopupNotification = jest.fn()
+
 jest.mock("@services/alerts/ops-events", () => ({
   notifyOpsEvent: (...args: unknown[]) => mockNotifyOpsEvent(...args),
 }))
@@ -573,6 +579,23 @@ describe("fygaro paymentHandler", () => {
         username: VALID_BODY.customReference,
         flow: "topup",
       })
+    })
+
+    it("notifies the customer with the NET once the credit lands", async () => {
+      // The app promises "we'll let you know as soon as it lands" and then
+      // stops polling after a minute. Without this the promise is kept by
+      // nothing, and a credit that arrives on a Fygaro retry is never announced.
+      const res = makeRes()
+
+      await paymentHandler(makeReq(VALID_BODY), res)
+
+      expect(mockSendTopupNotification).toHaveBeenCalledWith(
+        expect.objectContaining({ outcome: "credited" }),
+      )
+      const [args] = mockSendTopupNotification.mock.calls[0]
+      // The NET, not the gross: naming what they paid overstates the balance
+      // change by the fees.
+      expect(args.amountCents).toBeLessThan(Math.round(Number(VALID_BODY.amount) * 100))
     })
 
     it("credits with a discounted flash fee and promotes the discounted breakdown", async () => {

--- a/test/flash/unit/services/fygaro/webhook-server/payment.spec.ts
+++ b/test/flash/unit/services/fygaro/webhook-server/payment.spec.ts
@@ -165,6 +165,36 @@ const makeRes = (): Response => {
 const makeReq = (body: Record<string, unknown>): Request =>
   ({ body }) as unknown as Request
 
+const SIGNED_INTENT_ID = "8c1d2e3f-4a5b-6c7d-8e9f-0a1b2c3d4e5f"
+
+/**
+ * Turn a payload into one carrying a SERVER-SIGNED reference, and stand up the
+ * authorisation it points at.
+ *
+ * The distinction matters wherever the handler acts on the identity in
+ * `customReference` rather than just recording it: on legacy unsigned clients
+ * that field is free text the PAYER types, while `username|intentId` can only
+ * come from an authorizeFygaroTopup call Flash made for that account. Pass an
+ * `authorizedCents` that differs from what is paid to produce a mismatch.
+ */
+const signedBody = (
+  body: Record<string, unknown>,
+  authorizedCents: number,
+): Record<string, unknown> => {
+  mockReadIntent.mockResolvedValue({
+    found: true,
+    intent: {
+      intentId: SIGNED_INTENT_ID,
+      accountId: ACCOUNT_ID as string,
+      username: VALID_BODY.customReference,
+      amountCents: authorizedCents,
+      currency: String(body.currency ?? "USD"),
+      createdAtMs: 1_700_000_000_000,
+    },
+  })
+  return { ...body, customReference: `${body.customReference}|${SIGNED_INTENT_ID}` }
+}
+
 beforeEach(() => {
   jest.clearAllMocks()
   mockFygaroConfig.credit = { enabled: false }
@@ -958,11 +988,12 @@ describe("fygaro paymentHandler", () => {
       },
     )
 
-    // "We have your $X payment and are completing it manually. We'll let you
-    // know when it lands" is a COMMITMENT that a human finishes this payment.
-    // It must go out only for the reasons where that is the real outcome — an
-    // exclusion list of one silently hands the same promise to every gate added
-    // later, including ones where nothing is ever going to land.
+    // "We have your $X payment and are completing it manually" is a COMMITMENT
+    // that a human finishes this payment. It must go out only for the reasons
+    // where that is the real outcome — an exclusion list of one silently hands
+    // the same promise to every gate added later, including ones where nothing
+    // is ever going to land — and only to an account we can PROVE asked for the
+    // checkout.
     describe("the held-for-review push is an allowlist, not a denylist", () => {
       it.each([
         [
@@ -986,7 +1017,12 @@ describe("fygaro paymentHandler", () => {
         [
           "no-daily-limit-for-level",
           (body: Record<string, unknown>) => body,
-          () => mockFindByUsername.mockResolvedValue({ id: ACCOUNT_ID, level: 0 }),
+          () =>
+            mockFindByUsername.mockResolvedValue({
+              id: ACCOUNT_ID,
+              level: 0,
+              username: VALID_BODY.customReference,
+            }),
           { amountCents: 1000, currency: "USD" },
         ],
         [
@@ -1008,7 +1044,12 @@ describe("fygaro paymentHandler", () => {
           arrange()
           const res = makeRes()
 
-          await paymentHandler(makeReq(mutateBody(VALID_BODY)), res)
+          // Signed: the refusal push only goes to a reference Flash itself
+          // minted (see the unverified-reference case below).
+          await paymentHandler(
+            makeReq(signedBody(mutateBody(VALID_BODY), expected.amountCents)),
+            res,
+          )
 
           // Pin the gate this case actually tripped, the way the silent block
           // below does. Without it the case name is decoration: nudge
@@ -1038,6 +1079,7 @@ describe("fygaro paymentHandler", () => {
           // customer exactly when nobody wants more traffic.
           "auto-credit-disabled",
           (body: Record<string, unknown>) => body,
+          1000,
           () =>
             mockGetFygaroSettings.mockResolvedValue({
               ...DEFAULT_SETTINGS,
@@ -1049,42 +1091,73 @@ describe("fygaro paymentHandler", () => {
           // promising that it will is simply untrue.
           "non-positive-net",
           (body: Record<string, unknown>) => ({ ...body, amount: "0.10" }),
+          10,
           () => undefined,
         ],
         [
           // The payment does not match the checkout we signed. That is a refund
-          // or an escalation, not a hand-credit.
+          // or an escalation, not a hand-credit. Signed for $20, paid $10.
           "intent-mismatch",
-          (body: Record<string, unknown>) => ({
-            ...body,
-            customReference: `${VALID_BODY.customReference}|1a2b3c4d-5e6f-4a1b-8c2d-3e4f5a6b7c8d`,
-          }),
-          () =>
-            mockReadIntent.mockResolvedValue({
-              found: true,
-              intent: {
-                intentId: "1a2b3c4d-5e6f-4a1b-8c2d-3e4f5a6b7c8d",
-                accountId: ACCOUNT_ID as string,
-                username: VALID_BODY.customReference,
-                amountCents: 2000,
-                currency: "USD",
-                createdAtMs: 1_700_000_000_000,
-              },
-            }),
+          (body: Record<string, unknown>) => body,
+          2000,
+          () => undefined,
         ],
       ])(
         "stays silent on %s — no hand-credit is coming",
-        async (reason, mutateBody, arrange) => {
+        async (reason, mutateBody, authorizedCents, arrange) => {
           arrange()
           const res = makeRes()
 
-          await paymentHandler(makeReq(mutateBody(VALID_BODY)), res)
+          // Signed too, so these cases keep testing the ALLOWLIST rather than
+          // passing for free on the unverified-reference gate. Flip any of
+          // these three to `true` in REFUSAL_NOTIFIES_CUSTOMER and this fails.
+          await paymentHandler(
+            makeReq(signedBody(mutateBody(VALID_BODY), authorizedCents)),
+            res,
+          )
 
           // The refusal still happened and ops was still paged...
           expect(mockNotifyOpsEvent).toHaveBeenCalledWith(
             expect.objectContaining({ meta: expect.objectContaining({ reason }) }),
           )
           // ...the customer just is not promised something that will not happen.
+          expect(mockSendTopupNotification).not.toHaveBeenCalled()
+        },
+      )
+
+      it.each([
+        ["under-minimum", "2.00", "USD"],
+        // A single Jamaican dollar: the cheapest possible way to put a message
+        // on someone else's lock screen.
+        ["non-usd", "1.00", "JMD"],
+        ["over-limit", "500.01", "USD"],
+      ])(
+        "refuses to push at a PAYER-TYPED reference (%s) — that is a scam pretext, not a notification",
+        async (reason, amount, currency) => {
+          // On legacy unsigned clients `customReference` is free text the payer
+          // types (there is no intentId to verify it against), so an attacker
+          // can pay a trivial amount with a STRANGER's username on it. Without
+          // this gate the bank's own app then tells that stranger we are holding
+          // a payment of theirs — a ready-made pretext for a follow-up scam
+          // call, bought for a dollar. Unlike the `credited` push, whose abuse
+          // means paying the victim real money, nothing here makes it
+          // self-defeating.
+          const res = makeRes()
+
+          // No `|intentId`: exactly what a pre-signed-checkout build sends.
+          await paymentHandler(makeReq({ ...VALID_BODY, amount, currency }), res)
+
+          // The payment is still recorded and ops is still paged — the money is
+          // real, it is only the identity claim that is not.
+          expect(mockNotifyOpsEvent).toHaveBeenCalledWith(
+            expect.objectContaining({ meta: expect.objectContaining({ reason }) }),
+          )
+          expect(mockAlertBridge).toHaveBeenCalledWith(
+            expect.objectContaining({
+              context: expect.objectContaining({ reason }),
+            }),
+          )
+          expect(res.json).toHaveBeenCalledWith({ status: "recorded", credited: false })
           expect(mockSendTopupNotification).not.toHaveBeenCalled()
         },
       )

--- a/typos.toml
+++ b/typos.toml
@@ -1,5 +1,11 @@
 files.extend-exclude = [
   "dev",
+  # Spanish copy, checked against an English dictionary. "momento" (a moment)
+  # is read as a misspelling of "memento", and every Spanish word added later
+  # is the same coin flip. A per-word allowlist would be worse than this: it is
+  # global, so it would also stop flagging those words where they ARE typos, in
+  # the English files. en.json stays checked.
+  "src/config/locales/es.json",
   "src/domain/users/languages.ts",
   "src/services/loopd/protos",
   "docs/postman-collection/galoy_graphql_main_api.postman_collection.json",


### PR DESCRIPTION
Makes an app promise true. Pairs with **flash-mobile#700**.

## Why

After a card payment, the app now says: *"We've received your payment and are crediting your wallet — we'll let you know as soon as it lands."* Then it stops polling after a minute. **Nothing kept that promise.**

A credit can easily outlive the screen: the transient webhook paths deliberately return 500 so Fygaro retries, which can stretch to minutes. Without this, the customer closes the app and finds out whenever they next happen to look.

## Every outcome notifies

Sending only on success would keep the promise exactly when it costs nothing, and break it in the case that actually matters — the customer whose money was captured and **not** credited, left on a screen that said we'd be in touch.

- **credited** → "Top-up complete / \$56.52 has been added to your wallet."
- **crediting** (IBEX reported `IN_FLIGHT` — the vendor's own documented 200) → its own phrase, deliberately promising no follow-up message, because nothing re-notifies when an in-flight send settles.
- **heldForReview** → "Top-up needs a moment / We have your \$60.00 payment and are completing it manually. We'll let you know when it lands."

The held wording is deliberately not alarming and not a dead end: ops is already paged by the same gate that produced the outcome, and most of these get hand-credited.

`credit-disabled` is excluded — it's the silent deploy-level master gate that records without crediting by design, and pushing for it would notify every customer during a rollout.

## Flag dependencies — read before merging

Two config flags decide how much of this PR is actually live. Neither is visible from the diff, so they are spelled out here.

**`fygaro.credit.enabled`** — gates the *credit* half. **`true` in PROD**, `false` in TEST and in the shared template (`lnflash/deployments`). With it off no push is reachable at all: the gate answers `credit-disabled`, which stays silent by design, and the credit path is never entered. The boot-time "Firebase messaging unavailable" CRITICAL is gated on this flag for that reason — otherwise it pages, on every pod restart and rolling deploy with no auto-resolve, about pushes that could not fire regardless.

**`fygaro.checkout.enabled`** — gates the *refusal* half. Defaults to `false`, requires a Fygaro Pro-or-above plan for JWT links, and is currently set **nowhere** in `lnflash/deployments` — so it is `false` in both TEST and PROD today. With it off, `authorizeFygaroTopup` returns `checkout-disabled` and every client builds an unsigned `customReference`, which the payer can type freely. Refusal pushes at an unverified reference are a scam pretext bought for a dollar, so the cheap reasons (`non-usd`, `under-minimum`, and both daily-limit gates — free once the victim already sits at their cap) require a server-signed reference and therefore **do not fire today**.

`over-limit` is the deliberate exception, and the reason this is a per-reason table (`REFUSAL_NEEDS_VERIFIED_REFERENCE`) rather than one blanket `authorizedIntent &&` check: it trips only *above* the operator's single-payment auto-credit limit, so forging it costs the attacker more than that limit — real money that ops then hand-credits **to the victim**. That is the same self-defeating economics that leaves the `credited` push ungated. It fires unsigned, which is what keeps the refusal half of this PR alive in the configuration prod is actually running.

**To light up the remaining four reasons**, turn on `fygaro.checkout.enabled` (with `buttonUrl` + `keyId`, and the Fygaro plan behind it) and ship the signed-checkout app build. Until then, expect only `over-limit` refusals to reach customers.

## Details worth a look

**The credited push names the NET, not the gross.** \$60 paid, \$56.52 credited. Naming what they paid overstates the balance change by the fees and invites a support ticket about the missing \$3.48. `crediting` names the NET too; `heldForReview` names the GROSS, because nothing has been credited to net against and the gross is what their card statement shows.

**Awaited, not fired-and-forgotten.** Matches `sendBridgeDepositNotificationBestEffort`'s call site. The helper swallows every failure internally, so awaiting cannot fail a credit — and *not* awaiting leaves a dangling promise a recycled pod can drop, losing precisely the notification we told the customer to expect.

**Stale device tokens are pruned** on `DeviceTokensNotRegistered`, same as the Bridge path, so the next notification isn't sent into the same void.

**One entry point per module.** Both `send-topup-notification.ts` and `send-deposit-notification.ts` export only their best-effort wrapper. There is deliberately no error-returning variant: every caller is on a money path where the payment has already been captured, so a notification failure must never become the payment's failure.

Strings added for `en` and `es`.

## Rebase note

This touches two call sites in the Fygaro webhook that **flash#487** also edits. The notification module itself is new and conflict-free; expect a small conflict at the two insertion points depending on merge order.

## Tests

196 suites / 1965 green. New coverage: the net-not-gross wording, that a refusal notifies at all, locale selection, and that the best-effort wrapper never throws — including when the push fails outright and when the account is unreadable — plus webhook-level tests that the credit path actually calls it, since a notification nothing invokes is the failure mode here.

The push gates are pinned from both sides: an unsigned \$500.01 pushes while an unsigned J\$1 does not (both verified to fail against the previous blanket gate), the silent reasons are tested *signed* so they keep testing the allowlist rather than passing for free, and the boot alert is covered for credit-disabled-with-null-messaging as well as the paging case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NEoz7nBtdtsHyuYG5wNPQV
