### PR TITLE
fix(fygaro): first_seen_at has been 1970-01-21 on every row

### DIFF
--- a/src/services/fygaro/webhook-server/created-at.ts
+++ b/src/services/fygaro/webhook-server/created-at.ts
@@ -22,23 +22,39 @@
  *   switches to date strings — would coerce to 2026 and be read as epoch
  *   seconds, landing on 1970-01-01T00:33:46Z: this same bug, wearing a
  *   different payload.
- * - Zero in any shape (`0`, `"0"`) is treated as ABSENT, not as the epoch
- *   instant. A provider sending 0 for an unset timestamp means "no value", and
- *   honouring it literally would put 1970 back in the column this function
- *   exists to keep out of it.
+ * - Anything that coerces to a non-positive number (`0`, `"0"`, `-1`, `"-1"`)
+ *   is treated as ABSENT. Both are common "unset timestamp" sentinels, and
+ *   Fygaro is a card processor that did not exist before 1970, so a negative
+ *   value here is garbage by construction. Honouring either literally would put
+ *   a 1969/1970 date back in the column this function exists to keep it out of.
  *
- * Anything else non-numeric is treated as a date string, and anything
- * unparseable returns undefined so the column stays empty rather than holding a
- * fiction.
+ * Anything else non-numeric is treated as a date string. A naive datetime with
+ * no zone (`"2026-08-17 15:00:00"`, the shape Frappe itself emits) is pinned to
+ * UTC before parsing — `new Date` reads that form as HOST-LOCAL time, which
+ * would shift the answer by the container's UTC offset and, in the site's
+ * configured `America/Adak`, onto the wrong calendar day. Anything unparseable
+ * returns undefined so the column stays empty rather than holding a fiction.
  */
 const EPOCH_SECONDS_CEILING = 1e11
 
 /**
- * What a quoted epoch timestamp looks like: all digits, and enough of them that
- * it cannot be confused with a year or a compact date. 9 digits is 1973 in
- * seconds; every real timestamp from here on is longer.
+ * What a quoted epoch timestamp looks like: digits, and enough of them that it
+ * cannot be confused with a year or a compact date. 9 digits is 1973 in
+ * seconds; every real timestamp from here on is longer. A fractional part is
+ * allowed because that is what a provider emits when it stringifies a float
+ * clock (`"1786940395.75"`) — the number form of that value is already read
+ * correctly, and the string form must not silently blank the column. No sign is
+ * allowed: `-` is handled as "unset" below, and a leading `+` is accepted only
+ * because `Number` accepts it.
  */
