### PR TITLE
fix(fygaro): custom_reference breached Fygaro's 40-char cap on every account

### DIFF
--- a/src/app/fygaro/topup-status.ts
+++ b/src/app/fygaro/topup-status.ts
@@ -134,7 +134,7 @@ export const getFygaroTopupStatus = async ({
     return lookup.unavailable ? { found: false, unavailable: true } : { found: false }
   }
 
-  // The intent id is a random uuid, so guessing one is impractical — but the
+  // The intent id is 96 random bits, so guessing one is impractical — but the
   // record names the account it was minted for, and checking costs nothing.
   // Payment state is exactly the kind of thing that must not leak across
   // accounts on a mere id match.

--- a/src/services/fygaro/checkout-intent-store.ts
+++ b/src/services/fygaro/checkout-intent-store.ts
@@ -146,9 +146,10 @@ const claimKey = (intentId: string) => `fygaro-checkout-claim:${intentId}`
 // longer payable (Fygaro rejects an expired token) and are pruned on read.
 const accountIntentsKey = (accountId: string) => `fygaro-checkout-intents:${accountId}`
 
-// `<amountCents>:<intentId>`. Amount first because an intentId is a uuid and
-// carries no colon, so the split point is unambiguous either way, and a
-// malformed member yields NaN which is dropped rather than summed.
+// `<amountCents>:<intentId>`. Amount first because an intentId is base64url
+// (`[A-Za-z0-9_-]`) and carries no colon, so the split point is unambiguous
+// either way, and a malformed member yields NaN which is dropped rather than
+// summed.
 const reservationMember = ({
   intentId,
   amountCents,

--- a/src/services/fygaro/checkout-intent-store.ts
+++ b/src/services/fygaro/checkout-intent-store.ts
@@ -173,8 +173,11 @@ const reservationAmountCents = (member: string): number => {
  * cap for every real account and Fygaro answered the customer with an error
  * page instead of a payment form.
  *
- * 16 characters leaves 23 for the username, which covers the ordinary case
- * without the short `|<intentId>` form; buildCustomReference handles the rest.
+ * 16 characters leaves 23 BYTES for the username — 23 ASCII characters, fewer
+ * for the multi-byte usernames UsernameRegex allows (roughly 11 Cyrillic, 7
+ * CJK); see buildCustomReference, which measures the ceiling in UTF-8 bytes.
+ * That covers the ordinary case without the short `|<intentId>` form;
+ * buildCustomReference handles the rest.
  * 96 bits is far beyond what guessing resistance needs here — an id is only
  * useful inside its 15-minute window, and an intent is bound to one account and
  * one amount, so a guessed id buys an attacker a mismatch, not a credit.

--- a/src/services/fygaro/checkout-intent-store.ts
+++ b/src/services/fygaro/checkout-intent-store.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from "crypto"
+import { randomBytes } from "crypto"
 
 import { CacheUndefinedError } from "@domain/cache"
 import { baseLogger } from "@services/logger"
@@ -162,7 +162,26 @@ const reservationAmountCents = (member: string): number => {
   return Number.isFinite(amount) && amount > 0 ? amount : 0
 }
 
-export const newIntentId = (): string => randomUUID()
+/**
+ * 12 random bytes as base64url — 16 characters, 96 bits.
+ *
+ * Deliberately NOT a UUID. The id is carried inside Fygaro's
+ * `custom_reference`, which is capped at 40 characters
+ * (FYGARO_CUSTOM_REFERENCE_MAX_LENGTH), and a 36-character UUID left room for a
+ * 3-character username and nothing longer — so `<username>|<uuid>` breached the
+ * cap for every real account and Fygaro answered the customer with an error
+ * page instead of a payment form.
+ *
+ * 16 characters leaves 23 for the username, which covers the ordinary case
+ * without the short `|<intentId>` form; buildCustomReference handles the rest.
+ * 96 bits is far beyond what guessing resistance needs here — an id is only
+ * useful inside its 15-minute window, and an intent is bound to one account and
+ * one amount, so a guessed id buys an attacker a mismatch, not a credit.
+ *
+ * 12 bytes rather than a length-sliced UUID because base64url of 12 bytes is
+ * exactly 16 characters with no padding to strip.
+ */
+export const newIntentId = (): string => randomBytes(12).toString("base64url")
 
 export const saveIntent = async ({
   intent,

--- a/src/services/fygaro/checkout.ts
+++ b/src/services/fygaro/checkout.ts
@@ -95,12 +95,22 @@ export const buildCustomReference = ({
 /**
  * Read a `custom_reference` coming back from Fygaro.
  *
- * Deliberately lenient about shape and strict about meaning: anything that is
- * not exactly `username|intentId` yields no intentId, so the caller falls back
- * to the unverified legacy path rather than treating a malformed reference as
- * an authorisation. Returns undefined only when there is no usable username at
- * all — that is the "payment we cannot attribute" case the webhook already
- * records and alerts on.
+ * Three shapes are meaningful, and they are the three buildCustomReference can
+ * mint:
+ *
+ *   `username`             legacy — every client predating signed checkout
+ *   `username|intentId`    signed, with the account named inline
+ *   `|intentId`            signed, username dropped to fit the 40-byte ceiling
+ *
+ * Deliberately lenient about shape and strict about meaning: anything else
+ * yields no intentId, so the caller falls back to the unverified legacy path
+ * rather than treating a reference it does not understand as an authorisation.
+ *
+ * Returns undefined only when there is nothing usable at ALL — neither a
+ * username nor an intent id. That is the "payment we cannot attribute" case the
+ * webhook already records and alerts on. Note the asymmetry it creates: a
+ * `|intentId` result carries no username, so every caller must treat
+ * `username` as optional and resolve the account from the intent record.
  */
 export const parseCustomReference = (
   raw: string | undefined | null,

--- a/src/services/fygaro/checkout.ts
+++ b/src/services/fygaro/checkout.ts
@@ -24,8 +24,25 @@ import { createHmac } from "crypto"
 // checkedToUsername) and it survives URL/JSON encoding unescaped.
 export const FYGARO_REFERENCE_SEPARATOR = "|"
 
+/**
+ * Fygaro's hard limit on `custom_reference`. Exceeding it is not a soft
+ * truncation — Fygaro refuses the whole checkout with "Custom reference cannot
+ * exceed 40 characters in length", which the customer meets as an error page
+ * where the payment form should be.
+ *
+ * This is why signed checkout never worked for a single real account. The
+ * original format was `<username>|<uuid>`: a v4 UUID is 36 characters and the
+ * separator is 1, so the reference was 37 + the username, and usernames are at
+ * least 3 characters (UsernameRegex). Exactly 40 for a 3-character username and
+ * over the limit for every longer one — which is to say, everyone.
+ */
+export const FYGARO_CUSTOM_REFERENCE_MAX_LENGTH = 40
+
 export type FygaroCustomReference = {
-  username: string
+  // Absent when the reference carries ONLY an intent id — see
+  // buildCustomReference for when that happens. The caller resolves the account
+  // from the intent record in that case.
+  username?: string
   // Absent for references built by app versions that predate signed checkout.
   // Those payments are still recorded and still pass through the credit gate —
   // they simply carry no proof of what was authorised.
@@ -34,6 +51,20 @@ export type FygaroCustomReference = {
 
 /**
  * `<username>|<intentId>`, or bare `<username>` when no intent is bound.
+ *
+ * When the username is long enough that `<username>|<intentId>` would breach
+ * Fygaro's 40-character ceiling, the username is dropped and the reference
+ * becomes `|<intentId>` — a leading separator, which is unambiguous because a
+ * username can never be empty and can never contain the separator.
+ *
+ * Keeping the username whenever it FITS is deliberate, and it is the reason
+ * this is a conditional rather than always minting the short form. The username
+ * is what the webhook attributes a payment by; the intent record is a 75-minute
+ * Redis entry. If Redis is lost mid-window, `<username>|<intentId>` still names
+ * an account and the payment credits, where `|<intentId>` alone would fall
+ * through to payer-email attribution. That fallback exists and is handled, but
+ * it is strictly worse than not needing it, so it is reserved for the case that
+ * has no alternative.
  */
 export const buildCustomReference = ({
   username,
@@ -41,8 +72,12 @@ export const buildCustomReference = ({
 }: {
   username: string
   intentId?: string
-}): string =>
-  intentId ? `${username}${FYGARO_REFERENCE_SEPARATOR}${intentId}` : username
+}): string => {
+  if (!intentId) return username
+  const withUsername = `${username}${FYGARO_REFERENCE_SEPARATOR}${intentId}`
+  if (withUsername.length <= FYGARO_CUSTOM_REFERENCE_MAX_LENGTH) return withUsername
+  return `${FYGARO_REFERENCE_SEPARATOR}${intentId}`
+}
 
 /**
  * Read a `custom_reference` coming back from Fygaro.
@@ -62,15 +97,19 @@ export const parseCustomReference = (
 
   const parts = trimmed.split(FYGARO_REFERENCE_SEPARATOR)
   const username = parts[0].trim()
-  if (username === "") return undefined
 
-  // Exactly two segments, both non-empty, is the only shape that carries an
-  // intent. A third segment means something built a reference we do not
-  // understand; treating that as legacy is the safe reading.
-  if (parts.length !== 2) return { username }
+  // Exactly two segments is the only shape that carries an intent. A third
+  // means something built a reference we do not understand; treating that as
+  // legacy is the safe reading.
+  if (parts.length !== 2) return username === "" ? undefined : { username }
   const intentId = parts[1].trim()
-  if (intentId === "") return { username }
 
+  // `|<intentId>` — the long-username form. An empty first segment cannot be a
+  // username (they are 3+ characters), so this shape is unambiguous. The caller
+  // resolves the account from the intent record.
+  if (username === "") return intentId === "" ? undefined : { intentId }
+
+  if (intentId === "") return { username }
   return { username, intentId }
 }
 

--- a/src/services/fygaro/checkout.ts
+++ b/src/services/fygaro/checkout.ts
@@ -75,7 +75,20 @@ export const buildCustomReference = ({
 }): string => {
   if (!intentId) return username
   const withUsername = `${username}${FYGARO_REFERENCE_SEPARATOR}${intentId}`
-  if (withUsername.length <= FYGARO_CUSTOM_REFERENCE_MAX_LENGTH) return withUsername
+  // Measured in UTF-8 BYTES, not `String.length`. Fygaro documents the cap as
+  // "40 characters" but does not say what it counts, and UsernameRegex is
+  // `[\p{L}0-9_]{3,50}` — ANY Unicode letter — so a 13-character Cyrillic
+  // username is 26 UTF-16 code units and 39 UTF-8 bytes. If their validator
+  // counts bytes, `.length` would hand that account a reference Fygaro
+  // refuses: an error page where the payment form should be, then a silent
+  // fall back to the editable legacy URL. That is precisely the bug this
+  // module exists to fix, and assuming the unit of the limit is the same
+  // mistake one level down. Bytes is the conservative reading — the only cost
+  // of being wrong this way is that a few more accounts take the `|<intentId>`
+  // form, which is handled end to end.
+  if (Buffer.byteLength(withUsername, "utf8") <= FYGARO_CUSTOM_REFERENCE_MAX_LENGTH) {
+    return withUsername
+  }
   return `${FYGARO_REFERENCE_SEPARATOR}${intentId}`
 }
 

--- a/src/services/fygaro/webhook-server/routes/payment.ts
+++ b/src/services/fygaro/webhook-server/routes/payment.ts
@@ -71,6 +71,7 @@ import {
   releaseIntentReservation,
   type FygaroCheckoutIntent,
   type FygaroTopupOutcomeState,
+  type IntentLookup,
 } from "../../checkout-intent-store"
 import { evaluateCreditGate, RecordOnlyReason } from "../fees"
 
@@ -330,9 +331,21 @@ export const paymentHandler = async (req: Request, res: Response) => {
   // through to payer-email attribution, exactly where an unrecognised reference
   // already lands. That is the whole reason buildCustomReference keeps the
   // username inline whenever it fits.
+  //
+  // MEMOIZED, and that is not a micro-optimisation. The authorisation
+  // cross-check below reads the same intent, and two independent reads of one
+  // Redis key can DISAGREE: a blip on the first (fail-open, so `username`
+  // stays undefined) followed by a success on the second produced a delivery
+  // that stamped `held-for-review`/`unattributed`, paged ops, and told the
+  // customer we were completing it by hand — while holding, two lines later,
+  // the very record naming the account it had just failed to attribute to. One
+  // read cannot produce that state.
+  let intentLookup: IntentLookup | undefined
+  const lookupIntent = async (id: string): Promise<IntentLookup> =>
+    (intentLookup ??= await readIntent(id))
   const usernameFromIntent = async (): Promise<string | undefined> => {
     if (!intentId) return undefined
-    const lookup = await readIntent(intentId)
+    const lookup = await lookupIntent(intentId)
     return lookup.found ? lookup.intent.username : undefined
   }
   const username = reference?.username ?? (await usernameFromIntent())
@@ -536,9 +549,14 @@ export const paymentHandler = async (req: Request, res: Response) => {
     // already-credited payment cannot walk the answer backwards.
     await recordOutcome({ state: "received" })
 
-    // Look the authorisation up ONCE, and do it BEFORE the unattributed branch
-    // below, so every terminal answer in this handler can let go of the hold
-    // the authorisation still has on the account's daily allowance. A leaked
+    // Look the authorisation up ONCE — `lookupIntent` memoizes, so this shares
+    // the single read the username recovery at the top of the handler may
+    // already have taken, and the two can never disagree about whether the
+    // record exists.
+    //
+    // Do it BEFORE the unattributed branch below, so every terminal answer in
+    // this handler can let go of the hold the authorisation still has on the
+    // account's daily allowance. A leaked
     // hold is not cosmetic: the audit row already counts the payment towards
     // the cap, so a hold left behind on top of it double-counts one payment for
     // the rest of the JWT's window and refuses the account's next legitimate
@@ -551,7 +569,7 @@ export const paymentHandler = async (req: Request, res: Response) => {
     // check against.
     let authorizedIntent: FygaroCheckoutIntent | undefined
     if (intentId) {
-      const lookup = await readIntent(intentId)
+      const lookup = await lookupIntent(intentId)
       if (lookup.found) {
         authorizedIntent = lookup.intent
       } else {
@@ -599,18 +617,28 @@ export const paymentHandler = async (req: Request, res: Response) => {
       // or an attacker can type anyone's address), so the alert says confirm
       // before crediting rather than "credit this account".
       const resolvedUsername = emailAttributedAccount?.username
+      // Show ops the reference the PAYER actually sent, not the username we
+      // failed to derive from it. Those are different things in the
+      // `|<intentId>` form: there the raw reference carries an intent id and
+      // no username, so reporting the (undefined) username as "<blank>" reads
+      // at 3am as "the payer sent us nothing" when in fact we minted a
+      // reference and then could not read our own record. The intent id is
+      // also the only handle a human has for tracing the payment back to the
+      // checkout, so it is carried alongside.
+      const rawReference = payload.customReference || "<blank>"
       alertBridge({
         dedupKey: generateDedupKey.fygaroUnattributed(transactionId),
         source: "fygaro-webhook",
         severity: "warning",
         title: "Fygaro payment could not be attributed to an account",
         detail: resolvedUsername
-          ? `customReference=${username ?? "<blank>"} — UNVERIFIED payer-email match on @${resolvedUsername}; confirm the payer owns this account before crediting`
-          : `customReference=${username ?? "<blank>"} — manual attribution needed`,
+          ? `customReference=${rawReference} — UNVERIFIED payer-email match on @${resolvedUsername}; confirm the payer owns this account before crediting`
+          : `customReference=${rawReference} — manual attribution needed`,
         context: {
           transaction_id: transactionId,
           amount: String(payload.amount),
           client_email: payload.client?.email,
+          ...(intentId ? { intent_id: intentId } : {}),
           ...(resolvedUsername ? { email_matched_username: resolvedUsername } : {}),
         },
       })
@@ -623,8 +651,9 @@ export const paymentHandler = async (req: Request, res: Response) => {
         meta: {
           provider: "Fygaro",
           transactionId,
-          reference: username ?? "blank",
+          reference: rawReference,
           email: payload.client?.email ?? "unknown",
+          ...(intentId ? { intentId } : {}),
           ...(resolvedUsername ? { emailMatchedUsername: resolvedUsername } : {}),
         },
       })

--- a/src/services/fygaro/webhook-server/routes/payment.ts
+++ b/src/services/fygaro/webhook-server/routes/payment.ts
@@ -313,13 +313,29 @@ export const paymentHandler = async (req: Request, res: Response) => {
   const { transactionId } = payload
   const createdAt = fygaroCreatedAtToIso(payload.createdAt)
   const currency = (payload.currency ?? "USD").toUpperCase()
-  // `custom_reference` is either a bare username (built on-device by app
-  // versions predating signed checkout, and editable by the payer) or
-  // `username|intentId` minted by authorizeFygaroTopup. Both are accepted for
-  // as long as older clients are in the wild; only the second can be verified.
+  // `custom_reference` is one of three shapes: a bare username (built on-device
+  // by app versions predating signed checkout, and editable by the payer),
+  // `username|intentId`, or `|intentId` when the username was too long to fit
+  // Fygaro's 40-character ceiling alongside it. All three are accepted for as
+  // long as older clients are in the wild; only the latter two can be verified.
   const reference = parseCustomReference(payload.customReference)
-  const username = reference?.username
   const intentId = reference?.intentId
+  // Absent when the reference is the `|<intentId>` form, which is minted when a
+  // username is long enough that `<username>|<intentId>` would breach Fygaro's
+  // 40-character ceiling. The intent record names the account, so the username
+  // is recovered from it and everything downstream is unchanged.
+  //
+  // FAIL-OPEN, matching readIntent's posture everywhere else in this handler: an
+  // unreadable intent leaves the username undefined and the payment falls
+  // through to payer-email attribution, exactly where an unrecognised reference
+  // already lands. That is the whole reason buildCustomReference keeps the
+  // username inline whenever it fits.
+  const usernameFromIntent = async (): Promise<string | undefined> => {
+    if (!intentId) return undefined
+    const lookup = await readIntent(intentId)
+    return lookup.found ? lookup.intent.username : undefined
+  }
+  const username = reference?.username ?? (await usernameFromIntent())
 
   if (!transactionId || !payload.amount) {
     baseLogger.warn(

--- a/src/services/fygaro/webhook-server/routes/payment.ts
+++ b/src/services/fygaro/webhook-server/routes/payment.ts
@@ -344,17 +344,23 @@ export const paymentHandler = async (req: Request, res: Response) => {
   // then ignored it after the first call would hand a later caller a record
   // naming an account and an amount it never asked for — on the one path where
   // that record is what the credit is cross-checked against. It is bound to
-  // THIS delivery's `intentId` instead; every call site is already inside an
-  // `if (intentId)` guard.
+  // THIS delivery's `intentId` instead.
+  //
+  // It returns `IntentLookup | undefined` rather than asserting the id is
+  // present, so "there is no intent to look up" is a value the caller has to
+  // handle rather than a claim the compiler was told to stop checking. With a
+  // non-null assertion, a future call site outside an `if (intentId)` guard
+  // reads the key `fygaro-checkout-intent:undefined` and gets a miss that is
+  // indistinguishable from an expired authorisation.
   let intentLookup: IntentLookup | undefined
-  const lookupIntent = async (): Promise<IntentLookup> =>
-    (intentLookup ??= await readIntent(intentId as string))
-  const usernameFromIntent = async (): Promise<string | undefined> => {
+  const lookupIntent = async (): Promise<IntentLookup | undefined> => {
     if (!intentId) return undefined
-    const lookup = await lookupIntent()
-    return lookup.found ? lookup.intent.username : undefined
+    return (intentLookup ??= await readIntent(intentId))
   }
-  const username = reference?.username ?? (await usernameFromIntent())
+  const usernameFromIntent = async (): Promise<string | undefined> => {
+    const lookup = await lookupIntent()
+    return lookup?.found ? lookup.intent.username : undefined
+  }
 
   if (!transactionId || !payload.amount) {
     baseLogger.warn(
@@ -388,6 +394,16 @@ export const paymentHandler = async (req: Request, res: Response) => {
   }
 
   try {
+    // Resolved HERE, inside the try and after the payload validation above,
+    // not at parse time. It is the handler's first Redis touch, and its first
+    // call awaits a dynamic `import()` of the cache module — a rejection there
+    // (or any throw the module raises on load) outside this try would escape
+    // paymentHandler as an unhandled rejection, answering the provider with a
+    // bare 500 and none of the record-first handling below. Reading it after
+    // validation also means a payload that was never going to be processed
+    // does not cost a lookup.
+    const username = reference?.username ?? (await usernameFromIntent())
+
     baseLogger.info(
       {
         transactionId,
@@ -576,7 +592,7 @@ export const paymentHandler = async (req: Request, res: Response) => {
     let authorizedIntent: FygaroCheckoutIntent | undefined
     if (intentId) {
       const lookup = await lookupIntent()
-      if (lookup.found) {
+      if (lookup?.found) {
         authorizedIntent = lookup.intent
       } else {
         baseLogger.info(

--- a/src/services/fygaro/webhook-server/routes/payment.ts
+++ b/src/services/fygaro/webhook-server/routes/payment.ts
@@ -340,12 +340,18 @@ export const paymentHandler = async (req: Request, res: Response) => {
   // customer we were completing it by hand — while holding, two lines later,
   // the very record naming the account it had just failed to attribute to. One
   // read cannot produce that state.
+  // It takes NO key, and that is deliberate. A memo that accepted an id and
+  // then ignored it after the first call would hand a later caller a record
+  // naming an account and an amount it never asked for — on the one path where
+  // that record is what the credit is cross-checked against. It is bound to
+  // THIS delivery's `intentId` instead; every call site is already inside an
+  // `if (intentId)` guard.
   let intentLookup: IntentLookup | undefined
-  const lookupIntent = async (id: string): Promise<IntentLookup> =>
-    (intentLookup ??= await readIntent(id))
+  const lookupIntent = async (): Promise<IntentLookup> =>
+    (intentLookup ??= await readIntent(intentId as string))
   const usernameFromIntent = async (): Promise<string | undefined> => {
     if (!intentId) return undefined
-    const lookup = await lookupIntent(intentId)
+    const lookup = await lookupIntent()
     return lookup.found ? lookup.intent.username : undefined
   }
   const username = reference?.username ?? (await usernameFromIntent())
@@ -569,7 +575,7 @@ export const paymentHandler = async (req: Request, res: Response) => {
     // check against.
     let authorizedIntent: FygaroCheckoutIntent | undefined
     if (intentId) {
-      const lookup = await lookupIntent(intentId)
+      const lookup = await lookupIntent()
       if (lookup.found) {
         authorizedIntent = lookup.intent
       } else {
@@ -625,7 +631,13 @@ export const paymentHandler = async (req: Request, res: Response) => {
       // reference and then could not read our own record. The intent id is
       // also the only handle a human has for tracing the payment back to the
       // checkout, so it is carried alongside.
-      const rawReference = payload.customReference || "<blank>"
+      // TRIMMED before the blank test, so this line and `parseCustomReference`
+      // agree on what counts as blank. A payer who typed only spaces into the
+      // legacy editable reference is blank to the parser (checkout.ts trims
+      // first) and must read as blank here too — untrimmed, `" "` is truthy and
+      // ops get `customReference= — manual attribution needed`, which renders
+      // as nothing at all.
+      const rawReference = payload.customReference?.trim() || "<blank>"
       alertBridge({
         dedupKey: generateDedupKey.fygaroUnattributed(transactionId),
         source: "fygaro-webhook",

--- a/test/flash/unit/services/fygaro/checkout.spec.ts
+++ b/test/flash/unit/services/fygaro/checkout.spec.ts
@@ -2,12 +2,14 @@ import { createHmac } from "crypto"
 
 import {
   buildCustomReference,
+  FYGARO_CUSTOM_REFERENCE_MAX_LENGTH,
   buildFygaroCheckout,
   formatFygaroAmount,
   NBF_SKEW_SECONDS,
   parseCustomReference,
   signFygaroCheckoutJwt,
 } from "@services/fygaro/checkout"
+import { newIntentId } from "@services/fygaro/checkout-intent-store"
 
 const SECRET = "fygaro-shared-secret"
 const KEY_ID = "key-1"
@@ -37,6 +39,54 @@ describe("custom_reference round-trip", () => {
     })
   })
 
+  it("never mints a reference Fygaro will refuse", () => {
+    // THE BUG. Fygaro caps custom_reference at 40 characters and refuses the
+    // whole checkout past it — the customer gets "Custom reference cannot
+    // exceed 40 characters in length" where the payment form should be.
+    //
+    // The original format was `<username>|<uuid>`: 36 + 1 + username, so it was
+    // exactly 40 for a 3-character username (the shortest one allowed) and over
+    // for every longer one. Signed checkout could never have worked for a real
+    // account, which is why the amount stayed editable for everyone — the app
+    // was falling back to the legacy URL every time.
+    for (const username of ["abc", "jaceth2009", "a".repeat(23), "a".repeat(50)]) {
+      const reference = buildCustomReference({ username, intentId: newIntentId() })
+      expect(reference.length).toBeLessThanOrEqual(FYGARO_CUSTOM_REFERENCE_MAX_LENGTH)
+    }
+  })
+
+  it("keeps the username inline whenever it fits, and drops it only when it cannot", () => {
+    // Keeping the username is what lets the webhook attribute a payment without
+    // Redis. The intent record is a 75-minute entry; if it is lost mid-window,
+    // an inline username still credits the right account, where `|<intentId>`
+    // alone falls through to payer-email attribution. So the short form is a
+    // last resort, not the default.
+    const id = newIntentId()
+    expect(buildCustomReference({ username: "jaceth2009", intentId: id })).toBe(
+      `jaceth2009|${id}`,
+    )
+
+    // 23 characters is the longest username that still fits alongside a
+    // 16-character id and the separator.
+    const longest = "a".repeat(23)
+    expect(buildCustomReference({ username: longest, intentId: id })).toBe(
+      `${longest}|${id}`,
+    )
+
+    const tooLong = "a".repeat(24)
+    expect(buildCustomReference({ username: tooLong, intentId: id })).toBe(`|${id}`)
+    expect(parseCustomReference(`|${id}`)).toEqual({ intentId: id })
+  })
+
+  it("mints an intent id short enough to leave room for a username", () => {
+    // 12 random bytes as base64url: 16 characters, no padding to strip.
+    const id = newIntentId()
+    expect(id).toHaveLength(16)
+    expect(id).toMatch(/^[A-Za-z0-9_-]{16}$/)
+    // Distinct ids, so the reference identifies one authorisation.
+    expect(new Set(Array.from({ length: 200 }, newIntentId)).size).toBe(200)
+  })
+
   it("reads a bare username as legacy, with no intent", () => {
     // Every app version before signed checkout sends this shape, and will keep
     // sending it for months. It must stay attributable.
@@ -58,10 +108,21 @@ describe("custom_reference round-trip", () => {
     }
   })
 
-  it("returns undefined when there is no usable username", () => {
-    for (const raw of ["", "   ", "|abc-123", undefined, null]) {
+  it("returns undefined when there is nothing usable at all", () => {
+    for (const raw of ["", "   ", "|", " | ", undefined, null]) {
       expect(parseCustomReference(raw)).toBeUndefined()
     }
+  })
+
+  it("reads a leading separator as an intent with no username", () => {
+    // The long-username form. `<username>|<intentId>` breaches Fygaro's
+    // 40-character ceiling once the username is more than 23 characters, so
+    // buildCustomReference drops the username and mints `|<intentId>`. An empty
+    // first segment cannot be a username — they are 3+ characters — so this
+    // shape is unambiguous, and the webhook recovers the account from the
+    // intent record.
+    expect(parseCustomReference("|abc-123")).toEqual({ intentId: "abc-123" })
+    expect(parseCustomReference("  |  abc-123 ")).toEqual({ intentId: "abc-123" })
   })
 
   it("trims surrounding whitespace on both halves", () => {

--- a/test/flash/unit/services/fygaro/checkout.spec.ts
+++ b/test/flash/unit/services/fygaro/checkout.spec.ts
@@ -49,9 +49,27 @@ describe("custom_reference round-trip", () => {
     // for every longer one. Signed checkout could never have worked for a real
     // account, which is why the amount stayed editable for everyone — the app
     // was falling back to the legacy URL every time.
-    for (const username of ["abc", "jaceth2009", "a".repeat(23), "a".repeat(50)]) {
+    //
+    // The non-ASCII entries are not decoration. UsernameRegex is
+    // `[\p{L}0-9_]{3,50}` — any Unicode letter — so a username of ordinary
+    // LENGTH can be well past 40 BYTES, and Fygaro documents the cap as
+    // "characters" without saying what it counts. The ceiling is therefore
+    // measured in UTF-8 bytes, and these pin that: 13 Cyrillic characters is
+    // 26 UTF-8 bytes, so `<username>|<16-char id>` is 43 bytes — over the cap
+    // on a reference that is only 30 characters long.
+    for (const username of [
+      "abc",
+      "jaceth2009",
+      "a".repeat(23),
+      "a".repeat(50),
+      "марианна",
+      "з".repeat(13),
+      "日本語のなまえ",
+    ]) {
       const reference = buildCustomReference({ username, intentId: newIntentId() })
-      expect(reference.length).toBeLessThanOrEqual(FYGARO_CUSTOM_REFERENCE_MAX_LENGTH)
+      expect(Buffer.byteLength(reference, "utf8")).toBeLessThanOrEqual(
+        FYGARO_CUSTOM_REFERENCE_MAX_LENGTH,
+      )
     }
   })
 
@@ -83,8 +101,16 @@ describe("custom_reference round-trip", () => {
     const id = newIntentId()
     expect(id).toHaveLength(16)
     expect(id).toMatch(/^[A-Za-z0-9_-]{16}$/)
-    // Distinct ids, so the reference identifies one authorisation.
-    expect(new Set(Array.from({ length: 200 }, newIntentId)).size).toBe(200)
+  })
+
+  it("draws the id from 12 random bytes — 96 bits, not a shorter draw", () => {
+    // Assert on the WIDTH OF THE DRAW, not on a sample of outputs. The
+    // previous assertion here was `new Set(200 draws).size === 200`, which
+    // cannot tell 96 bits from 32: narrowing randomBytes(12) to randomBytes(4)
+    // collides with probability ~2e-5 over 200 draws, so that test passes
+    // essentially always on the one regression it exists to catch. Decoding
+    // the id back to bytes catches it on the first draw.
+    expect(Buffer.from(newIntentId(), "base64url")).toHaveLength(12)
   })
 
   it("reads a bare username as legacy, with no intent", () => {

--- a/test/flash/unit/services/fygaro/webhook-server/payment.spec.ts
+++ b/test/flash/unit/services/fygaro/webhook-server/payment.spec.ts
@@ -351,6 +351,32 @@ describe("fygaro paymentHandler", () => {
     expect(res.json).toHaveBeenCalledWith({ status: "recorded", attributed: false })
   })
 
+  it("reports a WHITESPACE-ONLY customReference to ops as <blank>", async () => {
+    // The parser trims before deciding, so `" "` is blank to the handler and
+    // takes the unattributed branch. The alert has to agree: untrimmed, `" "`
+    // is truthy and ops read `customReference= — manual attribution needed`,
+    // which renders as nothing at all — the alert and the parser disagreeing
+    // about what counts as blank, on the one line whose job is to tell ops
+    // exactly what the payer sent.
+    const res = makeRes()
+
+    await paymentHandler(makeReq({ ...VALID_BODY, customReference: "   " }), res)
+
+    expect(mockFindByUsername).not.toHaveBeenCalled()
+    expect(mockAlertBridge).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: "customReference=<blank> — manual attribution needed",
+      }),
+    )
+    expect(mockNotifyOpsEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        phase: "fygaro-unattributed",
+        meta: expect.objectContaining({ reference: "<blank>" }),
+      }),
+    )
+    expect(res.json).toHaveBeenCalledWith({ status: "recorded", attributed: false })
+  })
+
   it("stamps an outcome on a DEDUPED unattributed re-delivery", async () => {
     // The third terminal return, and the one the first two fixes missed. If the
     // first delivery's Redis stamp failed (swallowed by design), every retry

--- a/test/flash/unit/services/fygaro/webhook-server/payment.spec.ts
+++ b/test/flash/unit/services/fygaro/webhook-server/payment.spec.ts
@@ -160,6 +160,9 @@ import {
   mergeIntentOutcome,
   type FygaroTopupOutcome,
 } from "@services/fygaro/checkout-intent-store"
+// Not mocked: reference parsing is pure, and the shapes it accepts are the
+// whole contract between the app's checkout and this handler.
+import { FYGARO_REFERENCE_SEPARATOR } from "@services/fygaro/checkout"
 
 const ACCOUNT_ID = "account-1" as AccountId
 const WALLET_ID = "wallet-1" as WalletId
@@ -1910,6 +1913,115 @@ describe("fygaro paymentHandler", () => {
       expect(mockWriteFygaroTopup).toHaveBeenCalledWith(
         expect.objectContaining({ accountId: ACCOUNT_ID }),
       )
+    })
+
+    // The `|<intentId>` form — the half of this change that makes long-username
+    // checkouts credit at all. Every account whose username does not fit
+    // alongside the id pays through this branch, so it gets the same treatment
+    // as the `username|intentId` case above: the match, the miss, and the
+    // mismatch.
+    describe("the |intentId form, minted when the username will not fit", () => {
+      const SHORT_BODY = {
+        ...VALID_BODY,
+        customReference: `${FYGARO_REFERENCE_SEPARATOR}${INTENT_ID}`,
+      }
+
+      it("recovers the username from the intent record and credits normally", async () => {
+        mockReadIntent.mockResolvedValue(intent())
+        const res = makeRes()
+
+        await paymentHandler(makeReq(SHORT_BODY), res)
+
+        // The reference names no account, so the intent record is the ONLY
+        // thing standing between this payment and the unattributed alert.
+        expect(mockFindByUsername).toHaveBeenCalledWith(VALID_BODY.customReference)
+        expect(mockCreditFygaroTopup).toHaveBeenCalledWith(
+          expect.objectContaining({ recipientAccountId: ACCOUNT_ID, amountCents: 901 }),
+        )
+        expect(res.json).toHaveBeenCalledWith({ status: "success", credited: true })
+      })
+
+      it("reads the intent exactly once across username recovery and the cross-check", async () => {
+        // Two independent reads of one Redis key can DISAGREE: a blip on the
+        // first leaves the username undefined and sends the payment to the
+        // unattributed branch, while the second succeeds and hands the
+        // cross-check the very record naming the account we just failed to
+        // attribute to. Memoizing the lookup is what makes that state
+        // unreachable, and only a call count can hold it there.
+        mockReadIntent.mockResolvedValue(intent())
+        const res = makeRes()
+
+        await paymentHandler(makeReq(SHORT_BODY), res)
+
+        expect(mockReadIntent).toHaveBeenCalledTimes(1)
+        expect(mockReadIntent).toHaveBeenCalledWith(INTENT_ID)
+      })
+
+      it("falls through to the unattributed branch when the intent cannot be read", async () => {
+        // FAIL-OPEN, matching readIntent everywhere else: an unreadable intent
+        // is not an accusation, it is an unattributable payment — the same
+        // position a payer-typed reference we do not recognise is in.
+        mockReadIntent.mockResolvedValue({ found: false })
+        const res = makeRes()
+
+        await paymentHandler(makeReq(SHORT_BODY), res)
+
+        // Nothing to look up: the reference carries no username, and the whole
+        // raw reference must never be handed to findByUsername as if it were.
+        expect(mockFindByUsername).not.toHaveBeenCalled()
+        expect(mockCreditFygaroTopup).not.toHaveBeenCalled()
+        expect(res.json).toHaveBeenCalledWith({ status: "recorded", attributed: false })
+      })
+
+      it("shows ops the reference the payer actually sent, and the intent id", async () => {
+        // The alert used to render the (undefined) username, so this case
+        // reached ops as `customReference=<blank>` — which reads at 3am as
+        // "the payer sent us nothing" when in fact we minted the reference and
+        // then could not read our own record. The intent id is the only handle
+        // a human has for tracing the payment back to the checkout.
+        mockReadIntent.mockResolvedValue({ found: false })
+        const res = makeRes()
+
+        await paymentHandler(makeReq(SHORT_BODY), res)
+
+        expect(mockAlertBridge).toHaveBeenCalledWith(
+          expect.objectContaining({
+            title: "Fygaro payment could not be attributed to an account",
+            detail: `customReference=${SHORT_BODY.customReference} — manual attribution needed`,
+            context: expect.objectContaining({ intent_id: INTENT_ID }),
+          }),
+        )
+        expect(mockNotifyOpsEvent).toHaveBeenCalledWith(
+          expect.objectContaining({
+            phase: "fygaro-unattributed",
+            meta: expect.objectContaining({
+              reference: SHORT_BODY.customReference,
+              intentId: INTENT_ID,
+            }),
+          }),
+        )
+      })
+
+      it("still refuses a payment that does not match what was authorised", async () => {
+        // The short form must not be a way around the cross-check: the
+        // username arrives from the intent record itself, but the amount and
+        // account it names are still checked against what was paid.
+        mockReadIntent.mockResolvedValue(intent({ amountCents: 2000 }))
+        const res = makeRes()
+
+        await paymentHandler(makeReq(SHORT_BODY), res)
+
+        expect(mockCreditFygaroTopup).not.toHaveBeenCalled()
+        expect(mockAlertBridge).toHaveBeenCalledWith(
+          expect.objectContaining({
+            context: expect.objectContaining({
+              reason: "intent-mismatch",
+              intent_mismatch: "authorised 2000c, paid 1000c",
+            }),
+          }),
+        )
+        expect(res.json).toHaveBeenCalledWith({ status: "recorded", credited: false })
+      })
     })
 
     it("records-only on an amount mismatch and names both numbers in the alert", async () => {


### PR DESCRIPTION
Signed checkout has never worked for a single real user. This is why.

## What Fygaro said

> Custom reference cannot exceed 40 characters in length, please contact support if needed.

Not a soft truncation — Fygaro refuses the whole checkout, and the customer meets an error page where the payment form should be.

## The arithmetic

The format was `<username>|<uuid>`. A v4 UUID is 36 characters, the separator is 1, and usernames are 3+ characters (`UsernameRegex`):

| username | reference | |
|---|---|---|
| 3 chars (shortest allowed) | 40 | exactly at the cap |
| 5 chars | 42 | refused |
| 10 chars | 47 | refused |
| 20 chars | 57 | refused |

So it was broken for everyone except a hypothetical 3-character username. And because `checkout-disabled`-class failures degrade silently to the legacy pre-fill URL, the symptom was **"the amount is still editable"** — which reads as the feature not being deployed, not as a rejected reference.

## The fix

Shortening the id alone cannot work: a username may be up to 50 characters, so no id length makes every case fit. Two changes:

- **`newIntentId`** mints 12 random bytes as base64url — 16 characters, 96 bits — instead of a 36-character UUID. That leaves 23 characters for the username, covering the ordinary case. 96 bits is far beyond what guessing resistance needs: an id is only useful inside its 15-minute window, and an intent is bound to one account and one amount, so a guessed id buys a mismatch, not a credit.
- **`buildCustomReference`** drops the username and mints `|<intentId>` when even that will not fit. An empty first segment is unambiguous — a username can never be empty and can never contain the separator — and the webhook recovers the account from the intent record.

### Why that is a conditional and not just always the short form

The username is what the webhook attributes a payment by (`findByUsername` → account → credit). The intent record is a 75-minute Redis entry. If Redis is lost mid-window, `<username>|<intentId>` still names an account and the payment credits, where `|<intentId>` alone falls through to payer-email attribution. That fallback exists and is handled, but it is strictly worse than not needing it — so the short form is a last resort, not the default.

The intent lookup added to the webhook is **fail-open**, matching `readIntent`'s posture everywhere else in that handler: an unreadable intent leaves the username undefined and the payment lands exactly where an unrecognised reference already lands.

## Compatibility

All three reference shapes parse: bare `<username>` (every pre-signed-checkout client, still in the wild), `<username>|<intentId>`, and `|<intentId>`. Legacy attribution is untouched.

## Tests

`test/flash/unit/services/fygaro/checkout.spec.ts` — the length ceiling is now asserted directly against usernames of 3, 10, 23 and 50 characters, so a future id or separator change that breaches it fails here rather than at a customer's payment page. Plus the inline-vs-dropped username boundary at 23/24 characters, the id's shape and distinctness, and the `|<intentId>` parse.

Full unit suite: 204 suites / 2208 passing. tsc and eslint clean.

## Deploy

This is the last known blocker on test. After it ships, `make flash ENV=test` and retry — expect the Fygaro page with the amount fixed. Prod still has `checkout.enabled` absent (deployments#173 was only applied to test), so prod is unaffected either way.