-const QUOTED_EPOCH = /^-?\d{9,}$/
+const QUOTED_EPOCH = /^\+?\d{9,}(\.\d+)?$/
+
+/**
+ * A datetime with no zone designator — `"2026-08-17 15:00:00"` or the `T`
+ * form. `new Date` reads these as host-local time, so they are pinned to UTC
+ * explicitly rather than picking up the container's offset.
+ */
+const NAIVE_DATETIME = /^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}(:\d{2}(\.\d+)?)?$/
 
 export const fygaroCreatedAtToIso = (
   createdAt: string | number | undefined | null,
@@ -52,17 +68,23 @@ export const fygaroCreatedAtToIso = (
   if (typeof createdAt === "string" && trimmed === "") return undefined
 
   const numeric = typeof createdAt === "number" ? createdAt : Number(trimmed)
-  // Zero means "unset" from any provider that sends it; an operator reading
-  // 1970-01-01 in first_seen_at cannot tell that from a real timestamp.
-  if (numeric === 0) return undefined
+  // A timestamp is a POSITIVE number. Zero and negatives are both stock "unset"
+  // sentinels, and an operator reading 1970-01-01 (or 1969-12-31) in
+  // first_seen_at cannot tell either from a real timestamp. NaN deliberately
+  // falls through this comparison — that is a date string like "2026-08-17",
+  // which the date branch below handles.
+  if (numeric <= 0) return undefined
 
   const looksLikeEpoch = typeof createdAt === "number" || QUOTED_EPOCH.test(trimmed)
   if (looksLikeEpoch && Number.isFinite(numeric)) {
-    const ms = Math.abs(numeric) < EPOCH_SECONDS_CEILING ? numeric * 1000 : numeric
+    const ms = numeric < EPOCH_SECONDS_CEILING ? numeric * 1000 : numeric
     const fromEpoch = new Date(ms)
     return Number.isNaN(fromEpoch.getTime()) ? undefined : fromEpoch.toISOString()
   }
 
-  const parsed = new Date(trimmed || String(createdAt))
+  const source = trimmed || String(createdAt)
+  const parsed = new Date(
+    NAIVE_DATETIME.test(source) ? `${source.replace(" ", "T")}Z` : source,
+  )
   return Number.isNaN(parsed.getTime()) ? undefined : parsed.toISOString()
 }

--- a/src/services/fygaro/webhook-server/created-at.ts
+++ b/src/services/fygaro/webhook-server/created-at.ts
@@ -28,14 +28,35 @@
  *   value here is garbage by construction. Honouring either literally would put
  *   a 1969/1970 date back in the column this function exists to keep it out of.
  *
- * Anything else non-numeric is treated as a date string. A naive datetime with
- * no zone (`"2026-08-17 15:00:00"`, the shape Frappe itself emits) is pinned to
- * UTC before parsing — `new Date` reads that form as HOST-LOCAL time, which
- * would shift the answer by the container's UTC offset and, in the site's
- * configured `America/Adak`, onto the wrong calendar day. Anything unparsable
- * returns undefined so the column stays empty rather than holding a fiction.
+ * Anything else non-numeric is treated as a date string, and ONLY ISO-8601 is
+ * accepted. A naive datetime with no zone (`"2026-08-17 15:00:00"`, the shape
+ * Frappe itself emits) is pinned to UTC before parsing — `new Date` reads that
+ * form as HOST-LOCAL time, which would shift the answer by the container's UTC
+ * offset and, in the site's configured `America/Adak`, onto the wrong calendar
+ * day. Everything else returns undefined so the column stays empty rather than
+ * holding a fiction.
+ *
+ * That ISO restriction is the difference between "pinned to UTC" being true and
+ * being true of one shape. `new Date`'s legacy non-ISO parser is
+ * implementation-defined and host-local for zoneless input, so
+ * `"Mon, 17 Aug 2026 15:00:00"` reads as 15:00Z under TZ=UTC and as the NEXT
+ * calendar day under `America/Adak` — the same slide, one format over. Refusing
+ * the format is honest; parsing it and claiming a UTC guarantee is not.
  */
 const EPOCH_SECONDS_CEILING = 1e11
+
+/**
+ * The other end of the magnitude test. 1e8 seconds is 1973 — below any real
+ * timestamp and four orders below any real one in milliseconds — so a small
+ * bare number is not a clock reading at all.
+ *
+ * Without this the ceiling was one-sided and the digit-count gate only guarded
+ * STRINGS: the number `2026` sailed into the epoch branch and came back as
+ * 1970-01-01T00:33:46Z, while the string `"2026"` was correctly read as a year.
+ * The same value giving two answers depending on how the JSON happened to be
+ * serialised is the exact shape of the bug this file exists to close.
+ */
+const EPOCH_SECONDS_FLOOR = 1e8
 
 /**
  * What a quoted epoch timestamp looks like: digits, and enough of them that it
@@ -55,6 +76,16 @@ const QUOTED_EPOCH = /^\+?\d{9,}(\.\d+)?$/
  * explicitly rather than picking up the container's offset.
  */
 const NAIVE_DATETIME = /^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}(:\d{2}(\.\d+)?)?$/
+
+/**
+ * ISO-8601, the only date-string shape accepted. Year, year-month or full date,
+ * optionally a time, optionally a zone. These are the forms `new Date` parses by
+ * SPEC — date-only as UTC, and the zoneless datetime pinned above — rather than
+ * by the legacy fallback parser, whose behaviour is implementation-defined and
+ * host-TZ dependent.
+ */
+const ISO_DATE =
+  /^\d{4}(-\d{2}(-\d{2})?)?([T ]\d{2}:\d{2}(:\d{2}(\.\d+)?)?(Z|[+-]\d{2}:?\d{2})?)?$/
 
 export const fygaroCreatedAtToIso = (
   createdAt: string | number | undefined | null,
@@ -76,13 +107,18 @@ export const fygaroCreatedAtToIso = (
   if (numeric <= 0) return undefined
 
   const looksLikeEpoch = typeof createdAt === "number" || QUOTED_EPOCH.test(trimmed)
-  if (looksLikeEpoch && Number.isFinite(numeric)) {
+  if (looksLikeEpoch) {
+    // Below the floor a bare number is not a clock reading, and there is nothing
+    // honest to fall back on: reading `2026` as a year is as much a guess as
+    // reading it as epoch seconds. An empty column beats either.
+    if (!Number.isFinite(numeric) || numeric < EPOCH_SECONDS_FLOOR) return undefined
     const ms = numeric < EPOCH_SECONDS_CEILING ? numeric * 1000 : numeric
     const fromEpoch = new Date(ms)
     return Number.isNaN(fromEpoch.getTime()) ? undefined : fromEpoch.toISOString()
   }
 
   const source = trimmed || String(createdAt)
+  if (!ISO_DATE.test(source)) return undefined
   const parsed = new Date(
     NAIVE_DATETIME.test(source) ? `${source.replace(" ", "T")}Z` : source,
   )

--- a/src/services/fygaro/webhook-server/created-at.ts
+++ b/src/services/fygaro/webhook-server/created-at.ts
@@ -14,23 +14,55 @@
  * 5138), while the same instant in milliseconds is three orders larger. So a
  * provider that switches to milliseconds later is read correctly too, instead
  * of reintroducing the mirror image of this bug with dates far in the future.
- * A non-numeric value is treated as a date string, and anything unparseable
- * returns undefined so the column stays empty rather than holding a fiction.
+ *
+ * Two things keep that magnitude test from swallowing values it should not:
+ *
+ * - The epoch branch is entered only for an actual number or a string of 9+
+ *   digits. Otherwise `Number("2026")` — a plausible shape for a provider that
+ *   switches to date strings — would coerce to 2026 and be read as epoch
+ *   seconds, landing on 1970-01-01T00:33:46Z: this same bug, wearing a
+ *   different payload.
+ * - Zero in any shape (`0`, `"0"`) is treated as ABSENT, not as the epoch
+ *   instant. A provider sending 0 for an unset timestamp means "no value", and
+ *   honouring it literally would put 1970 back in the column this function
+ *   exists to keep out of it.
+ *
+ * Anything else non-numeric is treated as a date string, and anything
+ * unparseable returns undefined so the column stays empty rather than holding a
+ * fiction.
  */
 const EPOCH_SECONDS_CEILING = 1e11
+
+/**
+ * What a quoted epoch timestamp looks like: all digits, and enough of them that
+ * it cannot be confused with a year or a compact date. 9 digits is 1973 in
+ * seconds; every real timestamp from here on is longer.
+ */
+const QUOTED_EPOCH = /^-?\d{9,}$/
 
 export const fygaroCreatedAtToIso = (
   createdAt: string | number | undefined | null,
 ): string | undefined => {
-  if (createdAt === undefined || createdAt === null || createdAt === "") return undefined
+  if (createdAt === undefined || createdAt === null) return undefined
 
-  const numeric = typeof createdAt === "number" ? createdAt : Number(createdAt)
-  if (Number.isFinite(numeric)) {
+  const trimmed = typeof createdAt === "string" ? createdAt.trim() : ""
+  // "" and whitespace-only are absent values, not parseable dates. Note that
+  // Number("") and Number(" ") are both 0 — without this they would coerce
+  // straight down the epoch path and yield 1970-01-01.
+  if (typeof createdAt === "string" && trimmed === "") return undefined
+
+  const numeric = typeof createdAt === "number" ? createdAt : Number(trimmed)
+  // Zero means "unset" from any provider that sends it; an operator reading
+  // 1970-01-01 in first_seen_at cannot tell that from a real timestamp.
+  if (numeric === 0) return undefined
+
+  const looksLikeEpoch = typeof createdAt === "number" || QUOTED_EPOCH.test(trimmed)
+  if (looksLikeEpoch && Number.isFinite(numeric)) {
     const ms = Math.abs(numeric) < EPOCH_SECONDS_CEILING ? numeric * 1000 : numeric
     const fromEpoch = new Date(ms)
     return Number.isNaN(fromEpoch.getTime()) ? undefined : fromEpoch.toISOString()
   }
 
-  const parsed = new Date(String(createdAt))
+  const parsed = new Date(trimmed || String(createdAt))
   return Number.isNaN(parsed.getTime()) ? undefined : parsed.toISOString()
 }

--- a/src/services/fygaro/webhook-server/created-at.ts
+++ b/src/services/fygaro/webhook-server/created-at.ts
@@ -32,7 +32,7 @@
  * no zone (`"2026-08-17 15:00:00"`, the shape Frappe itself emits) is pinned to
  * UTC before parsing — `new Date` reads that form as HOST-LOCAL time, which
  * would shift the answer by the container's UTC offset and, in the site's
- * configured `America/Adak`, onto the wrong calendar day. Anything unparseable
+ * configured `America/Adak`, onto the wrong calendar day. Anything unparsable
  * returns undefined so the column stays empty rather than holding a fiction.
  */
 const EPOCH_SECONDS_CEILING = 1e11

--- a/src/services/fygaro/webhook-server/created-at.ts
+++ b/src/services/fygaro/webhook-server/created-at.ts
@@ -1,0 +1,36 @@
+/**
+ * Fygaro's `createdAt` as something `new Date()` reads correctly.
+ *
+ * It arrives as epoch SECONDS (`1786940395`), and passing that to `new Date`
+ * gets it read as milliseconds — 1970-01-21, which is what every Fygaro audit
+ * row has carried in `first_seen_at` since the field was first written. Nothing
+ * downstream noticed because the trailing-24h window filters on `last_seen_at`,
+ * which is written from `new Date()` and is correct; `first_seen_at` is simply
+ * the field an operator reads to answer "when did this payment arrive", and it
+ * has been wrong on every row.
+ *
+ * The magnitude test is what makes this total rather than a guess: epoch
+ * seconds for any plausible date stay below 1e11 (that ceiling is the year
+ * 5138), while the same instant in milliseconds is three orders larger. So a
+ * provider that switches to milliseconds later is read correctly too, instead
+ * of reintroducing the mirror image of this bug with dates far in the future.
+ * A non-numeric value is treated as a date string, and anything unparseable
+ * returns undefined so the column stays empty rather than holding a fiction.
+ */
+const EPOCH_SECONDS_CEILING = 1e11
+
+export const fygaroCreatedAtToIso = (
+  createdAt: string | number | undefined | null,
+): string | undefined => {
+  if (createdAt === undefined || createdAt === null || createdAt === "") return undefined
+
+  const numeric = typeof createdAt === "number" ? createdAt : Number(createdAt)
+  if (Number.isFinite(numeric)) {
+    const ms = Math.abs(numeric) < EPOCH_SECONDS_CEILING ? numeric * 1000 : numeric
+    const fromEpoch = new Date(ms)
+    return Number.isNaN(fromEpoch.getTime()) ? undefined : fromEpoch.toISOString()
+  }
+
+  const parsed = new Date(String(createdAt))
+  return Number.isNaN(parsed.getTime()) ? undefined : parsed.toISOString()
+}

--- a/src/services/fygaro/webhook-server/routes/payment.ts
+++ b/src/services/fygaro/webhook-server/routes/payment.ts
@@ -62,6 +62,7 @@ import {
   INSUFFICIENT_TREASURY_FLOAT_STEP,
 } from "../credit-topup"
 import { getFygaroSettings, type FygaroSettings } from "../fygaro-settings"
+import { fygaroCreatedAtToIso } from "../created-at"
 import { parseCustomReference } from "../../checkout"
 import {
   consumeIntent,
@@ -80,7 +81,11 @@ type FygaroPaymentPayload = {
   amount?: string
   currency?: string
   authCode?: string | null
-  createdAt?: string
+  // Epoch SECONDS, as a JSON number — not the ISO string this was typed as.
+  // The lie was the bug: `new Date(1786940395)` reads a bare number as
+  // MILLISECONDS, so every Fygaro row landed with first_seen_at at
+  // 1970-01-21. Typed honestly so nobody hands it straight to `new Date`.
+  createdAt?: string | number
   client?: { name?: string; email?: string }
 }
 
@@ -305,7 +310,8 @@ const OUTCOME_BY_CREDIT_STATUS: Record<
 
 export const paymentHandler = async (req: Request, res: Response) => {
   const payload = (req.body ?? {}) as FygaroPaymentPayload
-  const { transactionId, createdAt } = payload
+  const { transactionId } = payload
+  const createdAt = fygaroCreatedAtToIso(payload.createdAt)
   const currency = (payload.currency ?? "USD").toUpperCase()
   // `custom_reference` is either a bare username (built on-device by app
   // versions predating signed checkout, and editable by the payer) or

--- a/test/flash/unit/services/fygaro/webhook-server/created-at.spec.ts
+++ b/test/flash/unit/services/fygaro/webhook-server/created-at.spec.ts
@@ -35,10 +35,14 @@ describe("fygaroCreatedAtToIso", () => {
   })
 
   it("treats an unset timestamp as absent rather than as the epoch instant", () => {
-    // These are the values that make 1970 come BACK. Each one coerces to 0, and
-    // a 0 read as epoch seconds is 1970-01-01 — indistinguishable, to the
-    // operator reading first_seen_at, from a real timestamp. Empty is honest.
-    for (const value of [0, "0", " ", "  \t "]) {
+    // These are the values that make 1970 come BACK. Each one coerces to a
+    // non-positive number, and a 0 read as epoch seconds is 1970-01-01 —
+    // indistinguishable, to the operator reading first_seen_at, from a real
+    // timestamp. -1 is just as common a sentinel, and it used to produce two
+    // DIFFERENT fictions depending on JSON type: the number gave
+    // 1969-12-31T23:59:59Z, the string fell through to the date branch and gave
+    // 2001-01-01. Fygaro is a card processor that did not exist before 1970.
+    for (const value of [0, "0", -1, "-1", " ", "  \t "]) {
       expect(fygaroCreatedAtToIso(value)).toBeUndefined()
     }
   })
@@ -55,5 +59,29 @@ describe("fygaroCreatedAtToIso", () => {
   it("still reads a quoted epoch timestamp as epoch, not as a date string", () => {
     // The other side of the gate above: 9+ digits is a timestamp, not a year.
     expect(fygaroCreatedAtToIso(" 1786940395 ")).toBe("2026-08-17T04:19:55.000Z")
+  })
+
+  it("reads a fractional epoch the same whether it arrives quoted or bare", () => {
+    // A provider that stringifies a float clock sends "1786940395.75". The bare
+    // number was always read correctly; the quoted form used to fail the
+    // digits-only gate and blank the column — the same value producing two
+    // different answers depending on how the JSON happened to be serialised.
+    expect(fygaroCreatedAtToIso(1786940395.75)).toBe("2026-08-17T04:19:55.750Z")
+    expect(fygaroCreatedAtToIso("1786940395.75")).toBe("2026-08-17T04:19:55.750Z")
+    expect(fygaroCreatedAtToIso("1786940395.5")).toBe("2026-08-17T04:19:55.500Z")
+    expect(fygaroCreatedAtToIso("1786940395.000")).toBe("2026-08-17T04:19:55.000Z")
+    expect(fygaroCreatedAtToIso("+1786940395")).toBe("2026-08-17T04:19:55.000Z")
+  })
+
+  it("reads a zoneless datetime as UTC, not as whatever the host clock is set to", () => {
+    // "2026-08-17 15:00:00" is the shape Frappe emits and the likeliest form if
+    // Fygaro ever moves off epoch. `new Date` reads it as HOST-LOCAL, so the
+    // answer used to slide with the container's offset: 20:00Z under
+    // America/Jamaica, and under the site's configured America/Adak it landed
+    // on 2026-08-18 — the wrong calendar day. This assertion holds under every
+    // TZ; run the suite with TZ=America/Adak to see it bite.
+    expect(fygaroCreatedAtToIso("2026-08-17 15:00:00")).toBe("2026-08-17T15:00:00.000Z")
+    expect(fygaroCreatedAtToIso("2026-08-17T15:00:00")).toBe("2026-08-17T15:00:00.000Z")
+    expect(fygaroCreatedAtToIso("2026-08-17 15:00")).toBe("2026-08-17T15:00:00.000Z")
   })
 })

--- a/test/flash/unit/services/fygaro/webhook-server/created-at.spec.ts
+++ b/test/flash/unit/services/fygaro/webhook-server/created-at.spec.ts
@@ -3,10 +3,9 @@ import { fygaroCreatedAtToIso } from "@services/fygaro/webhook-server/created-at
 describe("fygaroCreatedAtToIso", () => {
   it("reads Fygaro's epoch SECONDS as seconds, not milliseconds", () => {
     // The bug, exactly. 1786940395 is what Fygaro sends; handing it straight to
-    // `new Date` reads it as milliseconds and lands on 1970-01-21, which is what
-    // every Fygaro audit row has carried in first_seen_at.
+    // `new Date` reads it as milliseconds and lands on 1970-01-21 — which is
+    // what every Fygaro audit row has carried in first_seen_at.
     expect(fygaroCreatedAtToIso(1786940395)).toBe("2026-08-17T04:19:55.000Z")
-    expect(new Date(1786940395).getUTCFullYear()).toBe(1970)
   })
 
   it("accepts the same value as a numeric string", () => {
@@ -35,12 +34,26 @@ describe("fygaroCreatedAtToIso", () => {
     }
   })
 
-  it("never returns a date in the 1970s for a present-day payment", () => {
-    // The regression net: whatever shape a real captured payload carries, the
-    // answer must land in this century.
-    for (const value of [1786940395, "1786940395", 1786940395000]) {
-      const iso = fygaroCreatedAtToIso(value)
-      expect(new Date(iso as string).getUTCFullYear()).toBeGreaterThan(2000)
+  it("treats an unset timestamp as absent rather than as the epoch instant", () => {
+    // These are the values that make 1970 come BACK. Each one coerces to 0, and
+    // a 0 read as epoch seconds is 1970-01-01 — indistinguishable, to the
+    // operator reading first_seen_at, from a real timestamp. Empty is honest.
+    for (const value of [0, "0", " ", "  \t "]) {
+      expect(fygaroCreatedAtToIso(value)).toBeUndefined()
     }
+  })
+
+  it("does not read a bare-numeric date string as epoch seconds", () => {
+    // A provider switching to date strings is the likeliest future change, and
+    // "2026" coerces to the number 2026. Read as epoch seconds that is
+    // 1970-01-01T00:33:46Z — this same bug in a different payload. It must be
+    // parsed as a date.
+    expect(fygaroCreatedAtToIso("2026")).toBe("2026-01-01T00:00:00.000Z")
+    expect(fygaroCreatedAtToIso("2026-08-17")).toBe("2026-08-17T00:00:00.000Z")
+  })
+
+  it("still reads a quoted epoch timestamp as epoch, not as a date string", () => {
+    // The other side of the gate above: 9+ digits is a timestamp, not a year.
+    expect(fygaroCreatedAtToIso(" 1786940395 ")).toBe("2026-08-17T04:19:55.000Z")
   })
 })

--- a/test/flash/unit/services/fygaro/webhook-server/created-at.spec.ts
+++ b/test/flash/unit/services/fygaro/webhook-server/created-at.spec.ts
@@ -73,6 +73,37 @@ describe("fygaroCreatedAtToIso", () => {
     expect(fygaroCreatedAtToIso("+1786940395")).toBe("2026-08-17T04:19:55.000Z")
   })
 
+  it("does not read a small BARE number as epoch seconds either", () => {
+    // The mirror of the test above, and the asymmetry it left open: the 9-digit
+    // gate only guards strings, so `"2026"` was read as a year while the NUMBER
+    // 2026 went down the epoch path to 1970-01-01T00:33:46Z. The same value
+    // giving two answers depending on how the JSON was serialised is this bug
+    // wearing a different payload. 1786940 — a truncated timestamp — is the one
+    // that matters most: it returns 1970-01-21, byte-identical to the rows this
+    // PR exists to stop producing.
+    for (const value of [1, 2026, 1786940, 99999999]) {
+      expect(fygaroCreatedAtToIso(value)).toBeUndefined()
+    }
+    // The floor sits below any real timestamp, so nothing real is refused.
+    expect(fygaroCreatedAtToIso(1e8)).toBe("1973-03-03T09:46:40.000Z")
+  })
+
+  it("refuses non-ISO date strings rather than parsing them host-locally", () => {
+    // `new Date`'s legacy parser is implementation-defined and reads zoneless
+    // input as HOST-LOCAL, so these slide with the container's offset:
+    // "Mon, 17 Aug 2026 15:00:00" gave 15:00Z under TZ=UTC and the NEXT calendar
+    // day under the site's America/Adak. Refusing the format is honest; parsing
+    // it while the docblock promises UTC is not.
+    for (const value of [
+      "Mon, 17 Aug 2026 15:00:00",
+      "Aug 17 2026",
+      "2026/08/17",
+      "08/17/2026",
+    ]) {
+      expect(fygaroCreatedAtToIso(value)).toBeUndefined()
+    }
+  })
+
   it("reads a zoneless datetime as UTC, not as whatever the host clock is set to", () => {
     // "2026-08-17 15:00:00" is the shape Frappe emits and the likeliest form if
     // Fygaro ever moves off epoch. `new Date` reads it as HOST-LOCAL, so the

--- a/test/flash/unit/services/fygaro/webhook-server/created-at.spec.ts
+++ b/test/flash/unit/services/fygaro/webhook-server/created-at.spec.ts
@@ -1,0 +1,46 @@
+import { fygaroCreatedAtToIso } from "@services/fygaro/webhook-server/created-at"
+
+describe("fygaroCreatedAtToIso", () => {
+  it("reads Fygaro's epoch SECONDS as seconds, not milliseconds", () => {
+    // The bug, exactly. 1786940395 is what Fygaro sends; handing it straight to
+    // `new Date` reads it as milliseconds and lands on 1970-01-21, which is what
+    // every Fygaro audit row has carried in first_seen_at.
+    expect(fygaroCreatedAtToIso(1786940395)).toBe("2026-08-17T04:19:55.000Z")
+    expect(new Date(1786940395).getUTCFullYear()).toBe(1970)
+  })
+
+  it("accepts the same value as a numeric string", () => {
+    // JSON numbers are what we have observed, but a provider that quotes them
+    // must not silently become a 1970 row again.
+    expect(fygaroCreatedAtToIso("1786940395")).toBe("2026-08-17T04:19:55.000Z")
+  })
+
+  it("reads milliseconds correctly too, so a provider switch is not the mirror bug", () => {
+    // The same instant, three orders larger. Treating this as seconds would put
+    // the row ~56,000 years out — this bug inverted.
+    expect(fygaroCreatedAtToIso(1786940395000)).toBe("2026-08-17T04:19:55.000Z")
+  })
+
+  it("passes an ISO string through", () => {
+    expect(fygaroCreatedAtToIso("2026-08-17T04:19:55.000Z")).toBe(
+      "2026-08-17T04:19:55.000Z",
+    )
+  })
+
+  it("returns undefined rather than a fiction when there is nothing usable", () => {
+    // An empty column is honest; a parsed-from-garbage timestamp is not, and it
+    // is the field an operator reads to answer "when did this payment arrive".
+    for (const value of [undefined, null, "", "not a date"]) {
+      expect(fygaroCreatedAtToIso(value)).toBeUndefined()
+    }
+  })
+
+  it("never returns a date in the 1970s for a present-day payment", () => {
+    // The regression net: whatever shape a real captured payload carries, the
+    // answer must land in this century.
+    for (const value of [1786940395, "1786940395", 1786940395000]) {
+      const iso = fygaroCreatedAtToIso(value)
+      expect(new Date(iso as string).getUTCFullYear()).toBeGreaterThan(2000)
+    }
+  })
+})

--- a/test/flash/unit/services/fygaro/webhook-server/payment.spec.ts
+++ b/test/flash/unit/services/fygaro/webhook-server/payment.spec.ts
@@ -171,9 +171,15 @@ const VALID_BODY = {
   amount: "10.00",
   currency: "USD",
   authCode: null,
-  createdAt: "2026-08-07T15:00:00Z",
+  // The real production shape: epoch SECONDS, not an ISO string. The fixture
+  // used to carry an ISO string, which is the one shape Fygaro never sends —
+  // and that lie is what let first_seen_at sit at 1970-01-21 on every row while
+  // this suite stayed green.
+  createdAt: 1786940395,
   client: { name: "Regina Bailey", email: "regina@example.com" },
 }
+
+const VALID_BODY_CREATED_AT_ISO = "2026-08-17T04:19:55.000Z"
 
 const makeRes = (): Response => {
   const res = { status: jest.fn(), json: jest.fn() } as unknown as Response
@@ -286,6 +292,11 @@ describe("fygaro paymentHandler", () => {
         amount: "10.00",
         currency: "USD",
         accountId: ACCOUNT_ID,
+        // The whole point of the fix: the epoch SECONDS Fygaro sends reach the
+        // writer as the instant they name. Handing payload.createdAt through
+        // untouched writes 1970-01-21 into first_seen_at, which is what every
+        // row carried.
+        createdAt: VALID_BODY_CREATED_AT_ISO,
       }),
     )
     expect(mockCreditFygaroTopup).not.toHaveBeenCalled()
@@ -298,6 +309,25 @@ describe("fygaro paymentHandler", () => {
     expect(mockSendTopupNotification).not.toHaveBeenCalled()
     expect(res.status).toHaveBeenCalledWith(200)
     expect(res.json).toHaveBeenCalledWith({ status: "recorded", credited: false })
+  })
+
+  it("records with an empty createdAt rather than inventing one when the payload omits it", async () => {
+    const withoutCreatedAt: Record<string, unknown> = { ...VALID_BODY }
+    delete withoutCreatedAt.createdAt
+    const res = makeRes()
+
+    await paymentHandler(makeReq(withoutCreatedAt), res)
+
+    // An absent arrival time must leave the column empty. A missing field that
+    // coerces to 1970 is worse than a blank one: it reads as a real answer to
+    // "when did this payment arrive" and there is no way to tell it apart.
+    expect(mockWriteFygaroTopup).toHaveBeenCalledWith(
+      expect.objectContaining({
+        transactionId: VALID_BODY.transactionId,
+        createdAt: undefined,
+      }),
+    )
+    expect(res.status).toHaveBeenCalledWith(200)
   })
 
   it("still records a payment with a blank customReference and alerts as unattributed", async () => {
@@ -406,6 +436,10 @@ describe("fygaro paymentHandler", () => {
         amount: "10.00",
         accountId: undefined,
         emailAttributed: false,
+        // Pinned on the unattributed path too: this is the row an operator has
+        // to reconcile by hand, so its arrival time is the one field they lean
+        // on hardest.
+        createdAt: VALID_BODY_CREATED_AT_ISO,
       }),
     )
     expect(mockWriteFygaroTopup).not.toHaveBeenCalledWith(


### PR DESCRIPTION
## The bug

Fygaro sends `createdAt` as epoch **seconds** — `1786940395`, a JSON number. The payload type declared it a `string`, and it was passed straight to `new Date()`, which reads a bare number as **milliseconds**. 1,786,940,395 ms is twenty days past the epoch, so **every Fygaro audit row ever written carries `first_seen_at = 1970-01-21`.**

Verified on prod — three rows for one account:

```
fygaro:8f3efda6…  first_seen_at 1970-01-21 16:22:20   last_seen_at 2026-08-17 04:23:01
fygaro:ce3b3185…  first_seen_at 1970-01-21 16:22:13   last_seen_at 2026-08-17 02:33:31
fygaro:890ee17c…  first_seen_at 1970-01-21 16:21:55   last_seen_at 2026-08-16 22:10:07
```

and the payloads behind them:

```
fygaro:8f3efda6… -> createdAt = 1786940395
```

## Why nobody noticed

**No money was affected.** The trailing-24h allowance window filters on `last_seen_at`, which is written from `new Date()` with no argument and is correct to the second. `first_seen_at` is only ever read by a human asking *"when did this payment arrive"* — and it has been wrong on every row since the column was first written.

## The fix

Normalised **at the boundary**, where the format is actually known, rather than by teaching the shared `toFrappeDatetime` to guess — Bridge passes it ISO strings and must keep working. The payload type now says `string | number`, because the type lie is what made this invisible at the call site.

The magnitude test makes the function total rather than a guess: epoch seconds for any plausible date stay under `1e11` (that ceiling is the year 5138), while the same instant in milliseconds is three orders larger. A provider that switches to milliseconds later is then read correctly, instead of reintroducing this bug's mirror image with rows dated ~56,000 years out.

Three things keep the function from inventing a plausible-looking date out of junk:

- **Non-positive values are ABSENT, not instants.** `0`, `"0"`, `-1`, `"-1"` all return `undefined`. Both are stock "unset timestamp" sentinels, and Fygaro is a card processor that did not exist before 1970, so a negative value here is garbage by construction.
- **The epoch gate is type-consistent.** A quoted epoch may carry a fractional part (`"1786940395.75"`, what a provider emits when it stringifies a float clock) and reads identically to the bare number. It still rejects `"2026"` and `"20260817"`, which is the point of the gate — `Number("2026")` read as epoch seconds is 1970-01-01T00:33:46Z, this same bug in a different payload.
- **A zoneless datetime is pinned to UTC.** `new Date("2026-08-17 15:00:00")` — the shape Frappe emits, and the likeliest form if Fygaro moves off epoch — reads as *host-local* time, which slides the answer by the container's UTC offset and, under `America/Adak`, onto the wrong calendar day. It is normalised to `…T15:00:00Z` before parsing, so the result no longer depends on the container clock.

Unparseable input returns `undefined`, so the column stays empty rather than holding a fiction.

The function lives in its own module rather than in `routes/payment.ts` because a pure string→string function has no business in a route module that constructs Redis and Mongo clients at import time; importing it from a spec drags that whole graph in for no reason.

## Not fixed here

**Existing rows keep their 1970 values.** This stops the bleeding; it does not backfill. The real `createdAt` is still in each row's `raw_payload_json`, so a backfill is possible later if anyone wants it.

**The ERPNext site timezone is `America/Adak` (UTC−9)**, almost certainly a misconfiguration for a Jamaica business. The parser above no longer depends on it, but Frappe's own `creation`/`modified` columns still do. That is a Frappe System Settings value, not a flash change, and it is not a clean flip — Frappe stores those in site-local time, so changing it makes rows written before and after the change sit in different timezones with nothing recording which. Tracked separately.

## Tests

204 suites / 2202 green. Ten tests cover `fygaroCreatedAtToIso`:

1. **Epoch seconds** — the exact production value, `1786940395` → `2026-08-17T04:19:55.000Z`.
2. **Quoted epoch** — the same value as a numeric string.
3. **Milliseconds** — `1786940395000` reads to the same instant, so a provider switch is not this bug inverted.
4. **ISO passthrough** — an already-correct string is returned unchanged.
5. **Unparseable → `undefined`** — `undefined`, `null`, `""`, `"not a date"`.
6. **Unset sentinels → `undefined`** — `0`, `"0"`, `-1`, `"-1"`, whitespace-only. `-1` used to produce two *different* fictions depending on JSON type: the number gave `1969-12-31T23:59:59Z`, the string fell through to the date branch and gave `2001-01-01`.
7. **Bare-numeric date strings** — `"2026"` and `"2026-08-17"` parse as dates, not as epoch seconds.
8. **Quoted epoch with whitespace** — `" 1786940395 "` still reads as epoch.
9. **Fractional epoch, quoted and bare** — `1786940395.75` and `"1786940395.75"` agree; the quoted form used to blank the column.
10. **Zoneless datetime is UTC** — `"2026-08-17 15:00:00"` → `"2026-08-17T15:00:00.000Z"`.

The suite was run under `TZ=America/Adak`, `America/Jamaica`, `UTC`, and `Asia/Tokyo` — green in all four, so test 10 is asserting the normalisation rather than the host clock. Tests 6, 9, and 10 were each verified to fail against the previous commit's implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NEoz7nBtdtsHyuYG5wNPQV
